### PR TITLE
Sort selected target frameworks to avoid warnings

### DIFF
--- a/CUETools.AccurateRip/CUETools.AccurateRip.csproj
+++ b/CUETools.AccurateRip/CUETools.AccurateRip.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
     <Version>2.1.7.0</Version>
     <AssemblyName>CUETools.AccurateRip</AssemblyName>
     <RootNamespace>CUETools.AccurateRip</RootNamespace>

--- a/CUETools.CDImage/CUETools.CDImage.csproj
+++ b/CUETools.CDImage/CUETools.CDImage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
     <Version>2.1.7.0</Version>
     <AssemblyName>CUETools.CDImage</AssemblyName>
     <RootNamespace>CUETools.CDImage</RootNamespace>

--- a/CUETools.CTDB.Types/CUETools.CTDB.Types.csproj
+++ b/CUETools.CTDB.Types/CUETools.CTDB.Types.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
     <Version>2.1.7.0</Version>
     <AssemblyName>CUETools.CTDB.Types</AssemblyName>
     <RootNamespace>CUETools.CTDB</RootNamespace>

--- a/CUETools.CTDB/CUETools.CTDB.csproj
+++ b/CUETools.CTDB/CUETools.CTDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
     <Version>2.1.7.0</Version>
     <AssemblyName>CUETools.CTDB</AssemblyName>
     <RootNamespace>CUETools.CTDB</RootNamespace>

--- a/CUETools.Codecs/CUETools.Codecs.csproj
+++ b/CUETools.Codecs/CUETools.Codecs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
     <Version>2.1.7.0</Version>
     <AssemblyName>CUETools.Codecs</AssemblyName>
     <RootNamespace>CUETools.Codecs</RootNamespace>

--- a/CUETools.Parity/CUETools.Parity.csproj
+++ b/CUETools.Parity/CUETools.Parity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
     <Version>2.1.7.0</Version>
     <AssemblyName>CUETools.Parity</AssemblyName>
     <RootNamespace>CUETools.Parity</RootNamespace>


### PR DESCRIPTION
Sort `TargetFrameworks` in the following projects with `net20` first,
to avoid warnings from **`CUETools.CTDB.EACPlugin`**:
`  CUETools.AccurateRip, CUETools.CDImage, CUETools.CTDB,`
`  CUETools.CTDB.Types, CUETools.Codecs, CUETools.Parity`
Change order:
`  <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>`
  ->
`  <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>`

- Fixes the following warnings after opening **`CUETools.sln`**
  in Visual Studio, e.g.:
`  The referenced project 'CUETools.AccurateRip' is targeting a higher`
`  framework version (4.7) than this project’s current target framework`
`  version (2.0). This may lead to build failures if types from`
`  assemblies outside this project’s target framework are used by any`
`  project in the dependency chain. Project: CUETools.CTDB.EACPlugin`
