### PR TITLE
Fix .exe filenames in console output

### DIFF
--- a/CUETools.ARCUE/Program.cs
+++ b/CUETools.ARCUE/Program.cs
@@ -29,7 +29,7 @@ namespace ArCueDotNet
             if (!ok || pathIn == null)
             {
                 Console.SetOut(Console.Error);
-                Console.WriteLine("Usage: ArCueDotNet [options] <filename>");
+                Console.WriteLine("Usage    : CUETools.ARCUE.exe [options] <filename>");
                 Console.WriteLine();
                 Console.WriteLine("Options:");
                 Console.WriteLine();

--- a/CUETools.LossyWAV/Program.cs
+++ b/CUETools.LossyWAV/Program.cs
@@ -12,7 +12,7 @@ namespace CUETools.LossyWAVSharp
 	{
 		static void Usage()
 		{
-			Console.WriteLine("Usage    : LossyWAVSharp.exe <file.wav> <options>");
+			Console.WriteLine("Usage    : CUETools.LossyWAV.exe <file.wav> <options>");
 			Console.WriteLine();
 			Console.WriteLine("Quality Options:");
 			Console.WriteLine();


### PR DESCRIPTION
Update the console output to show the current filenames:
```
ArCueDotNet.exe   -> CUETools.ARCUE.exe
LossyWAVSharp.exe -> CUETools.LossyWAV.exe
```
