### PR TITLE
[CUERipper] Save metadata before UpdateDrive(s)

### DIFF
--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -214,11 +214,21 @@ namespace CUERipper
 			{
 				int val = m.WParam.ToInt32();
 				if (val == DBT_DEVICEARRIVAL || val == DBT_DEVICEREMOVECOMPLETE)
+				{
+					// Save current metadata before clearing
+					if (data.selectedRelease != null)
+						data.selectedRelease.metadata.Save();
 					UpdateDrive();
+				}
 				else if (val == DBT_DEVNODES_CHANGED)
 				{
 					if (_workThread == null)
+					{
+						// Save current metadata before clearing
+						if (data.selectedRelease != null)
+							data.selectedRelease.metadata.Save();
 						UpdateDrives();
+					}
 				}
 			}
 			base.WndProc(ref m);


### PR DESCRIPTION
Up to now, entered metadata was cleared and lost, when `UpdateDrive()` or
`UpdateDrives()` was called after device change events. This happened for
example in case of a `DBT_DEVNODES_CHANGE` event. Typical triggers for
this event are often not even CD drive related, like insert/eject of
USB sticks, disconnection or connection of a Bluetooth mouse etc.

- In order to avoid loss of entered metadata in case of such events,
  save the data first before calling the methods `UpdateDrive()`
  or `UpdateDrives()`.
- The entered metadata is now also saved, when a CD is ejected.
- Fixes #20
