### PR TITLE
[CUETools] Update offset entry

### DIFF
--- a/CUETools/frmCUETools.Designer.cs
+++ b/CUETools/frmCUETools.Designer.cs
@@ -640,6 +640,7 @@ namespace JDP {
             this.toolStripSplitButtonInputBrowser});
             this.toolStripInput.Name = "toolStripInput";
             this.toolStripInput.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            this.toolStripInput.Click += new System.EventHandler(this.toolStripInput_Click);
             // 
             // toolStripLabelInput
             // 
@@ -697,6 +698,7 @@ namespace JDP {
             this.toolStripOutput.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.toolStripOutput.Name = "toolStripOutput";
             this.toolStripOutput.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            this.toolStripOutput.Click += new System.EventHandler(this.toolStripOutput_Click);
             // 
             // toolStripLabelOutput
             // 
@@ -848,6 +850,7 @@ namespace JDP {
             this.textBoxOffset.Name = "textBoxOffset";
             this.textBoxOffset.TextChanged += new System.EventHandler(this.textBoxOffset_TextChanged);
             this.textBoxOffset.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBoxOffset_KeyPress);
+            this.textBoxOffset.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxOffset_Validating);
             // 
             // panelGo
             // 
@@ -902,6 +905,7 @@ namespace JDP {
             this.toolStripMenu.Name = "toolStripMenu";
             this.toolStripMenu.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
             this.toolStripMenu.Stretch = true;
+            this.toolStripMenu.Click += new System.EventHandler(this.toolStripMenu_Click);
             // 
             // toolStripDropDownButtonProfile
             // 

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -1389,7 +1389,10 @@ namespace JDP
             _profile._outputAudioFormat = SelectedOutputAudioFormat;
             _profile._action = SelectedAction;
             _profile._CUEStyle = SelectedCUEStyle;
-            _profile._writeOffset = Int32.Parse(textBoxOffset.Text);
+            // _profile._writeOffset = Int32.Parse(textBoxOffset.Text);
+            // Use Int32.TryParse() instead of Int32.Parse to make sure that 0 is written to the settings file
+            // in case of invalid textBoxOffset.Text (empty or '-'), which should not happen anyway because of validating
+            Int32.TryParse(textBoxOffset.Text, out _profile._writeOffset);
             _profile._outputTemplate = comboBoxOutputFormat.Text;
             _profile._script = SelectedScript;
             _profile._editTags = checkBoxEditTags.Checked;
@@ -2678,6 +2681,24 @@ namespace JDP
             cueSheet.ScanLocalDB(folder);
         }
 
+        private void toolStripMenu_Click(object sender, EventArgs e)
+        {
+            // Trigger textBoxOffset_Validating event, when clicking here
+            toolStripMenu.Focus();
+        }
+
+        private void toolStripInput_Click(object sender, EventArgs e)
+        {
+            // Trigger textBoxOffset_Validating event, when clicking here
+            toolStripInput.Focus();
+        }
+
+        private void toolStripOutput_Click(object sender, EventArgs e)
+        {
+            // Trigger textBoxOffset_Validating event, when clicking here
+            toolStripOutput.Focus();
+        }
+
         private void backgroundWorkerAddToLocalDB_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             SetStatus(sender, new CUEToolsProgressEventArgs());
@@ -2745,13 +2766,20 @@ namespace JDP
                     sb.Append(c);
             if (textBoxOffset.Text != sb.ToString())
                 textBoxOffset.Text = sb.ToString();
-            if (!int.TryParse(textBoxOffset.Text, out res))
-                textBoxOffset.Text = "0";
-            else
+            if (int.TryParse(textBoxOffset.Text, out res))
+                // invalid values of textBoxOffset.Text are handled in textBoxOffset_Validating
             {
                 res = Math.Max(-9999,Math.Min(res, 9999));
                 if (textBoxOffset.Text != res.ToString() && textBoxOffset.Text != "-0")
                     textBoxOffset.Text = res.ToString();
+            }
+        }
+
+        private void textBoxOffset_Validating(object sender, CancelEventArgs e)
+        {
+            if (!int.TryParse(textBoxOffset.Text, out _))
+            {
+                textBoxOffset.Text = "0";
             }
         }
     }


### PR DESCRIPTION
A check of `textBoxOffset.Text` for invalid values (empty or '-' only)
is now done in a `textBoxOffset_Validating()` event instead of
previously `textBoxOffset_TextChanged()`.
This avoids observed difficulties, when entering negative offsets,
where the zero could be in the way.
