### PR TITLE
Prevent exception on non-standard CUE sheet

### DIFF
--- a/CUETools.CDImage/CDImage.cs
+++ b/CUETools.CDImage/CDImage.cs
@@ -432,7 +432,11 @@ namespace CUETools.CDImage
 				for (int iTrack = 1; iTrack < AudioTracks; iTrack++)
 					mbSB.AppendFormat("{0:X8}", _tracks[_firstAudio + iTrack].Start - _tracks[_firstAudio].Start);
 				mbSB.AppendFormat("{0:X8}", _tracks[_firstAudio + (int)AudioTracks - 1].End + 1 - _tracks[_firstAudio].Start);
-				mbSB.Append(new string('0', (100 - (int)AudioTracks) * 8));
+				int numberOfRemainingAudioTracks = 100 - (int)AudioTracks;
+				if (numberOfRemainingAudioTracks < 0)
+					// Non-standard CUE sheet with more than 99 tracks.
+					numberOfRemainingAudioTracks = 0;
+				mbSB.Append(new string('0', numberOfRemainingAudioTracks * 8));
 				byte[] hashBytes = (new SHA1CryptoServiceProvider()).ComputeHash(Encoding.ASCII.GetBytes(mbSB.ToString()));
 				return Convert.ToBase64String(hashBytes).Replace('+', '.').Replace('/', '_').Replace('=', '-');
 			}

--- a/CUETools.CDImage/CDImage.cs
+++ b/CUETools.CDImage/CDImage.cs
@@ -432,11 +432,8 @@ namespace CUETools.CDImage
 				for (int iTrack = 1; iTrack < AudioTracks; iTrack++)
 					mbSB.AppendFormat("{0:X8}", _tracks[_firstAudio + iTrack].Start - _tracks[_firstAudio].Start);
 				mbSB.AppendFormat("{0:X8}", _tracks[_firstAudio + (int)AudioTracks - 1].End + 1 - _tracks[_firstAudio].Start);
-				int numberOfRemainingAudioTracks = 100 - (int)AudioTracks;
-				if (numberOfRemainingAudioTracks < 0)
-					// Non-standard CUE sheet with more than 99 tracks.
-					numberOfRemainingAudioTracks = 0;
-				mbSB.Append(new string('0', numberOfRemainingAudioTracks * 8));
+				// Use Math.Max() to avoid negative count number in case of non-standard CUE sheet with more than 99 tracks.
+				mbSB.Append(new string('0', Math.Max(0, (100 - (int)AudioTracks) * 8)));
 				byte[] hashBytes = (new SHA1CryptoServiceProvider()).ComputeHash(Encoding.ASCII.GetBytes(mbSB.ToString()));
 				return Convert.ToBase64String(hashBytes).Replace('+', '.').Replace('/', '_').Replace('=', '-');
 			}


### PR DESCRIPTION
In case of a CUE sheet with more than about 99 tracks, [this](https://github.com/gchudov/cuetools.net/blob/master/CUETools.CDImage/CDImage.cs#L435) `string` constructor threw an exception, because its repetition parameter was negative.

With this patch, I was able to process such a non-standard CUE sheet successfully.

What about [this](https://github.com/gchudov/cuetools.net/blob/master/CUETools.CDImage/CDImage.cs#L409) very similar line in the same file? Does it also have to be changed? (Why does one line say `100` and the other `99`?)