### PR TITLE
[CUETools] Use NumericUpDown control for offset

### DIFF
--- a/CUETools/frmCUETools.Designer.cs
+++ b/CUETools/frmCUETools.Designer.cs
@@ -100,7 +100,7 @@ namespace JDP {
             this.txtPreGapLength = new System.Windows.Forms.MaskedTextBox();
             this.labelDataTrack = new System.Windows.Forms.Label();
             this.txtDataTrackLength = new System.Windows.Forms.MaskedTextBox();
-            this.textBoxOffset = new System.Windows.Forms.TextBox();
+            this.numericUpDownOffset = new System.Windows.Forms.NumericUpDown();
             this.panelGo = new System.Windows.Forms.Panel();
             this.btnConvert = new System.Windows.Forms.Button();
             this.btnStop = new System.Windows.Forms.Button();
@@ -151,6 +151,7 @@ namespace JDP {
             this.grpAction.SuspendLayout();
             this.grpExtra.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownOffset)).BeginInit();
             this.panelGo.SuspendLayout();
             this.toolStripMenu.SuspendLayout();
             this.contextMenuStripFileTree.SuspendLayout();
@@ -804,7 +805,7 @@ namespace JDP {
             this.tableLayoutPanel4.Controls.Add(this.txtPreGapLength, 1, 0);
             this.tableLayoutPanel4.Controls.Add(this.labelDataTrack, 0, 1);
             this.tableLayoutPanel4.Controls.Add(this.txtDataTrackLength, 1, 1);
-            this.tableLayoutPanel4.Controls.Add(this.textBoxOffset, 1, 2);
+            this.tableLayoutPanel4.Controls.Add(this.numericUpDownOffset, 1, 2);
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             // 
             // labelPregap
@@ -842,12 +843,21 @@ namespace JDP {
             this.txtDataTrackLength.TextMaskFormat = System.Windows.Forms.MaskFormat.IncludePromptAndLiterals;
             this.toolTip1.SetToolTip(this.txtDataTrackLength, resources.GetString("txtDataTrackLength.ToolTip"));
             // 
-            // textBoxOffset
+            // numericUpDownOffset
             // 
-            resources.ApplyResources(this.textBoxOffset, "textBoxOffset");
-            this.textBoxOffset.Name = "textBoxOffset";
-            this.textBoxOffset.TextChanged += new System.EventHandler(this.textBoxOffset_TextChanged);
-            this.textBoxOffset.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxOffset_KeyPress);
+            resources.ApplyResources(this.numericUpDownOffset, "numericUpDownOffset");
+            this.numericUpDownOffset.Maximum = new decimal(new int[] {
+            99999,
+            0,
+            0,
+            0});
+            this.numericUpDownOffset.Minimum = new decimal(new int[] {
+            99999,
+            0,
+            0,
+            -2147483648});
+            this.numericUpDownOffset.Name = "numericUpDownOffset";
+            this.numericUpDownOffset.ValueChanged += new System.EventHandler(this.numericUpDownOffset_ValueChanged);
             // 
             // panelGo
             // 
@@ -918,8 +928,8 @@ namespace JDP {
             // 
             // toolStripTextBoxAddProfile
             // 
-            this.toolStripTextBoxAddProfile.Name = "toolStripTextBoxAddProfile";
             resources.ApplyResources(this.toolStripTextBoxAddProfile, "toolStripTextBoxAddProfile");
+            this.toolStripTextBoxAddProfile.Name = "toolStripTextBoxAddProfile";
             this.toolStripTextBoxAddProfile.KeyDown += new System.Windows.Forms.KeyEventHandler(this.toolStripTextBoxAddProfile_KeyDown);
             // 
             // toolStripMenuItemDeleteProfile
@@ -1104,6 +1114,7 @@ namespace JDP {
             this.grpExtra.ResumeLayout(false);
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownOffset)).EndInit();
             this.panelGo.ResumeLayout(false);
             this.toolStripMenu.ResumeLayout(false);
             this.toolStripMenu.PerformLayout();
@@ -1217,7 +1228,7 @@ namespace JDP {
         private System.Windows.Forms.ToolStripMenuItem updateLocalDatabaseToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem locateInExplorerToolStripMenuItem;
         private System.Windows.Forms.Button buttonEncoderSettings;
-        private System.Windows.Forms.TextBox textBoxOffset;
-	}
+        private System.Windows.Forms.NumericUpDown numericUpDownOffset;
+    }
 }
 

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -492,7 +492,7 @@ namespace JDP
                 cueSheet.PasswordRequired += new EventHandler<CompressionPasswordRequiredEventArgs>(PasswordRequired);
                 cueSheet.CUEToolsProgress += new EventHandler<CUEToolsProgressEventArgs>(SetStatus);
                 cueSheet.CUEToolsSelection += new EventHandler<CUEToolsSelectionEventArgs>(MakeSelection);
-                cueSheet.WriteOffset = Int32.Parse(textBoxOffset.Text);
+                cueSheet.WriteOffset = (int)numericUpDownOffset.Value;
 
                 object[] p = new object[7];
 
@@ -1332,7 +1332,7 @@ namespace JDP
 
         private bool CheckWriteOffset()
         {
-            if (!rbActionEncode.Checked || SelectedOutputAudioType == AudioEncoderType.NoAudio || 0 == Int32.Parse(textBoxOffset.Text))
+            if (!rbActionEncode.Checked || SelectedOutputAudioType == AudioEncoderType.NoAudio || numericUpDownOffset.Value == 0)
             {
                 return true;
             }
@@ -1350,7 +1350,7 @@ namespace JDP
             SelectedOutputAudioFormat = _profile._outputAudioFormat;
             SelectedAction = _profile._action;
             SelectedCUEStyle = _profile._CUEStyle;
-            textBoxOffset.Text = _profile._writeOffset.ToString();
+            numericUpDownOffset.Value = _profile._writeOffset;
             comboBoxOutputFormat.Text = _profile._outputTemplate ?? comboBoxOutputFormat.Items[0].ToString();
             toolStripDropDownButtonProfile.Text = _profile._name;
             SelectedScript = _profile._script;
@@ -1389,7 +1389,7 @@ namespace JDP
             _profile._outputAudioFormat = SelectedOutputAudioFormat;
             _profile._action = SelectedAction;
             _profile._CUEStyle = SelectedCUEStyle;
-            _profile._writeOffset = Int32.Parse(textBoxOffset.Text);
+            _profile._writeOffset = (int)numericUpDownOffset.Value;
             _profile._outputTemplate = comboBoxOutputFormat.Text;
             _profile._script = SelectedScript;
             _profile._editTags = checkBoxEditTags.Checked;
@@ -2656,6 +2656,12 @@ namespace JDP
                 CorrectorModeEnum.Extension : CorrectorModeEnum.Locate;
         }
 
+        private void numericUpDownOffset_ValueChanged(object sender, EventArgs e)
+        {
+            // Round the same way as displayed in the NumericUpDown control, if decimal values are entered.
+            numericUpDownOffset.Value = Math.Round(numericUpDownOffset.Value, 0, MidpointRounding.AwayFromZero);
+        }
+
         private void pictureBoxMotd_Click(object sender, EventArgs e)
         {
             if (motdImage != null && pictureBoxMotd.Image == motdImage)
@@ -2723,36 +2729,6 @@ namespace JDP
                 settingsForm.ShowDialog(this);
             }
             SelectedOutputAudioType = SelectedOutputAudioType;
-        }
-
-        private void textBoxOffset_KeyPress(object sender, KeyPressEventArgs e)
-        {
-            if (!char.IsControl(e.KeyChar)
-                && !char.IsDigit(e.KeyChar)
-                && e.KeyChar != '-')
-            {
-                e.Handled = true;
-            }
-            base.OnKeyPress(e);
-        }
-
-        private void textBoxOffset_TextChanged(object sender, EventArgs e)
-        {
-            int res;
-            var sb = new StringBuilder();
-            foreach (var c in textBoxOffset.Text.ToCharArray())
-                if (char.IsDigit(c) || (c == '-' && sb.Length == 0))
-                    sb.Append(c);
-            if (textBoxOffset.Text != sb.ToString())
-                textBoxOffset.Text = sb.ToString();
-            if (!int.TryParse(textBoxOffset.Text, out res))
-                textBoxOffset.Text = "0";
-            else
-            {
-                res = Math.Max(-9999,Math.Min(res, 9999));
-                if (textBoxOffset.Text != res.ToString() && textBoxOffset.Text != "-0")
-                    textBoxOffset.Text = res.ToString();
-            }
         }
     }
 }

--- a/CUETools/frmCUETools.resx
+++ b/CUETools/frmCUETools.resx
@@ -940,7 +940,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelPregap" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblWriteOffset" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtPreGapLength" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDataTrack" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtDataTrackLength" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxOffset" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,56.75676,Percent,43.24324" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelPregap" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblWriteOffset" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtPreGapLength" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDataTrack" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtDataTrackLength" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownOffset" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,56.75676,Percent,43.24324" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="grpExtra.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -2550,16 +2550,16 @@
   <data name="&gt;&gt;txtDataTrackLength.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.Name" xml:space="preserve">
-    <value>textBoxOffset</value>
+  <data name="&gt;&gt;numericUpDownOffset.Name" xml:space="preserve">
+    <value>numericUpDownOffset</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.Type" xml:space="preserve">
+  <data name="&gt;&gt;numericUpDownOffset.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.Parent" xml:space="preserve">
+  <data name="&gt;&gt;numericUpDownOffset.Parent" xml:space="preserve">
     <value>tableLayoutPanel4</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;numericUpDownOffset.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
   <data name="tableLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -2593,7 +2593,7 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelPregap" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblWriteOffset" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtPreGapLength" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDataTrack" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtDataTrackLength" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxOffset" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,56.75676,Percent,43.24324" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelPregap" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblWriteOffset" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtPreGapLength" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDataTrack" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtDataTrackLength" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="numericUpDownOffset" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,56.75676,Percent,43.24324" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="labelPregap.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2790,40 +2790,34 @@
   <data name="&gt;&gt;txtDataTrackLength.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="textBoxOffset.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="numericUpDownOffset.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="textBoxOffset.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="numericUpDownOffset.Location" type="System.Drawing.Point, System.Drawing">
     <value>128, 81</value>
   </data>
-  <data name="textBoxOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="numericUpDownOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
   </data>
-  <data name="textBoxOffset.MaxLength" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="textBoxOffset.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="numericUpDownOffset.Size" type="System.Drawing.Size, System.Drawing">
     <value>87, 27</value>
   </data>
-  <data name="textBoxOffset.TabIndex" type="System.Int32, mscorlib">
+  <data name="numericUpDownOffset.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
-  <data name="textBoxOffset.Text" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="textBoxOffset.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+  <data name="numericUpDownOffset.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.Name" xml:space="preserve">
-    <value>textBoxOffset</value>
+  <data name="&gt;&gt;numericUpDownOffset.Name" xml:space="preserve">
+    <value>numericUpDownOffset</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.Type" xml:space="preserve">
+  <data name="&gt;&gt;numericUpDownOffset.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.Parent" xml:space="preserve">
+  <data name="&gt;&gt;numericUpDownOffset.Parent" xml:space="preserve">
     <value>tableLayoutPanel4</value>
   </data>
-  <data name="&gt;&gt;textBoxOffset.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;numericUpDownOffset.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
   <data name="btnConvert.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">


### PR DESCRIPTION
Use `NumericUpDown` control instead of a `TextBox` for entering offset
values in **`CUETools`**. This avoids difficulties, when entering negative
offsets, where the zero can be in the way. The control is now similar
to the `NumericUpDown` in **`CUERipper`**.