### PR TITLE
Target CUETools.CTDB.EACPlugin at .NET v4.7

### DIFF
--- a/CUETools.CTDB.EACPlugin/CUETools.CTDB.EACPlugin.csproj
+++ b/CUETools.CTDB.EACPlugin/CUETools.CTDB.EACPlugin.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CUETools.CTDB.EACPlugin</RootNamespace>
     <AssemblyName>CUETools.CTDB.EACPlugin</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/CUETools.CTDB.EACPlugin/app.config
+++ b/CUETools.CTDB.EACPlugin/app.config
@@ -1,3 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
-	<startup/></configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+  </startup>
+</configuration>


### PR DESCRIPTION
The .NET version in **`CUETools.CTDB.EACPlugin.csproj`** was still at `v2.0`.
In the meantime, all the other projects, which are referenced by the
EACPlugin, have already been targeted at `v4.7`:
`  CUETools.AccurateRip, CUETools.CDImage, CUETools.CTDB,`
`  CUETools.CTDB.Types, CUETools.Codecs, CUETools.Parity`

- Fixes the following warnings after opening **`CUETools.sln`**
  in Visual Studio, e.g.:
`  The referenced project 'CUETools.AccurateRip' is targeting a higher`
`  framework version (4.7) than this project’s current target framework`
`  version (2.0). This may lead to build failures if types from`
`  assemblies outside this project’s target framework are used by any`
`  project in the dependency chain. Project: CUETools.CTDB.EACPlugin`
