### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Prebuilt binaries can be downloaded from [CUETools Download](http://cue.tools/wi
 `git submodule update --init --recursive`
 * Get the FFmpeg.AutoGen sources from GitHub ([https://github.com/Ruslan-B/FFmpeg.AutoGen](https://github.com/Ruslan-B/FFmpeg.AutoGen)):  
 `git clone https://github.com/Ruslan-B/FFmpeg.AutoGen.git`
-* The solution can be built using Microsoft Visual Studio 2017 (Community Edition will work)
+* The solution can be built using Microsoft Visual Studio 2017 or newer (Community Edition will work)
   * Install the required .NET framework development tools (currently 4.7)
   * Install an appropriate Windows SDK version (currently 10.0.16299.0)
   * Install the Microsoft Visual Studio Installer Projects
+* Optional: Install [NASM](https://www.nasm.us/) and add it to your PATH. This is required for building the 32-bit flac plugin.
 * Open cuetools.net\CUETools\CUETools.sln
 * Select 'Any CPU' under 'Solution Platforms'
 * Build solution


### PR DESCRIPTION
Add info concerning installation of NASM, which is required for
building the 32-bit flac plugin. This concerns only 32-bit,
where x86 assembly optimizations are enabled by default.
For further details see: ThirdParty\flac\README