### PR TITLE
Bump copyright year to 2020

### DIFF
--- a/CUEControls/CUEControls.csproj
+++ b/CUEControls/CUEControls.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUEControls</RootNamespace>
     <Product>CUETools</Product>
     <Description>Library containing windows GUI controls for CUETools.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUEPlayer/Properties/AssemblyInfo.cs
+++ b/CUEPlayer/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("CUETools")]
 [assembly: AssemblyProduct("CUEPlayer")]
-[assembly: AssemblyCopyright("Copyright © Grigory Chudov 2010")]
+[assembly: AssemblyCopyright("Copyright © 2010-2020 Grigory Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUERipper/Properties/AssemblyInfo.cs
+++ b/CUERipper/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CUERipper")]
-[assembly: AssemblyCopyright("Copyright (c) 2008-2009 Greg Chudov")]
+[assembly: AssemblyCopyright("Copyright (c) 2008-2020 Greg Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools.ALACEnc/CUETools.ALACEnc.csproj
+++ b/CUETools.ALACEnc/CUETools.ALACEnc.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A tool for encoding and decoding ALAC.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.ALACEnc/Program.cs
+++ b/CUETools.ALACEnc/Program.cs
@@ -143,7 +143,7 @@ namespace CUETools.ALACEnc
 
 			if (!quiet)
 			{
-				Console.WriteLine("CUETools.ALACEnc, Copyright (C) 2009 Grigory Chudov.");
+				Console.WriteLine("CUETools.ALACEnc, Copyright (C) 2009-2020 Grigory Chudov.");
 				Console.WriteLine("Based on ffdshow ALAC audio encoder");
 				Console.WriteLine("Copyright (c) 2008  Jaikrishnan Menon, <realityman@gmx.net>");
 				Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");

--- a/CUETools.ARCUE/CUETools.ARCUE.csproj
+++ b/CUETools.ARCUE/CUETools.ARCUE.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A tool for CD image verification against AccurateRip.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.AccurateRip/CUETools.AccurateRip.csproj
+++ b/CUETools.AccurateRip/CUETools.AccurateRip.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.AccurateRip</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for calculating AccurateRip checksums, CRC32 and Reed-solomon codes of CD audio.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.CDImage/CUETools.CDImage.csproj
+++ b/CUETools.CDImage/CUETools.CDImage.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.CDImage</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for working with CD TOC.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.CLParity/CLParity.cs
+++ b/CUETools.CLParity/CLParity.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.CLParity: Reed-Solomon (32 bit) using OpenCL
- * Copyright (c) 2009 Gregory S. Chudov
+ * Copyright (c) 2009-2020 Gregory S. Chudov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/CUETools.CLParity/Properties/AssemblyInfo.cs
+++ b/CUETools.CLParity/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CUETools.CLParity")]
-[assembly: AssemblyCopyright("Copyright © 2011 Gregory S. Chudov")]
+[assembly: AssemblyCopyright("Copyright © 2011-2020 Gregory S. Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools.CLParity/parity.cl
+++ b/CUETools.CLParity/parity.cl
@@ -1,6 +1,6 @@
 /**
  * CUETools.CLParity: Reed-Solomon (32 bit) using OpenCL
- * Copyright (c) 2010 Gregory S. Chudov
+ * Copyright (c) 2010-2020 Gregory S. Chudov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
+++ b/CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A tool for CTDB database files conversion.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.CTDB.EACPlugin/Options.Designer.cs
+++ b/CUETools.CTDB.EACPlugin/Options.Designer.cs
@@ -69,7 +69,7 @@ namespace AudioDataPlugIn
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(345, 52);
             this.label2.TabIndex = 1;
-            this.label2.Text = "Copyright (c) 2011-12 Grigory Chudov";
+            this.label2.Text = "Copyright (c) 2011-2020 Grigory Chudov";
             // 
             // linkLabel1
             // 

--- a/CUETools.CTDB.EACPlugin/Properties/AssemblyInfo.cs
+++ b/CUETools.CTDB.EACPlugin/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CUETools.CTDB.EACPlugin")]
-[assembly: AssemblyCopyright("Copyright © Grigory Chudov 2012")]
+[assembly: AssemblyCopyright("Copyright © 2012-2020 Grigory Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools.CTDB.Types/CUETools.CTDB.Types.csproj
+++ b/CUETools.CTDB.Types/CUETools.CTDB.Types.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.CTDB</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library containing serializable types for accessing CUETools Database.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.CTDB/CUETools.CTDB.csproj
+++ b/CUETools.CTDB/CUETools.CTDB.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.CTDB</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for accessing CUETools Database.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.ChaptersToCue/Program.cs
+++ b/CUETools.ChaptersToCue/Program.cs
@@ -1,7 +1,7 @@
 // ****************************************************************************
 // 
 // ChaptersToCue
-// Copyright (C) 2018 Grigory Chudov (gchudov@gmail.com)
+// Copyright (C) 2018-2020 Grigory Chudov (gchudov@gmail.com)
 // 
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -49,7 +49,7 @@ namespace CUETools.ChaptersToCue
         {
             TextWriter stdout = Console.Out;
             Console.SetOut(Console.Error);
-            Console.WriteLine("CUETools.ChaptersToCue v2.1.7 Copyright (C) 2017 Grigory Chudov");
+            Console.WriteLine("CUETools.ChaptersToCue v2.1.7 Copyright (C) 2017-2020 Grigory Chudov");
             Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
             Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
 

--- a/CUETools.ChaptersToCue/Properties/AssemblyInfo.cs
+++ b/CUETools.ChaptersToCue/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("CUETools.ChaptersToCue")]
-[assembly: AssemblyCopyright("Copyright © Grigory Chudov 2017")]
+[assembly: AssemblyCopyright("Copyright © 2017-2020 Grigory Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools.Codecs.ALAC/ALACDotNet.cs
+++ b/CUETools.Codecs.ALAC/ALACDotNet.cs
@@ -7,7 +7,7 @@ using CUETools.Codecs;
 using System.ComponentModel;
 using Newtonsoft.Json;
 
-//Copyright (c) 2008 Grigory Chudov.
+//Copyright (c) 2008-2020 Grigory Chudov.
 //This library is based on ALAC decoder by David Hammerton.
 //See http://crazney.net/programs/itunes/alac.html for details.
 //Copyright (c) 2004 David Hammerton.

--- a/CUETools.Codecs.ALAC/ALACWriter.cs
+++ b/CUETools.Codecs.ALAC/ALACWriter.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.Codecs.ALAC: pure managed ALAC audio encoder
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  * Based on ffdshow ALAC audio encoder
  * Copyright (c) 2008  Jaikrishnan Menon, realityman@gmx.net
  *

--- a/CUETools.Codecs.ALAC/Alac.cs
+++ b/CUETools.Codecs.ALAC/Alac.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.Codecs.ALAC: pure managed ALAC audio encoder
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  * Based on ffdshow ALAC audio encoder
  * Copyright (c) 2008  Jaikrishnan Menon, realityman@gmx.net
  *

--- a/CUETools.Codecs.ALAC/CUETools.Codecs.ALAC.csproj
+++ b/CUETools.Codecs.ALAC/CUETools.Codecs.ALAC.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding and decoding ALAC.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.CoreAudio/CUETools.Codecs.CoreAudio.csproj
+++ b/CUETools.Codecs.CoreAudio/CUETools.Codecs.CoreAudio.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.CoreAudio</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for playing sound on Windows using NAudio.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov. Uses NAudio by Mark Heath</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov. Uses NAudio by Mark Heath</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)</OutputPath>

--- a/CUETools.Codecs.FLACCL/FLACCLWriter.cs
+++ b/CUETools.Codecs.FLACCL/FLACCLWriter.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.FLACCL: FLAC audio encoder using CUDA
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/CUETools.Codecs.FLACCL/Properties/AssemblyInfo.cs
+++ b/CUETools.Codecs.FLACCL/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CUETools.Codecs.FLACCL")]
-[assembly: AssemblyCopyright("Copyright © 2009-2010 Grigory Chudov")]
+[assembly: AssemblyCopyright("Copyright © 2009-2020 Grigory Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools.Codecs.FLACCL/flac.cl
+++ b/CUETools.Codecs.FLACCL/flac.cl
@@ -1,6 +1,6 @@
 /**
  * CUETools.FLACCL: FLAC audio encoder using OpenCL
- * Copyright (c) 2010 Gregory S. Chudov
+ * Copyright (c) 2010-2020 Gregory S. Chudov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/CUETools.Codecs.FLAKE/CUETools.Codecs.FLAKE.csproj
+++ b/CUETools.Codecs.FLAKE/CUETools.Codecs.FLAKE.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.Flake</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding and decoding FLAC.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.FLAKE/Flake.cs
+++ b/CUETools.Codecs.FLAKE/Flake.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.Flake: pure managed FLAC audio encoder
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  * Based on Flake encoder, http://flake-enc.sourceforge.net/
  * Copyright (c) 2006-2009 Justin Ruggles
  *

--- a/CUETools.Codecs.Flake/AudioDecoder.cs
+++ b/CUETools.Codecs.Flake/AudioDecoder.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.Flake: pure managed FLAC audio encoder
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  * Based on Flake encoder, http://flake-enc.sourceforge.net/
  * Copyright (c) 2006-2009 Justin Ruggles
  *

--- a/CUETools.Codecs.Flake/AudioEncoder.cs
+++ b/CUETools.Codecs.Flake/AudioEncoder.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.Flake: pure managed FLAC audio encoder
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  * Based on Flake encoder, http://flake-enc.sourceforge.net/
  * Copyright (c) 2006-2009 Justin Ruggles
  *

--- a/CUETools.Codecs.HDCD/CUETools.Codecs.HDCD.csproj
+++ b/CUETools.Codecs.HDCD/CUETools.Codecs.HDCD.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.HDCD</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for decompressing RAR.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins\</OutputPath>

--- a/CUETools.Codecs.Icecast/CUETools.Codecs.Icecast.csproj
+++ b/CUETools.Codecs.Icecast/CUETools.Codecs.Icecast.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.Icecast</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for streaming audio using Icecast protocol.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)</OutputPath>

--- a/CUETools.Codecs.LossyWAV/CUETools.Codecs.LossyWAV.csproj
+++ b/CUETools.Codecs.LossyWAV/CUETools.Codecs.LossyWAV.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.LossyWAV</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding and decoding LossyWAV.</Description>
-    <Copyright>Copyright (c) 2007-2008 Nick Currie, C# port (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2007-2008 Nick Currie, C# port (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)</OutputPath>

--- a/CUETools.Codecs.MACLib/CUETools.Codecs.MACLib.csproj
+++ b/CUETools.Codecs.MACLib/CUETools.Codecs.MACLib.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.MACLib</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding APE files using official encoder.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.MPEG/CUETools.Codecs.MPEG.csproj
+++ b/CUETools.Codecs.MPEG/CUETools.Codecs.MPEG.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.MPEG</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding and decoding BluRay Disc LPCM audio.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.WMA/AudioDecoder.cs
+++ b/CUETools.Codecs.WMA/AudioDecoder.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.WMA: WMA audio decoder
- * Copyright (c) 20139 Grigory Chudov
+ * Copyright (c) 2013-2020 Grigory Chudov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/CUETools.Codecs.WMA/CUETools.Codecs.WMA.csproj
+++ b/CUETools.Codecs.WMA/CUETools.Codecs.WMA.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.WMA</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding and decoding Windows Media Audio.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.ffmpeg/CUETools.Codecs.ffmpeg.csproj
+++ b/CUETools.Codecs.ffmpeg/CUETools.Codecs.ffmpeg.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.ffmpegdll</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding various files using official encoder.</Description>
-    <Copyright>Copyright (c) 2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2018-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.lame_enc/CUETools.Codecs.LAME.csproj
+++ b/CUETools.Codecs.lame_enc/CUETools.Codecs.LAME.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.lame_enc</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding mp3 using LAME encoder.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins\win32</OutputPath>

--- a/CUETools.Codecs.libFLAC/CUETools.Codecs.libFLAC.csproj
+++ b/CUETools.Codecs.libFLAC/CUETools.Codecs.libFLAC.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.libFLAC</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding flac using official encoder.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.libmp3lame/CUETools.Codecs.libmp3lame.csproj
+++ b/CUETools.Codecs.libmp3lame/CUETools.Codecs.libmp3lame.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.libmp3lame</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding mp3 using LAME encoder.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs.libwavpack/CUETools.Codecs.libwavpack.csproj
+++ b/CUETools.Codecs.libwavpack/CUETools.Codecs.libwavpack.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs.libwavpack</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding wavpack using official encoder.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins</OutputPath>

--- a/CUETools.Codecs/CUETools.Codecs.csproj
+++ b/CUETools.Codecs/CUETools.Codecs.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Codecs</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for encoding and decoding audio.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Codecs/License.txt
+++ b/CUETools.Codecs/License.txt
@@ -1,5 +1,5 @@
 ﻿CUETools.Codecs: common audio encoder/decoder routines
-Copyright (c) 2009 Gregory S. Chudov
+Copyright (c) 2009-2020 Gregory S. Chudov
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/CUETools.Compression.Rar/CUETools.Compression.Rar.csproj
+++ b/CUETools.Compression.Rar/CUETools.Compression.Rar.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Compression.Rar</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for decompressing RAR.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov, Michael A. McCloskey</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov, Michael A. McCloskey</Copyright>
     <Authors>Grigory Chudov, Michael A. McCloskey</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins\win32</OutputPath>

--- a/CUETools.Compression.Zip/CUETools.Compression.Zip.csproj
+++ b/CUETools.Compression.Zip/CUETools.Compression.Zip.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Compression.Zip</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for decompressing ZIP.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins\</OutputPath>

--- a/CUETools.Compression/CUETools.Compression.csproj
+++ b/CUETools.Compression/CUETools.Compression.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Compression</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library containing interfaces for accessing compressed files.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Converter/CUETools.Converter.csproj
+++ b/CUETools.Converter/CUETools.Converter.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A tool for audio conversion.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Converter/Program.cs
+++ b/CUETools.Converter/Program.cs
@@ -125,7 +125,7 @@ namespace CUETools.Converter
                     break;
             }
 
-            Console.Error.WriteLine("CUETools.Converter, Copyright (C) 2009-2018 Grigory Chudov.");
+            Console.Error.WriteLine("CUETools.Converter, Copyright (C) 2009-2020 Grigory Chudov.");
             Console.Error.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
             Console.Error.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
             if (!ok || sourceFile == null || destFile == null)

--- a/CUETools.DSP.Mixer/CUETools.DSP.Mixer.csproj
+++ b/CUETools.DSP.Mixer/CUETools.DSP.Mixer.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.DSP.Mixer</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for mixing PCM streams together.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)</OutputPath>

--- a/CUETools.DSP.Resampler/CUETools.DSP.Resampler.csproj
+++ b/CUETools.DSP.Resampler/CUETools.DSP.Resampler.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.DSP.Resampler</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for changing PCM sampling frequency.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)</OutputPath>

--- a/CUETools.FLACCL.cmd/Program.cs
+++ b/CUETools.FLACCL.cmd/Program.cs
@@ -1,6 +1,6 @@
 /**
  * CUETools.FLACCL: FLAC audio encoder using CUDA
- * Copyright (c) 2009 Grigory Chudov
+ * Copyright (c) 2009-2020 Grigory Chudov
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -220,7 +220,7 @@ namespace CUETools.FLACCL.cmd
 			}
 			if (!quiet)
 			{
-                Console.WriteLine("{0}, Copyright (C) 2010-2013 Grigory Chudov.", Codecs.FLACCL.AudioEncoder.Vendor);
+                Console.WriteLine("{0}, Copyright (C) 2010-2020 Grigory Chudov.", Codecs.FLACCL.AudioEncoder.Vendor);
 				Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
 				Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
 			}

--- a/CUETools.FLACCL.cmd/Properties/AssemblyInfo.cs
+++ b/CUETools.FLACCL.cmd/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CUETools.FLACCL.cmd")]
-[assembly: AssemblyCopyright("Copyright © 2008-2010 Grigory Chudov")]
+[assembly: AssemblyCopyright("Copyright © 2008-2020 Grigory Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools.Flake/CUETools.Flake.csproj
+++ b/CUETools.Flake/CUETools.Flake.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A tool for encoding and decoding FLAC.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Flake/Program.cs
+++ b/CUETools.Flake/Program.cs
@@ -300,7 +300,7 @@ namespace CUETools.FlakeExe
 
             if (!quiet)
             {
-                Console.WriteLine("CUETools.Flake, Copyright (C) 2009-2014 Grigory Chudov.");
+                Console.WriteLine("CUETools.Flake, Copyright (C) 2009-2020 Grigory Chudov.");
                 Console.WriteLine("Initially based on Flake encoder by Justin Ruggles.");
                 Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
                 Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");

--- a/CUETools.LossyWAV/CUETools.LossyWAV.csproj
+++ b/CUETools.LossyWAV/CUETools.LossyWAV.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A tool for encoding and decoding LossyWAV.</Description>
-    <Copyright>Copyright (c) 2007-2008 Nick Currie, C# port (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2007-2008 Nick Currie, C# port (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.LossyWAV/Program.cs
+++ b/CUETools.LossyWAV/Program.cs
@@ -41,7 +41,7 @@ namespace CUETools.LossyWAVSharp
 		{
 			Console.SetOut(Console.Error);
 			Console.WriteLine("LossyWAV {0}, Copyright (C) 2007,2008 Nick Currie, Copyleft.", LossyWAVWriter.version_string);
-			Console.WriteLine("C# port Copyright (C) 2008 Grigory Chudov.");
+			Console.WriteLine("C# port Copyright (C) 2008-2020 Grigory Chudov.");
 			Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
 			Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
 			if (args.Length < 1 || (args[0].StartsWith("-") && args[0] != "-"))

--- a/CUETools.Parity/CUETools.Parity.csproj
+++ b/CUETools.Parity/CUETools.Parity.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Parity</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for Reed-Solomon coding.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov, based on work by Masayuki Miyazaki</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov, based on work by Masayuki Miyazaki</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Processor/CUETools.Processor.csproj
+++ b/CUETools.Processor/CUETools.Processor.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Processor</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for working with CUE Sheets and CD images.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Processor/License.txt
+++ b/CUETools.Processor/License.txt
@@ -1,6 +1,6 @@
 ﻿CUE Tools
 Copyright (C) 2006-2007  Moitah (moitah@yahoo.com)
-Copyright (C) 2008-2013  Gregory S. Chudov (gchudov@gmail.com)
+Copyright (C) 2008-2020 Gregory S. Chudov (gchudov@gmail.com)
  
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/CUETools.Ripper.Console/CUETools.ConsoleRipper.csproj
+++ b/CUETools.Ripper.Console/CUETools.ConsoleRipper.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A command line CD extraction tool.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.Ripper.Console/Program.cs
+++ b/CUETools.Ripper.Console/Program.cs
@@ -1,7 +1,7 @@
 // ****************************************************************************
 // 
 // CUERipper
-// Copyright (C) 2008-13 Grigory Chudov (gchudov@gmail.com)
+// Copyright (C) 2008-2020 Grigory Chudov (gchudov@gmail.com)
 // 
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -89,7 +89,7 @@ namespace CUETools.ConsoleRipper
 		static void Main(string[] args)
 		{
 			Console.SetOut(Console.Error);
-			Console.WriteLine("CUERipper v2.1.7 Copyright (C) 2008-10 Grigory Chudov");
+			Console.WriteLine("CUERipper v2.1.7 Copyright (C) 2008-2020 Grigory Chudov");
 			Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
 			Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
 

--- a/CUETools.Ripper.SCSI/CUETools.Ripper.SCSI.csproj
+++ b/CUETools.Ripper.SCSI/CUETools.Ripper.SCSI.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Ripper.SCSI</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for extracting audio CDs using SCSI interface.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\plugins\</OutputPath>

--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -1,7 +1,7 @@
 // ****************************************************************************
 // 
 // CUERipper
-// Copyright (C) 2008-13 Grigory Chudov (gchudov@gmail.com)
+// Copyright (C) 2008-2020 Grigory Chudov (gchudov@gmail.com)
 // 
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -1261,7 +1261,7 @@ namespace CUETools.Ripper.SCSI
 		{
 			get
 			{
-				return "CUERipper v2.1.7 Copyright (C) 2008-13 Grigory Chudov";
+				return "CUERipper v2.1.7 Copyright (C) 2008-2020 Grigory Chudov";
 				// ripper.GetName().Name + " " + ripper.GetName().Version;
 			}
 		}

--- a/CUETools.Ripper/CUETools.Ripper.csproj
+++ b/CUETools.Ripper/CUETools.Ripper.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>CUETools.Ripper</RootNamespace>
     <Product>CUETools</Product>
     <Description>A library for extracting audio CDs.</Description>
-    <Copyright>Copyright (c) 2008-2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2008-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.eac3to/CUETools.eac3to.csproj
+++ b/CUETools.eac3to/CUETools.eac3to.csproj
@@ -8,7 +8,7 @@
     <Product>CUETools</Product>
     <OutputType>Exe</OutputType>
     <Description>A command-line tool for BluRay audio extraction.</Description>
-    <Copyright>Copyright (c) 2018 Grigory Chudov</Copyright>
+    <Copyright>Copyright (c) 2018-2020 Grigory Chudov</Copyright>
     <Authors>Grigory Chudov</Authors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>

--- a/CUETools.eac3to/Program.cs
+++ b/CUETools.eac3to/Program.cs
@@ -14,7 +14,7 @@ namespace CUETools.eac3to
     {
         static void Usage()
         {
-            Console.Error.WriteLine("CUETools.eac3to, Copyright (C) 2018 Grigory Chudov.");
+            Console.Error.WriteLine("CUETools.eac3to, Copyright (C) 2018-2020 Grigory Chudov.");
             Console.Error.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
             Console.Error.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
             Console.Error.WriteLine();

--- a/CUETools.eac3ui/Properties/AssemblyInfo.cs
+++ b/CUETools.eac3ui/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BluTools")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyCopyright("Copyright © 2018-2020 Grigory Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools/Properties/AssemblyInfo.cs
+++ b/CUETools/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("")]
-[assembly: AssemblyCopyright("Copyright 2006-2007 Moitah, 2008-2010 Greg Chudov")]
+[assembly: AssemblyCopyright("Copyright 2006-2007 Moitah, 2008-2020 Greg Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/CUETools/frmAbout.resx
+++ b/CUETools/frmAbout.resx
@@ -270,7 +270,7 @@ hdcd.dll (c) Christopher Key</value>
     <value>6</value>
   </data>
   <data name="linkLabel3.Text" xml:space="preserve">
-    <value>Copyright 2008-2018 Grigory Chudov, gchudov@gmail.com</value>
+    <value>Copyright 2008-2020 Grigory Chudov, gchudov@gmail.com</value>
   </data>
   <data name="linkLabel3.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleCenter</value>

--- a/CUETools/frmAbout.ru-RU.resx
+++ b/CUETools/frmAbout.ru-RU.resx
@@ -159,7 +159,7 @@ hdcd.dll (c) Christopher Key
     <value>309, 17</value>
   </data>
   <data name="linkLabel3.Text" xml:space="preserve">
-    <value>Copyright 2008-2018 Григорий Чудов, gchudov@gmail.com</value>
+    <value>Copyright 2008-2020 Григорий Чудов, gchudov@gmail.com</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>439, 296</value>


### PR DESCRIPTION
The copyright year was last time updated in 2018. There is some cleanup
involved in this commit and the next copyright year update is supposed
to be simpler (i.e. substitute "-2020").

- Substitute occurrences of "-2018" with "-2020" using:
`  git grep -I -l -e '-2018' -- ':(exclude)*.bak' | xargs \`
`  sed -b -i -e 's/-2018/-2020/g'`

- Update special cases:
<pre>
  CUEPlayer
    git grep -I -l -e 'Grigory Chudov 2010' -- | xargs \
    sed -b -i -e 's/Grigory Chudov 2010/2010-2020 Grigory Chudov/g'
  CUERipper
    git grep -I -l -e '2008-2009' -- | xargs \
    sed -b -i -e 's/2008-2009/2008-2020/g'
  CUETools, CUETools.FLACCL.cmd
    git grep -I -l -e '2008-2010' -- ':(exclude)*FlaCuda*' | xargs \
    sed -b -i -e 's/2008-2010/2008-2020/g'
    git grep -I -l -e '2010-2013' -- | xargs \
    sed -b -i -e 's/2010-2013/2010-2020/g'
  CUETools.ChaptersToCue
    git grep -I -l -e 'Grigory Chudov 2017' -- | xargs \
    sed -b -i -e 's/Grigory Chudov 2017/2017-2020 Grigory Chudov/g'
  CUETools.CTDB.EACPlugin
    git grep -I -l -e 'Grigory Chudov 2012' -- | xargs \
    sed -b -i -e 's/Grigory Chudov 2012/2012-2020 Grigory Chudov/g'
    git grep -I -l -e '2011-12' -- | xargs \
    sed -b -i -e 's/2011-12/2011-2020/g'
  CUETools.Codecs.FLACCL
    git grep -I -l -e '2009-2010' -- ':(exclude)*FlaCuda*' | xargs \
    sed -b -i -e 's/2009-2010/2009-2020/g'
  CUETools.eac3ui (BluTools)
    git grep -I -l -e '©  2018' -- | xargs \
    sed -b -i -e 's/©  2018/© 2018-2020 Grigory Chudov/g'
  CUETools.Flake
    git grep -I -l -e ' 2009-2014 Gr' -- | xargs \
    sed -b -i -e 's/ 2009-2014 Gr/ 2009-2020 Gr/g'
  CUETools.Processor
    git grep -I -l -e ' 2008-2013  Gr' -- | xargs \
    sed -b -i -e 's/ 2008-2013  Gr/ 2008-2020 Gr/g'
  CUETools.Ripper.Console
    git grep -I -l -e ' 2008-10 Gr' -- | xargs \
    sed -b -i -e 's/ 2008-10 Gr/ 2008-2020 Gr/g'
  CUETools.Ripper.Console, CUETools.Ripper.SCSI
    git grep -I -l -e ' 2008-13 Gr' -- | xargs \
    sed -b -i -e 's/ 2008-13 Gr/ 2008-2020 Gr/g'

  Single year entries: 2008, 2009, 2010, 2011, 2017, 2018
    git grep -I -l -e ' 2008 Gr' -- | xargs \
    sed -b -i -e 's/ 2008 Gr/ 2008-2020 Gr/g'
    git grep -I -l -e ' 2009 Gr' -- ':(exclude)*FlaCuda*' | xargs \
    sed -b -i -e 's/ 2009 Gr/ 2009-2020 Gr/g'
    git grep -I -l -e ' 2010 Gr' -- | xargs \
    sed -b -i -e 's/ 2010 Gr/ 2010-2020 Gr/g'
    git grep -I -l -e ' 2011 Gr' -- | xargs \
    sed -b -i -e 's/ 2011 Gr/ 2011-2020 Gr/g'
    git grep -I -l -e ' 2017 Gr' -- | xargs \
    sed -b -i -e 's/ 2017 Gr/ 2017-2020 Gr/g'
    git grep -I -l -e ' 2018 Gr' -- | xargs \
    sed -b -i -e 's/ 2018 Gr/ 2018-2020 Gr/g'

  Fix typo in copyright year of CUETools.Codecs.WMA/AudioDecoder.cs:
    Copyright (c) 20139 Grigory Chudov
    git grep -I -lw -e '20139' -- | xargs \
    sed -b -i -e 's/20139/2013-2020/g'
</pre>
