### PR TITLE
Update HintPath for OpenCLNet and taglib-sharp

### DIFF
--- a/CUETools.ChaptersToCue/CUETools.ChaptersToCue.csproj
+++ b/CUETools.ChaptersToCue/CUETools.ChaptersToCue.csproj
@@ -57,7 +57,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="taglib-sharp, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\Release\taglib-sharp.dll</HintPath>
+      <HintPath>..\bin\$(Configuration)\net47\taglib-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CUETools.FLACCL.cmd/CUETools.FLACL.cmd.csproj
+++ b/CUETools.FLACCL.cmd/CUETools.FLACL.cmd.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <Reference Include="OpenCLNet, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ThirdParty\openclnet\source\bin\Release\net40\OpenCLNet.dll</HintPath>
+      <HintPath>..\ThirdParty\openclnet\source\bin\$(Configuration)\net47\OpenCLNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
- Use $(Configuration) instead of Release in path
- Update from net40 to net47
- Fixes:
Error CS0246 The type or namespace name 'OpenCLNet' could not be found
(are you missing a using directive or an assembly reference?)
CUETools.FLACL.cmd cuetools.net\CUETools.FLACCL.cmd\Program.cs 359 N/A
- Allows straight forward initial building in Debug configuration
