### PR TITLE
CUETools.FLACL.cmd: print Hz after SampleRate

### DIFF
--- a/CUETools.FLACCL.cmd/Program.cs
+++ b/CUETools.FLACCL.cmd/Program.cs
@@ -314,7 +314,7 @@ namespace CUETools.FLACCL.cmd
 			if (!quiet)
 			{
 				Console.WriteLine("Filename  : {0}", input_file);
-				Console.WriteLine("File Info : {0}kHz; {1} channel; {2} bit; {3}", audioSource.PCM.SampleRate, audioSource.PCM.ChannelCount, audioSource.PCM.BitsPerSample, TimeSpan.FromSeconds(audioSource.Length * 1.0 / audioSource.PCM.SampleRate));
+				Console.WriteLine("File Info : {0} Hz; {1} channel; {2} bit; {3}", audioSource.PCM.SampleRate, audioSource.PCM.ChannelCount, audioSource.PCM.BitsPerSample, TimeSpan.FromSeconds(audioSource.Length * 1.0 / audioSource.PCM.SampleRate));
                 Console.WriteLine("Device    : {0}, Platform: \"{1}\", Version: {2}, Driver: {3}", settings.Device.Trim(), settings.Platform, settings.PlatformVersion.Trim(), settings.DriverVersion.Trim());
             }
 


### PR DESCRIPTION
- Use Hz instead of kHz
- Fixes: https://github.com/gchudov/cuetools.net/issues/17