### PR TITLE
[CUETools] Preserve EAC log file encoding

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -2310,6 +2310,9 @@ namespace CUETools.Processor
         {
             bool utf8Required = CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(text)) != text;
             var encoding = utf8Required ? Encoding.UTF8 : CUESheet.Encoding;
+            // Preserve original UTF-16LE encoding of EAC log files, which contain a log checksum
+            if ((text.StartsWith("Exact Audio Copy") || text.StartsWith("EAC extraction logfile")) && text.Contains("==== Log checksum"))
+                encoding = Encoding.Unicode;
             using (StreamWriter sw1 = new StreamWriter(path, false, encoding))
                 sw1.Write(text);
         }


### PR DESCRIPTION
EAC log files are encoded using `UTF-16LE`. Preserve this encoding in
case of EAC log files, which contain a log checksum. This way, the
copied log file stays unchanged and the checksum can still be verified
using EAC's **`CheckLog.exe`**