### PR TITLE
Fix typos found by codespell

### DIFF
--- a/CUEControls/MediaSlider.cs
+++ b/CUEControls/MediaSlider.cs
@@ -2,7 +2,7 @@
 /************************************************************************************
     *  MediaSlider v1.3                                                                 *
     *                                                                                   *
-    *  Created:     Febuary 7, 2010                                                     *
+    *  Created:     February 7, 2010                                                     *
     *  Built on:    Win7                                                                *
     *  Purpose:     Animated slider control                                             *
     *  Revision:    1.3                                                                 *
@@ -100,7 +100,7 @@ namespace MediaSlider
         {
             None = 0,
             OnFocus,
-            Persistant
+            Persistent
         }
 
         public enum PresetType : uint
@@ -456,7 +456,7 @@ namespace MediaSlider
 
         #region Public Properties
         /// <summary>Run the animation effect when focused</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Run the animation effect when focused")]
         public bool Animated
         {
@@ -476,7 +476,7 @@ namespace MediaSlider
         }
 
         /// <summary>Animation cycle speed</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Animation cycle speed")]
         public AnimateSpeed AnimationSpeed
         {
@@ -502,7 +502,7 @@ namespace MediaSlider
         }
 
         /// <summary>Use an image for the slider background</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Use an image for the slider background")]
         public new Bitmap BackgroundImage
         {
@@ -538,7 +538,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify button accent color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify button accent color")]
         public Color ButtonAccentColor
         {
@@ -551,7 +551,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify button border color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify button border color")]
         public Color ButtonBorderColor
         {
@@ -564,7 +564,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify button base color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify button base color")]
         public Color ButtonColor
         {
@@ -586,7 +586,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify slider button size</summary>
-        [Browsable(true), Category("Appearence"), RefreshProperties(RefreshProperties.All),
+        [Browsable(true), Category("Appearance"), RefreshProperties(RefreshProperties.All),
         Description("Modify slider button size")]
         public Size ButtonSize
         {
@@ -600,7 +600,7 @@ namespace MediaSlider
         }
 
         /// <summary>Set the button style</summary>
-        [Browsable(true), Category("Appearence"), RefreshProperties(RefreshProperties.All),
+        [Browsable(true), Category("Appearance"), RefreshProperties(RefreshProperties.All),
         Description("Set the button style")]
         public ButtonType ButtonStyle
         {
@@ -734,7 +734,7 @@ namespace MediaSlider
         }
 
         /// <summary>The orientation of the control</summary>
-        [Browsable(true), Category("Appearence"), RefreshProperties(RefreshProperties.All),
+        [Browsable(true), Category("Appearance"), RefreshProperties(RefreshProperties.All),
         Description("The orientation of the control")]
         public Orientation Orientation
         {
@@ -764,7 +764,7 @@ namespace MediaSlider
         }
 
         /// <summary>Show the slider button only when control is focused or mouse is hovering</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Show the slider button only when control is focused or mouse is hovering")]
         public bool ShowButtonOnHover
         {
@@ -773,7 +773,7 @@ namespace MediaSlider
         }
 
         /// <summary>Enable the flyout caption window</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Enable the flyout caption window")]
         public FlyOutStyle SliderFlyOut
         {
@@ -874,7 +874,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify slider tick color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify slider tick color")]
         public Color TickColor
         {
@@ -887,7 +887,7 @@ namespace MediaSlider
         }
 
         /// <summary>Select the tickstyle</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Select the tickstyle")]
         public TickStyle TickStyle
         {
@@ -900,7 +900,7 @@ namespace MediaSlider
         }
 
         /// <summary>Select the tick drawing style</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Select the tick drawing style")]
         public TickMode TickType
         {
@@ -913,7 +913,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify slider border color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify slider border color")]
         public Color TrackBorderColor
         {
@@ -926,7 +926,7 @@ namespace MediaSlider
         }
 
         /// <summary>Adjust the slider track depth</summary>
-        [Browsable(true), Category("Appearence"), RefreshProperties(RefreshProperties.All),
+        [Browsable(true), Category("Appearance"), RefreshProperties(RefreshProperties.All),
         Description("Adjust the slider track depth")]
         public int TrackDepth
         {
@@ -940,7 +940,7 @@ namespace MediaSlider
         }
 
         /// <summary>Set the track fill color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Set the track fill color")]
         public Color TrackFillColor
         {
@@ -953,7 +953,7 @@ namespace MediaSlider
         }
 
         /// <summary>Set the track progress color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Set the track progress color")]
         public Color TrackProgressColor
         {
@@ -966,7 +966,7 @@ namespace MediaSlider
         }
 
         /// <summary>Enable track border shadow</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Enable track shadow")]
         public bool TrackShadow
         {
@@ -979,7 +979,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify track shadow color</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify track shadow color")]
         public Color TrackShadowColor
         {
@@ -992,7 +992,7 @@ namespace MediaSlider
         }
 
         /// <summary>Modify the display style of track</summary>
-        [Browsable(true), Category("Appearence"),
+        [Browsable(true), Category("Appearance"),
         Description("Modify the display style of track")]
         public TrackType TrackStyle
         {
@@ -1226,7 +1226,7 @@ namespace MediaSlider
             using (Graphics g = Graphics.FromHdc(_cControlDc.Hdc))
             {
                 DrawTrack();
-                if (this.SliderFlyOut == FlyOutStyle.Persistant)
+                if (this.SliderFlyOut == FlyOutStyle.Persistent)
                     DrawFlyOut(g);
 
                 switch (_eSliderState)
@@ -2578,7 +2578,7 @@ namespace MediaSlider
             }
         }
 
-        /// <summary>Destroy grahics objects</summary>
+        /// <summary>Destroy graphics objects</summary>
         private void DestroyGraphicsObjects()
         {
             // destroy sprite and timer
@@ -2818,7 +2818,7 @@ namespace MediaSlider
             }
         }
 
-        /// <summary>Maximun size based on control options</summary>
+        /// <summary>Maximum size based on control options</summary>
         private void CalculateMaximumSize()
         {
             Size sz = new Size(0, 0);

--- a/CUEPlayer/IcecastSettings.Designer.cs
+++ b/CUEPlayer/IcecastSettings.Designer.cs
@@ -117,7 +117,7 @@
 			// 
 			// textBoxDesctiption
 			// 
-			this.textBoxDesctiption.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.icecastSettingsDataBindingSource, "Desctiption", true));
+			this.textBoxDesctiption.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.icecastSettingsDataBindingSource, "Description", true));
 			this.textBoxDesctiption.Location = new System.Drawing.Point(91, 142);
 			this.textBoxDesctiption.Name = "textBoxDesctiption";
 			this.textBoxDesctiption.Size = new System.Drawing.Size(181, 20);

--- a/CUETools.CLParity/fastdecode/new/reed_solomon.c
+++ b/CUETools.CLParity/fastdecode/new/reed_solomon.c
@@ -81,7 +81,7 @@ void memory_init()
     inverse = t_inverse = (symbol *) malloc(sizeof(symbol) * N_walsh * n_field + 8);
     coeff = t_coeff = (symbol *) malloc(sizeof(symbol) * N_walsh * n_field + 8);
 
-    // allign memory for SSE operation
+    // align memory for SSE operation
     while ((int)(inverse) & 0xf) inverse++;
     while ((int)(coeff) & 0xf) coeff++;
 }
@@ -362,7 +362,7 @@ void compute_product()
 }
 
 // Same but quadratic version
-// Here only for debuging purpose
+// Here only for debugging purpose
 void compute_product_quadratic(int K, int *positions)
 {
     int i,j;

--- a/CUETools.CLParity/fastdecode/new/reed_solomon.h
+++ b/CUETools.CLParity/fastdecode/new/reed_solomon.h
@@ -35,7 +35,7 @@
 
 // type used to store one field symbol
 // With short int, we can work up to GF(16)
-// If one wants to work on bigger fied, replace this by int.
+// If one wants to work on bigger field, replace this by int.
 typedef unsigned short symbol;
 typedef unsigned char  byte;
 

--- a/CUETools.CLParity/fastdecode/reed_solomon.c
+++ b/CUETools.CLParity/fastdecode/reed_solomon.c
@@ -136,7 +136,7 @@ void fill_table(int nf)
         if (state>>n_field!=0) exit(0);
     }
 
-    // usefull since later
+    // useful since later
     // since log_table[0]=0
     // we set log_table[1]=modulo
     // so log_table is a bijection...
@@ -686,7 +686,7 @@ void incremental_encode(int N, int K, int S, void *b_src, void *b_dst)
         void *dst = b_dst + (x-K)*S;
         void *src = b_src + i*S;
 
-        // the second substraction can also
+        // the second subtraction can also
         // go into quadratic_init
         int t = product_enc[x] - log_table[i ^ x] - product_enc[i];
         if (t<0) t+= modulo;
@@ -790,7 +790,7 @@ void quadratic_encode(int N, int K, int S, void *b_src, void *b_dst)
         {
             void *src = b_src + i*S;
 
-            // the second substraction can also
+            // the second subtraction can also
             // go into quadratic_init
             int t = product_enc[x] - log_table[i ^ x] - product_enc[i];
             if (t<0) t+= modulo;
@@ -830,7 +830,7 @@ void quadratic_decode(int N, int K, int S, int *positions, void *b_src, void *b_
             {
                 void *src = b_src + i*S;
 
-                // the second substraction can also
+                // the second subtraction can also
                 // go into quadratic_init
                 int t = product[x] - log_table[positions[i] ^ x] - product[positions[i]];
                 if (t<0) t+= modulo;
@@ -978,7 +978,7 @@ void fast_decode(int N, int K, int S, int *positions, void *b_src, void *b_dst)
     karatsuba(fast_out+K*S, fast_in+K*S, inverse+K, n_walsh-1, S);
     memxor(fast_out, fast_out + K*S, K*S);
 
-    // final multiplication of unknow pieces
+    // final multiplication of unknown pieces
     for (i=0; i<K; i++) {
         if (pos[i]==0) {
             process_eq(product[i], b_dst + i*S, fast_out + i*S, S);

--- a/CUETools.CLParity/fastdecode/reed_solomon.h
+++ b/CUETools.CLParity/fastdecode/reed_solomon.h
@@ -42,7 +42,7 @@
 // type used to store one field symbol
 // With short int, we can work up to GF(16)
 // and we can apply the fast algo up to N_walsh=15
-// If one wants to work on bigger fied, replace this by int.
+// If one wants to work on bigger field, replace this by int.
 typedef uint16_t symbol;
 typedef uint8_t byte;
 

--- a/CUETools.CLParity/fastdecode/test_rs.c
+++ b/CUETools.CLParity/fastdecode/test_rs.c
@@ -136,7 +136,7 @@ void fill_table()
         if (state>>n_field!=0) exit(0);
     }
 
-    // usefull since later
+    // useful since later
     // log_table[1] = modulo
     exp_table[2*modulo]=1;
 }
@@ -283,7 +283,7 @@ void compute_product_quadratic(int K, int *positions)
 // [output] is where we will write the result
 
 // both functions are almost identical
-// but it is usefull to have two for profiling
+// but it is useful to have two for profiling
 
 void quadratic_enc(int K, int S, symbol *data, symbol *output, int x)
 {
@@ -292,7 +292,7 @@ void quadratic_enc(int K, int S, symbol *data, symbol *output, int x)
 
     // first time we overwrite output
     {
-        // the second substraction can also
+        // the second subtraction can also
         // go into quadratic_init
         int t = m - log_table[x] - product_enc[0];
         if (t<0) t+= modulo;
@@ -317,7 +317,7 @@ void quadratic_enc(int K, int S, symbol *data, symbol *output, int x)
     // other time we just xor into the output
     for (i=1; i<K; i++)
     {
-        // the second substraction can also
+        // the second subtraction can also
         // go into quadratic_init
         int t = m - log_table[i ^ x] - product_enc[i];
         if (t<0) t+= modulo;
@@ -347,7 +347,7 @@ void quadratic_dec(int K, int S, int *positions, symbol *data, symbol *output, i
 
     // first time we erase output
     {
-        // the second substraction can also
+        // the second subtraction can also
         // go into quadratic_init
         int t = m - log_table[positions[0] ^ x] - product[positions[0]];
         if (t<0) t+= modulo;
@@ -372,7 +372,7 @@ void quadratic_dec(int K, int S, int *positions, symbol *data, symbol *output, i
     // other time we just xor into the output
     for (i=1; i<K; i++)
     {
-        // the second substraction can also
+        // the second subtraction can also
         // go into quadratic_init
         int t = m - log_table[positions[i] ^ x] - product[positions[i]];
         if (t<0) t+= modulo;

--- a/CUETools.CLParity/matlab/Errors_And_Erasures_Test.m
+++ b/CUETools.CLParity/matlab/Errors_And_Erasures_Test.m
@@ -28,7 +28,7 @@ t = h/2
 
 %*** Generate the Galois Field and Generator polynomial ***
 
-% This step is neccessary for Matlab.  Here we create the Galois Field which is used for
+% This step is necessary for Matlab.  Here we create the Galois Field which is used for
 % computations of the Reed-Solomon code
 
 

--- a/CUETools.CLParity/matlab/RS_E_E_DEC.m
+++ b/CUETools.CLParity/matlab/RS_E_E_DEC.m
@@ -12,7 +12,7 @@ function DECODED = RS_E_E_DEC(received, erasures,n,k,t,h,g,field);
 
 %syndrome calculation
 S = [];
-%Subtitute alpha^i in received polynomial - Lin + Costello p.152 eq. 6.13
+%Substitute alpha^i in received polynomial - Lin + Costello p.152 eq. 6.13
 for ii = 1:2*t
     S(ii)= -Inf;
     for cc = 1:n
@@ -21,7 +21,7 @@ for ii = 1:2*t
 end
 %S
 
-%Test if syndrome  = 0, if syndrome equals 0, assume that no errors occured
+%Test if syndrome  = 0, if syndrome equals 0, assume that no errors occurred
 for i = 1:2*t
     test_pol(i) = -Inf;
 end
@@ -78,7 +78,7 @@ else
     else
         for i = 1:length(S_M)
             if (S_M(i) ~= -Inf)
-                flag = 1;     %Other errors occured in conjunction with erasures
+                flag = 1;     %Other errors occurred in conjunction with erasures
             end
         end
     end

--- a/CUETools.CLParity/matlab/gfsubstitute.m
+++ b/CUETools.CLParity/matlab/gfsubstitute.m
@@ -1,7 +1,7 @@
 function sum = gfsubstitute(polynomial,value,terms,n,field)
 
 %use: gfsubstitute(polynomial,value,terms,n,field)
-%Subtitute i^value in polynomial
+%Substitute i^value in polynomial
 %the number of terms in polynomial
 %n = n of the decoder
 

--- a/CUETools.CTDB.EACPlugin/Plugin.cs
+++ b/CUETools.CTDB.EACPlugin/Plugin.cs
@@ -105,7 +105,7 @@ namespace AudioDataPlugIn
         // StartNewSession is called once at the very beginning of an
         // extraction session. It receives the CD metadata, the
         // name of the used drive, the used read offset and whether
-        // the offset was setted by AccurateRip (so having a comparable
+        // the offset was set by AccurateRip (so having a comparable
         // offset value)
 
         public void StartNewSession(IMetadataLookup data, string drivename, int offset, bool aroffset, int mode)
@@ -183,7 +183,7 @@ namespace AudioDataPlugIn
                     else
                     {
 #if DEBUG
-                        m_trace.WriteLine("Sequence broken on new trasfer");
+                        m_trace.WriteLine("Sequence broken on new transfer");
 #endif
                         this.sequence_ok = false;
                     }
@@ -225,7 +225,7 @@ namespace AudioDataPlugIn
                 if ((m_start_pos + m_length) * 588 != thisAr.Position)
                 {
 #if DEBUG
-                    m_trace.WriteLine("Sequence broken on end of trasfer");
+                    m_trace.WriteLine("Sequence broken on end of transfer");
 #endif
                     this.sequence_ok = false;
                 }

--- a/CUETools.CTDB/UploadHelper/uploader.php
+++ b/CUETools.CTDB/UploadHelper/uploader.php
@@ -103,7 +103,7 @@ $file = $_FILES['uploadedfile'];
 
 //echo $file['name'], ini_get('upload_max_filesize');
 
-    // give info on PHP catched upload errors
+    // give info on PHP caught upload errors
     if($file['error']) switch($file['error']){
         case 1:
         case 2:

--- a/CUETools.Codecs.CoreAudio/CoreAudioApi/AudioEndpointVolumeCallback.cs
+++ b/CUETools.Codecs.CoreAudio/CoreAudioApi/AudioEndpointVolumeCallback.cs
@@ -46,7 +46,7 @@ namespace NAudio.CoreAudioApi
         {
             //Since AUDIO_VOLUME_NOTIFICATION_DATA is dynamic in length based on the
             //number of audio channels available we cannot just call PtrToStructure 
-            //to get all data, thats why it is split up into two steps, first the static
+            //to get all data, that's why it is split up into two steps, first the static
             //data is marshalled into the data structure, then with some IntPtr math the
             //remaining floats are read from memory.
             //

--- a/CUETools.Codecs.CoreAudio/CoreAudioApi/PropertyStore.cs
+++ b/CUETools.Codecs.CoreAudio/CoreAudioApi/PropertyStore.cs
@@ -106,7 +106,7 @@ namespace NAudio.CoreAudioApi
         }
 
         /// <summary>
-        /// Gets property key at sepecified index
+        /// Gets property key at specified index
         /// </summary>
         /// <param name="index">Index</param>
         /// <returns>Property key</returns>

--- a/CUETools.Codecs.FLACCL/flac.cl
+++ b/CUETools.Codecs.FLACCL/flac.cl
@@ -1019,7 +1019,7 @@ void clEstimateResidual(
     for (int offs = tid; offs < (MAX_BLOCKSIZE >> ESTPARTLOG); offs += GROUP_SIZE)
 	psum[offs] = 0;
     data[tid] = 0.0f;
-    // need to initialize "extra" data, because NaNs can produce wierd results even when multipled by zero extra coefs
+    // need to initialize "extra" data, because NaNs can produce weird results even when multiplied by zero extra coefs
     if (tid < 32)
 	data[GROUP_SIZE * 2 + tid] = 0.0f;
 
@@ -1467,7 +1467,7 @@ void clCalcPartition(
 	int s = (offs >= task.residualOrder && offs < end) ? residual[task.residualOffs + offs] : 0;
 	// convert to unsigned
 	uint t = (s << 1) ^ (s >> 31);
-	// calc number of unary bits for each residual sample with each rice paramater
+	// calc number of unary bits for each residual sample with each rice parameter
 	int part = (offs - start) / psize;
 	// we must ensure that psize * (t >> k) doesn't overflow;
 	uint lim = 0x7fffffffU / (uint)psize;

--- a/CUETools.Codecs.FlaCuda/flacuda.cu
+++ b/CUETools.Codecs.FlaCuda/flacuda.cu
@@ -1029,7 +1029,7 @@ extern "C" __global__ void cudaCalcPartition(
     s = (psize - shared.task.data.residualOrder * (threadIdx.x + blockIdx.x == 0)) * (threadIdx.y + 1);
     int dpos = __mul24(threadIdx.x, psize + 1);
     //int dpos = __mul24(threadIdx.x, psize);
-    // calc number of unary bits for part threadIdx.x with rice paramater threadIdx.y
+    // calc number of unary bits for part threadIdx.x with rice parameter threadIdx.y
 #pragma unroll 0
     for (int i = 0; i < psize; i++)
 	s += shared.data[dpos + i] >> threadIdx.y;
@@ -1095,7 +1095,7 @@ extern "C" __global__ void cudaCalcPartition16(
     shared.data[tid + threadIdx.y] = s;
     __syncthreads();
 
-    // calc number of unary bits for part threadIdx.x with rice paramater threadIdx.y
+    // calc number of unary bits for part threadIdx.x with rice parameter threadIdx.y
     int dpos = __mul24(threadIdx.x, 17);
     int sum =
 	(shared.data[dpos + 0] >> threadIdx.y) + (shared.data[dpos + 1] >> threadIdx.y) + 
@@ -1143,10 +1143,10 @@ extern "C" __global__ void cudaCalcLargePartition(
 	shared.data[tid] = min(0xfffff, (s << 1) ^ (s >> 31));
 	__syncthreads();
 
-	// calc number of unary bits for each residual sample with each rice paramater
+	// calc number of unary bits for each residual sample with each rice parameter
 #pragma unroll 0
 	for (int i = threadIdx.x; i < min(psize,256); i += 16)
-	    // for sample (i + threadIdx.x) with this rice paramater (threadIdx.y)
+	    // for sample (i + threadIdx.x) with this rice parameter (threadIdx.y)
 	    sum += shared.data[i] >> threadIdx.y;
 	__syncthreads();
     }
@@ -1331,7 +1331,7 @@ extern "C" __global__ void cudaFindPartitionOrder(
 	for (int i = 0; i < order; i++)
 	    if (threadIdx.x >= i)
 		sum[threadIdx.x - i] += coefs[threadIdx.x] * sample[order - i - 1];
-	fot (int i = order; i < blocksize; i++)
+	for (int i = order; i < blocksize; i++)
 	{
 	    if (!threadIdx.x) sample[order + i] = s = residual[order + i] + (sum[order + i] >> shift);
 	    sum[threadIdx.x + i + 1] += coefs[threadIdx.x] * s;

--- a/CUETools.Codecs.Icecast/IcecastWriter.cs
+++ b/CUETools.Codecs.Icecast/IcecastWriter.cs
@@ -55,7 +55,7 @@ namespace CUETools.Codecs.Icecast
 			req.Headers.Add("ice-public", "1");
 			if ((settings.Url ?? "") != "") req.Headers.Add("ice-url", settings.Url);
 			if ((settings.Genre ?? "") != "") req.Headers.Add("ice-genre", settings.Genre);
-			if ((settings.Desctiption ?? "") != "") req.Headers.Add("ice-description", settings.Desctiption);
+			if ((settings.Description ?? "") != "") req.Headers.Add("ice-description", settings.Description);
 			req.Headers.Add("Authorization", string.Format("Basic {0}", Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("source:{0}", settings.Password)))));
 			req.Timeout = System.Threading.Timeout.Infinite;
 			req.ReadWriteTimeout = System.Threading.Timeout.Infinite;
@@ -237,7 +237,7 @@ namespace CUETools.Codecs.Icecast
 		public string Password { get { return password; } set { password = value; } }
 		public string Mount { get { return mount; } set { mount = value; } }
 		public string Name { get { return name; } set { name = value; } }
-		public string Desctiption { get { return description; } set { description = value; } }
+		public string Description { get { return description; } set { description = value; } }
 		public string Url { get { return url; } set { url = value; } }
 		public string Genre { get { return genre; } set { genre = value; } }
 		public int    Bitrate { get; set; }

--- a/CUETools.Codecs.MPEG/MPLS/AudioDecoder.cs
+++ b/CUETools.Codecs.MPEG/MPLS/AudioDecoder.cs
@@ -124,7 +124,7 @@ namespace CUETools.Codecs.MPEG.MPLS
             var fr = new FrameReader(parentFr, len);
             parentFr.skip(len);
 
-            // Primary Clip identifer
+            // Primary Clip identifier
             item.clip_id = fr.read_string(5);
 
             // skip the redundant "M2TS" CodecIdentifier

--- a/CUETools.Codecs.lame_enc/Interop/LHV1.cs
+++ b/CUETools.Codecs.lame_enc/Interop/LHV1.cs
@@ -36,8 +36,8 @@ namespace CUETools.Codecs.LAME.Interop
         public int bNoRes;	// Disable Bit resorvoir (TRUE/FALSE)
         // MISC SETTINGS
         public int bStrictIso;			// Use strict ISO encoding rules (TRUE/FALSE)
-        public ushort nQuality;			// Quality Setting, HIGH BYTE should be NOT LOW byte, otherwhise quality=5
-        // FUTURE USE, SET TO 0, align strucutre to 331 bytes
+        public ushort nQuality;			// Quality Setting, HIGH BYTE should be NOT LOW byte, otherwise quality=5
+        // FUTURE USE, SET TO 0, align structure to 331 bytes
         //[ MarshalAs( UnmanagedType.ByValArray, SizeConst=255-4*4-2 )]
         //public byte[]	 btReserved;//[255-4*sizeof(DWORD) - sizeof( WORD )];
 

--- a/CUETools.Codecs.lame_enc/Interop/Lame_encDLL.cs
+++ b/CUETools.Codecs.lame_enc/Interop/Lame_encDLL.cs
@@ -20,7 +20,7 @@ namespace CUETools.Codecs.LAME.Interop
         /// </summary>
         /// <param name="pbeConfig">Encoder settings</param>
         /// <param name="dwSamples">Receives the number of samples (not bytes, each sample is a SHORT) to send to each beEncodeChunk() on return.</param>
-        /// <param name="dwBufferSize">Receives the minimun number of bytes that must have the output(result) buffer</param>
+        /// <param name="dwBufferSize">Receives the minimum number of bytes that must have the output(result) buffer</param>
         /// <param name="phbeStream">Receives the stream handle on return</param>
         /// <returns>On success: BE_ERR_SUCCESSFUL</returns>
         [DllImport("Lame_enc.dll")]
@@ -71,7 +71,7 @@ namespace CUETools.Codecs.LAME.Interop
         /// <param name="hbeStream">Handle of the stream.</param>
         /// <param name="buffer">Bytes to encode</param>
         /// <param name="index">Position of the first byte to encode</param>
-        /// <param name="nBytes">Number of bytes to encode (not samples, samples are two byte lenght)</param>
+        /// <param name="nBytes">Number of bytes to encode (not samples, samples are two byte length)</param>
         /// <param name="pOutput">Buffer where to write the encoded data.
         /// This buffer should be at least of the minimum size returned by beInitStream().</param>
         /// <param name="pdwOutput">Returns the number of bytes of encoded data written. 
@@ -88,7 +88,7 @@ namespace CUETools.Codecs.LAME.Interop
         /// <param name="hbeStream">Handle of the stream.</param>
         /// <param name="buffer">Bytes to encode</param>
         /// <param name="index">Position of the first byte to encode</param>
-        /// <param name="nBytes">Number of bytes to encode (not samples, samples are two byte lenght)</param>
+        /// <param name="nBytes">Number of bytes to encode (not samples, samples are two byte length)</param>
         /// <param name="pOutput">Buffer where to write the encoded data.
         /// This buffer should be at least of the minimum size returned by beInitStream().</param>
         /// <param name="pdwOutput">Returns the number of bytes of encoded data written. 

--- a/CUETools.Codecs.lame_enc/Interop/License.txt
+++ b/CUETools.Codecs.lame_enc/Interop/License.txt
@@ -9,7 +9,7 @@ Email:	yetiicb@hotmail.com
 Copyright (C) 2002-2003 Idael Cardoso. 
 	
 LAME ( LAME Ain't an Mp3 Encoder ) 
-You must call the fucntion "beVersion" to obtain information  like version 
+You must call the function "beVersion" to obtain information  like version 
 numbers (both of the DLL and encoding engine), release date and URL for 
 lame_enc's homepage. All this information should be made available to the 
 user of your product through a dialog box or something similar.

--- a/CUETools.Codecs/BitReader.cs
+++ b/CUETools.Codecs/BitReader.cs
@@ -221,7 +221,7 @@ namespace CUETools.Codecs
             int n = have_bits_m >> 3;
             for (int i = 0; i < n; i++)
                 crc = (ushort)((crc << 8) ^ Crc16.table[(crc >> 8) ^ (byte)(cache_m >> (56 - (i << 3)))]);
-            return Crc16.Substract(crc16_m, crc, n);
+            return Crc16.Subtract(crc16_m, crc, n);
         }
 
         public int readbits_signed(int bits)

--- a/CUETools.Codecs/BitWriter.cs
+++ b/CUETools.Codecs/BitWriter.cs
@@ -86,7 +86,7 @@ namespace CUETools.Codecs
             fixed (byte* buf1 = &buffer[0])
             {
                 if (old_pos % 8 != 0)
-                    crc16_m = Crc16.Substract(crc16_m, 0, 1);
+                    crc16_m = Crc16.Subtract(crc16_m, 0, 1);
                 crc16_m = Crc16.ComputeChecksum(crc16_m, buf + start1, end - start);
                 AudioSamples.MemCpy(buf1 + start, buf + start1, end - start);
                 buf1[start] |= start_val;

--- a/CUETools.Codecs/CRC/CRC16.cs
+++ b/CUETools.Codecs/CRC/CRC16.cs
@@ -130,7 +130,7 @@ namespace CUETools.Codecs
             return crc1;
         }
 
-        public static unsafe ushort Substract(ushort crc1, ushort crc2, long len2)
+        public static unsafe ushort Subtract(ushort crc1, ushort crc2, long len2)
         {
             crc1 = Crc16.Reflect(crc1);
             crc2 = Crc16.Reflect(crc2);

--- a/CUETools.Codecs/CRC/CRC32.cs
+++ b/CUETools.Codecs/CRC/CRC32.cs
@@ -228,7 +228,7 @@ namespace CUETools.Codecs
 			return crc1;
 		}
 
-		public static unsafe uint Substract(uint crc1, uint crc2, long len2)
+		public static unsafe uint Subtract(uint crc1, uint crc2, long len2)
 		{
 			/* degenerate case */
 			if (len2 == 0)

--- a/CUETools.Codecs/LPC.cs
+++ b/CUETools.Codecs/LPC.cs
@@ -398,7 +398,7 @@ namespace CUETools.Codecs
 			double* lpc_tmp = stackalloc double[MAX_LPC_ORDER];
 
 			if (max_order > MAX_LPC_ORDER)
-				throw new Exception("wierd");
+				throw new Exception("weird");
 
 			for (int i = 0; i < max_order; i++)
 				lpc_tmp[i] = 0;

--- a/CUETools.Parity/Parity2Syndrome.cs
+++ b/CUETools.Parity/Parity2Syndrome.cs
@@ -145,7 +145,7 @@ namespace CUETools.Parity
             //else
             //    for i = 1:length(S_M)
             //        if (S_M(i) ~= -Inf)
-            //            flag = 1;     %Other errors occured in conjunction with erasures
+            //            flag = 1;     %Other errors occurred in conjunction with erasures
             //        end
             //    end
             //end

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1224,7 +1224,7 @@ namespace CUETools.Processor
                                 }
                                 else
                                 {
-                                    // Wierd case: audio file after data track with only index 00 specified.
+                                    // Weird case: audio file after data track with only index 00 specified.
                                     if (!isAudioTrack && _sourcePaths.Count == 0 && indexes.Count > 0 && indexes[indexes.Count - 1].Index == 0)
                                     {
                                         indexInfo.Track = indexes[indexes.Count - 1].Track;
@@ -3223,7 +3223,7 @@ namespace CUETools.Processor
                     // TODO?
                 }
 
-                // these will be set explicitely
+                // these will be set explicitly
                 destTags.Remove("ARTIST");
                 destTags.Remove("TITLE");
                 destTags.Remove("ALBUM");
@@ -3305,7 +3305,7 @@ namespace CUETools.Processor
                     }
                 }
 
-                // these will be set explicitely
+                // these will be set explicitly
                 destTags.Remove("ARTIST");
                 destTags.Remove("TITLE");
                 destTags.Remove("ALBUM");

--- a/CUETools/CUETools.TestCodecs/Crc32Test.cs
+++ b/CUETools/CUETools.TestCodecs/Crc32Test.cs
@@ -76,8 +76,8 @@ namespace CUETools.TestCodecs
 			uint crcA = Crc32.ComputeChecksum(0, testBytes, 0, lenA);
 			uint crcB = Crc32.ComputeChecksum(0, testBytes, lenA, lenB);
 			Assert.AreEqual<uint>(crcAB, Crc32.Combine(crcA, crcB, lenB), "CRC32 was not combined correctly.");
-			Assert.AreEqual<uint>(crcB, Crc32.Combine(crcA, crcAB, lenB), "CRC32 was not substracted correctly.");
-			Assert.AreEqual<uint>(crcA, Crc32.Substract(crcAB, crcB, lenB), "CRC32 was not substracted correctly.");
+			Assert.AreEqual<uint>(crcB, Crc32.Combine(crcA, crcAB, lenB), "CRC32 was not subtracted correctly.");
+			Assert.AreEqual<uint>(crcA, Crc32.Subtract(crcAB, crcB, lenB), "CRC32 was not subtracted correctly.");
 		}
 
         /// <summary>
@@ -93,8 +93,8 @@ namespace CUETools.TestCodecs
             ushort crcA = Crc16.ComputeChecksum(0, testBytes, 0, lenA);
             ushort crcB = Crc16.ComputeChecksum(0, testBytes, lenA, lenB);
             Assert.AreEqual<uint>(crcAB, Crc16.Combine(crcA, crcB, lenB), "CRC16 was not combined correctly.");
-            Assert.AreEqual<uint>(crcB, Crc16.Combine(crcA, crcAB, lenB), "CRC16 was not substracted correctly.");
-            Assert.AreEqual<uint>(crcA, Crc16.Substract(crcAB, crcB, lenB), "CRC16 was not substracted correctly.");
+            Assert.AreEqual<uint>(crcB, Crc16.Combine(crcA, crcAB, lenB), "CRC16 was not subtracted correctly.");
+            Assert.AreEqual<uint>(crcA, Crc16.Subtract(crcAB, crcB, lenB), "CRC16 was not subtracted correctly.");
         }
 
 		/// <summary>

--- a/CUETools/CUETools.TestCodecs/Properties/AssemblyInfo.cs
+++ b/CUETools/CUETools.TestCodecs/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
+// to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/CUETools/CUETools.TestParity/Properties/AssemblyInfo.cs
+++ b/CUETools/CUETools.TestParity/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
+// to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/CUETools/CUETools.TestProcessor/Properties/AssemblyInfo.cs
+++ b/CUETools/CUETools.TestProcessor/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
+// to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/CUETools/ReadMe.txt
+++ b/CUETools/ReadMe.txt
@@ -60,7 +60,7 @@ is FLAC, and 'Add tags with CRCs' option in advanced settings is checked,
 the output flac file will contain ACCURATERIPCOUNT tag for each track,
 which shows that the track was ripped from the CD correctly, and also
 demonstrates how popular is this CD. You can set up foobar2000 to display
-this nice statictics for each file.
+this nice statistics for each file.
 
 The settings file is located in the "%AppData%\CUE Tools" folder.  For example,
 on Windows XP if your username is "John", the settings folder is likely
@@ -71,5 +71,5 @@ When called with a file name as argument, opens the usual dialog
 with this file name in the input box.
 When called with /verify switch and a filename, starts automatic
 AccurateRip verification, /convert stats conversion, and /fix
-starts AccurateRip verification and convertion (with possible
+starts AccurateRip verification and conversion (with possible
 offset correction).

--- a/CUETools/TestRipper/Properties/AssemblyInfo.cs
+++ b/CUETools/TestRipper/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
-// to COM componenets.  If you need to access a type in this assembly from 
+// to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/CUETools/frmCUETools.resx
+++ b/CUETools/frmCUETools.resx
@@ -2437,7 +2437,7 @@
     <value>&amp;Verify</value>
   </data>
   <data name="rbActionVerify.ToolTip" xml:space="preserve">
-    <value>Contact the AccurateRip databse for validation and compare the image against database</value>
+    <value>Contact the AccurateRip database for validation and compare the image against database</value>
   </data>
   <data name="&gt;&gt;rbActionVerify.Name" xml:space="preserve">
     <value>rbActionVerify</value>
@@ -2776,7 +2776,7 @@
     <value>1</value>
   </data>
   <data name="txtDataTrackLength.ToolTip" xml:space="preserve">
-    <value>Not used for normal music CDs. Enhanced CDs with data tracks cannot be found in database unless you know the length of the data track. You can often find it in EAC log. If EAC log is found next to the CUE sheet, it will be parsed automaticly and you won't have to enter anything here.</value>
+    <value>Not used for normal music CDs. Enhanced CDs with data tracks cannot be found in database unless you know the length of the data track. You can often find it in EAC log. If EAC log is found next to the CUE sheet, it will be parsed automatically and you won't have to enter anything here.</value>
   </data>
   <data name="&gt;&gt;txtDataTrackLength.Name" xml:space="preserve">
     <value>txtDataTrackLength</value>

--- a/CUETools/frmSettings.resx
+++ b/CUETools/frmSettings.resx
@@ -874,7 +874,7 @@
     <value>Decode HDCD to 20 bit</value>
   </data>
   <data name="chkHDCDDecode.ToolTip" xml:space="preserve">
-    <value>HDCD decoding is irreversable. Resulting files cannot be burned to the CD. 24-bit audio files are created, but the actual resolution is 20 bit</value>
+    <value>HDCD decoding is irreversible. Resulting files cannot be burned to the CD. 24-bit audio files are created, but the actual resolution is 20 bit</value>
   </data>
   <data name="&gt;&gt;chkHDCDDecode.Name" xml:space="preserve">
     <value>chkHDCDDecode</value>


### PR DESCRIPTION
- Typos were found by codespell v1.17.0.dev0 (commit 44fea6d)
- Command used:
```console
  codespell -q 2 \
  -L ba,bloc,blocs,doubleclick,dur,fille,frmat,numer,optin,passtime \
  -L pres,strack,te,tim,tre,uint,whn \
  --skip="*.de-DE.resx,./Bwg*,./Freedb,./MusicBrainz,./ProgressODoom" \
  --skip="./ThirdParty"
```
