### PR TITLE
Fix CD-Extra data track info in detailed log

### DIFF
--- a/CUETools.CTDB/CUEToolsDB.cs
+++ b/CUETools.CTDB/CUEToolsDB.cs
@@ -603,7 +603,7 @@ namespace CUETools.CTDB
                     string confFormat = (this.Total < 10) ? "{0:0}/{1:0}" :
                         (this.Total < 100) ? "{0:00}/{1:00}" : "{0:000}/{1:000}";
                     string conf = string.Format(confFormat, entry.conf, this.Total);
-                    string dataTrackInfo = !entry.toc[entry.toc.TrackCount].IsAudio && this.toc[this.toc.TrackCount].IsAudio ?
+                    string dataTrackInfo = !entry.toc[entry.toc.TrackCount].IsAudio && this.toc[1].IsAudio ?
                         string.Format("CD-Extra data track length {0}", entry.toc[entry.toc.TrackCount].LengthMSF) :
                         !entry.toc[1].IsAudio && this.toc[1].IsAudio ?
                         string.Format("Playstation type data track length {0}", entry.toc[entry.toc.FirstAudio].StartMSF) :


### PR DESCRIPTION
This fix concerns CDs with a CD-Extra data track.
The option 'Detailed log' has to be enabled in CUERipper. Up to now,
when there was a difference in CD-Extra data track length, only a comma
was written into the detailed *.accurip file. The following example is
from a CD with a CD-Extra data track length 00:47:50.
- Example, before:
```console
  [ CTDBID ] Status
  [020a6c01] (04/21) Has no data track, Accurately ripped
  [020a6c01] (04/21) , Accurately ripped
  [8625f4cf] (01/21) No match
  [020a6c01] (02/21) Accurately ripped
  [af64186e] (01/21) , No match
```
- Example, fixed:
```console
  [ CTDBID ] Status
  [020a6c01] (04/21) Has no data track, Accurately ripped
  [020a6c01] (04/21) CD-Extra data track length 01:02:57, Accurately ripped
  [8625f4cf] (01/21) No match
  [020a6c01] (02/21) Accurately ripped
  [af64186e] (01/21) CD-Extra data track length 01:02:57, No match
```
- Up to now the info about CD-Extra data track length was only written
  to the detailed log, when the CD did not contain a data track and the
  last track was an audio track.
- Fixes #43