### PR TITLE
Update German translation

### DIFF
--- a/Bwg.Scsi/Messages.de-DE.resx
+++ b/Bwg.Scsi/Messages.de-DE.resx
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SCSIErrorMessage_3A00" xml:space="preserve">
+    <value>Medium nicht vorhanden</value>
+  </data>
+  <data name="SCSIErrorMessage_3A01" xml:space="preserve">
+    <value>Medium nicht vorhanden - Schublade geschlossen</value>
+  </data>
+  <data name="SCSIErrorMessage_3A02" xml:space="preserve">
+    <value>Medium nicht vorhanden - Schublade offen</value>
+  </data>
+  <data name="SCSISenseKey_00" xml:space="preserve">
+    <value>unbekannter Fehler</value>
+  </data>
+  <data name="SCSISenseKey_01" xml:space="preserve">
+    <value>behobener Fehler</value>
+  </data>
+  <data name="SCSISenseKey_02" xml:space="preserve">
+    <value>nicht bereit</value>
+  </data>
+  <data name="SCSISenseKey_03" xml:space="preserve">
+    <value>Mediumfehler</value>
+  </data>
+  <data name="SCSISenseKey_04" xml:space="preserve">
+    <value>Hardwarefehler</value>
+  </data>
+  <data name="SCSISenseKey_05" xml:space="preserve">
+    <value>ungültige Anfrage</value>
+  </data>
+  <data name="SCSISenseKey_06" xml:space="preserve">
+    <value>unit attention</value>
+  </data>
+  <data name="SCSISenseKey_07" xml:space="preserve">
+    <value>data protect</value>
+  </data>
+  <data name="SCSISenseKey_08" xml:space="preserve">
+    <value>blank check</value>
+  </data>
+  <data name="SCSISenseKey_09" xml:space="preserve">
+    <value>vendor specific</value>
+  </data>
+  <data name="SCSISenseKey_0A" xml:space="preserve">
+    <value>Kopieren abgebrochen</value>
+  </data>
+  <data name="SCSISenseKey_0B" xml:space="preserve">
+    <value>abgebrochener Befehl</value>
+  </data>
+  <data name="SCSISenseKey_0D" xml:space="preserve">
+    <value>Volumenüberlauf</value>
+  </data>
+  <data name="SCSISenseKey_0E" xml:space="preserve">
+    <value>Vergleichsfehler</value>
+  </data>
+</root>

--- a/CUERipper/CUERipper.csproj
+++ b/CUERipper/CUERipper.csproj
@@ -112,6 +112,9 @@
     <EmbeddedResource Include="frmCUERipper.ru-RU.resx">
       <DependentUpon>frmCUERipper.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="frmFreedbSubmit.de-DE.resx">
+      <DependentUpon>frmFreedbSubmit.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="frmFreedbSubmit.resx">
       <DependentUpon>frmFreedbSubmit.cs</DependentUpon>
     </EmbeddedResource>

--- a/CUERipper/CUERipper.csproj
+++ b/CUERipper/CUERipper.csproj
@@ -121,6 +121,7 @@
     <EmbeddedResource Include="Options.resx">
       <DependentUpon>Options.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.de-DE.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/CUERipper/Properties/Resources.de-DE.resx
+++ b/CUERipper/Properties/Resources.de-DE.resx
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DetectingDrives" xml:space="preserve">
+    <value>Laufwerkserkennung läuft</value>
+  </data>
+  <data name="DoneRipping" xml:space="preserve">
+    <value>Rippen abgeschlossen</value>
+  </data>
+  <data name="DoneRippingErrors" xml:space="preserve">
+    <value>Der Rip enthält wahrscheinlich Fehler</value>
+  </data>
+  <data name="DoneRippingRepair" xml:space="preserve">
+    <value>Sie können eine Reparatur mit CUETools versuchen</value>
+  </data>
+  <data name="ExceptionMessage" xml:space="preserve">
+    <value>Ausnahme</value>
+  </data>
+  <data name="FailedToLoadRipperModule" xml:space="preserve">
+    <value>Laden des Ripper-Moduls fehlgeschlagen</value>
+  </data>
+  <data name="LookingUpVia" xml:space="preserve">
+    <value>Albumsuche via</value>
+  </data>
+  <data name="NoDrives" xml:space="preserve">
+    <value>Keine CD-Laufwerke gefunden</value>
+  </data>
+  <data name="PausedMessage" xml:space="preserve">
+    <value>Pausiert</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>erneut versuchen</value>
+  </data>
+</root>

--- a/CUERipper/frmCUERipper.de-DE.resx
+++ b/CUERipper/frmCUERipper.de-DE.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -177,9 +177,6 @@
   <data name="progressBarCD.Text" xml:space="preserve">
     <value>10%</value>
   </data>
-  <data name="comboBoxOutputFormat.ToolTip" xml:space="preserve">
-    <value>Vorlage für Ausgabedateien (foobar2000-Format)</value>
-  </data>
   <data name="txtOutputPath.ToolTip" xml:space="preserve">
     <value>Klicken, um die Vorlage zu ändern</value>
   </data>
@@ -212,5 +209,26 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>CUERipper 2.1.7</value>
+  </data>
+  <data name="bnComboBoxDrives.Text" xml:space="preserve">
+    <value>Laufwerke</value>
+  </data>
+  <data name="bnComboBoxEncoder.Text" xml:space="preserve">
+    <value>libFlac</value>
+  </data>
+  <data name="bnComboBoxFormat.Text" xml:space="preserve">
+    <value>flac</value>
+  </data>
+  <data name="bnComboBoxImage.Text" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="bnComboBoxLosslessOrNot.Text" xml:space="preserve">
+    <value>verlustfrei</value>
+  </data>
+  <data name="bnComboBoxRelease.Text" xml:space="preserve">
+    <value>Veröffentlichungen</value>
+  </data>
+  <data name="buttonEjectDisk.Text" xml:space="preserve">
+    <value>Auswerfen</value>
   </data>
 </root>

--- a/CUERipper/frmCUERipper.de-DE.resx
+++ b/CUERipper/frmCUERipper.de-DE.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="toolStripStatusAr.ToolTipText" xml:space="preserve">
-    <value>Album in der AccurateRip-Datenbank gefunden.</value>
+    <value>AccurateRip-Status</value>
   </data>
   <data name="toolStripProgressBar1.ToolTipText" xml:space="preserve">
     <value>Lesefortschritt</value>

--- a/CUERipper/frmCUERipper.resx
+++ b/CUERipper/frmCUERipper.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -159,7 +159,7 @@
     <value>28, 30</value>
   </data>
   <data name="toolStripStatusAr.ToolTipText" xml:space="preserve">
-    <value>Album found in AccurateRip database.</value>
+    <value>AccurateRip status</value>
   </data>
   <data name="toolStripProgressBar1.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 29</value>
@@ -1708,6 +1708,9 @@
   </data>
   <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="buttonEjectDisk.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="buttonEjectDisk.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>

--- a/CUERipper/frmFreedbSubmit.de-DE.resx
+++ b/CUERipper/frmFreedbSubmit.de-DE.resx
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="$this.Text" xml:space="preserve">
+    <value>An freedb senden</value>
+  </data>
+  <data name="buttonCancel.Text" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="buttonOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="labelAT.Text" xml:space="preserve">
+    <value>@</value>
+  </data>
+  <data name="labelCategory.Text" xml:space="preserve">
+    <value>Kategorie</value>
+  </data>
+  <data name="labelEmail.Text" xml:space="preserve">
+    <value>E-Mail Adresse</value>
+  </data>
+</root>

--- a/CUETools.CLParity/CUETools.CLParity.csproj
+++ b/CUETools.CLParity/CUETools.CLParity.csproj
@@ -87,6 +87,7 @@
     <Content Include="parity.cl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Properties\Resources.de-DE.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/CUETools.CLParity/Properties/Resources.de-DE.resx
+++ b/CUETools.CLParity/Properties/Resources.de-DE.resx
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DescriptionCPUThreads" xml:space="preserve">
+    <value>Zusätzliche CPU-Threads verwenden</value>
+  </data>
+  <data name="DescriptionDefines" xml:space="preserve">
+    <value>Zusätzliche Präprozessor-Definitionen für OpenCL-Kernel</value>
+  </data>
+  <data name="DescriptionDeviceType" xml:space="preserve">
+    <value>CPU oder GPU verwenden</value>
+  </data>
+  <data name="DescriptionDoRice" xml:space="preserve">
+    <value>Finale Kodierungsschritte auf der GPU ausführen (experimentell)</value>
+  </data>
+  <data name="DescriptionGPUOnly" xml:space="preserve">
+    <value>GPU für alle Schritte verwenden</value>
+  </data>
+  <data name="DescriptionGroupSize" xml:space="preserve">
+    <value>GPU-Thread Blockgröße (64, 128, 256)</value>
+  </data>
+  <data name="DescriptionMappedMemory" xml:space="preserve">
+    <value>Gerät verwendet Speicher des Systems (nicht verwenden)</value>
+  </data>
+  <data name="DescriptionPlatform" xml:space="preserve">
+    <value>Zu verwendende OpenCL-Plattform</value>
+  </data>
+  <data name="DescriptionTaskSize" xml:space="preserve">
+    <value>Anzahl prozessierter Frames je Multiprozessor</value>
+  </data>
+  <data name="DoMD5Description" xml:space="preserve">
+    <value>MD5-Prüfsumme für Audiodaten berechnen</value>
+  </data>
+  <data name="DoVerifyDescription" xml:space="preserve">
+    <value>Jeden Frame dekodieren und mit dem Original vergleichen</value>
+  </data>
+  <data name="ExceptionSampleCount" xml:space="preserve">
+    <value>Die geschriebenen Samples unterscheiden sich von der erwarteten Anzahl</value>
+  </data>
+  <data name="ExceptionValidationFailed" xml:space="preserve">
+    <value>Validierung fehlgeschlagen</value>
+  </data>
+</root>

--- a/CUETools.Codecs.FLACCL/CUETools.Codecs.FLACCL.csproj
+++ b/CUETools.Codecs.FLACCL/CUETools.Codecs.FLACCL.csproj
@@ -90,6 +90,7 @@
     <Content Include="flac.cl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <EmbeddedResource Include="Properties\Resources.de-DE.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/CUETools.Codecs.FLACCL/Properties/Resources.de-DE.resx
+++ b/CUETools.Codecs.FLACCL/Properties/Resources.de-DE.resx
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DescriptionCPUThreads" xml:space="preserve">
+    <value>Zusätzliche CPU-Threads verwenden</value>
+  </data>
+  <data name="DescriptionDefines" xml:space="preserve">
+    <value>Zusätzliche Präprozessor-Definitionen für OpenCL-Kernel</value>
+  </data>
+  <data name="DescriptionDeviceType" xml:space="preserve">
+    <value>CPU oder GPU verwenden</value>
+  </data>
+  <data name="DescriptionDoRice" xml:space="preserve">
+    <value>Finale Kodierungsschritte auf der GPU ausführen (experimentell)</value>
+  </data>
+  <data name="DescriptionGPUOnly" xml:space="preserve">
+    <value>GPU für alle Schritte verwenden</value>
+  </data>
+  <data name="DescriptionGroupSize" xml:space="preserve">
+    <value>GPU-Thread Blockgröße (64, 128, 256)</value>
+  </data>
+  <data name="DescriptionMappedMemory" xml:space="preserve">
+    <value>Gerät verwendet Speicher des Systems (nicht verwenden)</value>
+  </data>
+  <data name="DescriptionPlatform" xml:space="preserve">
+    <value>Zu verwendende OpenCL-Plattform</value>
+  </data>
+  <data name="DescriptionTaskSize" xml:space="preserve">
+    <value>Anzahl prozessierter Frames je Multiprozessor</value>
+  </data>
+  <data name="DoMD5Description" xml:space="preserve">
+    <value>MD5-Prüfsumme für Audiodaten berechnen</value>
+  </data>
+  <data name="DoVerifyDescription" xml:space="preserve">
+    <value>Jeden Frame dekodieren und mit dem Original vergleichen</value>
+  </data>
+  <data name="ExceptionSampleCount" xml:space="preserve">
+    <value>Die geschriebenen Samples unterscheiden sich von der erwarteten Anzahl</value>
+  </data>
+  <data name="ExceptionValidationFailed" xml:space="preserve">
+    <value>Validierung fehlgeschlagen</value>
+  </data>
+  <data name="DescriptionPadding" xml:space="preserve">
+    <value>Anzahl zu reservierender Bytes für Metadaten</value>
+  </data>
+  <data name="AllowNonSubsetDescription" xml:space="preserve">
+    <value>Non-subset Modi erlauben, die eine höhere Kompression ermöglichen, allerdings weniger kompatibel sind</value>
+  </data>
+</root>

--- a/CUETools.Codecs.Flake/Properties/Resources.de-DE.resx
+++ b/CUETools.Codecs.Flake/Properties/Resources.de-DE.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AllowNonSubsetDescription" xml:space="preserve">
+    <value>Non-subset Modi erlauben, die eine höhere Kompression ermöglichen, allerdings weniger kompatibel sind</value>
+  </data>
+  <data name="DoMD5Description" xml:space="preserve">
+    <value>MD5-Prüfsumme für Audiodaten berechnen</value>
+  </data>
+  <data name="DoVerifyDescription" xml:space="preserve">
+    <value>Jeden Frame dekodieren und mit dem Original vergleichen</value>
+  </data>
+  <data name="ExceptionSampleCount" xml:space="preserve">
+    <value>Die geschriebenen Samples unterscheiden sich von der erwarteten Anzahl</value>
+  </data>
+  <data name="ExceptionValidationFailed" xml:space="preserve">
+    <value>Validierung fehlgeschlagen</value>
+  </data>
+</root>

--- a/CUETools.Codecs.WMA/Properties/Resources.de-DE.resx
+++ b/CUETools.Codecs.WMA/Properties/Resources.de-DE.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DoMD5Description" xml:space="preserve">
+    <value>MD5-Prüfsumme für Audiodaten berechnen</value>
+  </data>
+  <data name="DoVerifyDescription" xml:space="preserve">
+    <value>Jeden Frame dekodieren und mit dem Original vergleichen</value>
+  </data>
+  <data name="ExceptionSampleCount" xml:space="preserve">
+    <value>Die geschriebenen Samples unterscheiden sich von der erwarteten Anzahl</value>
+  </data>
+</root>

--- a/CUETools.Ripper.SCSI/Resource1.de-DE.resx
+++ b/CUETools.Ripper.SCSI/Resource1.de-DE.resx
@@ -1,0 +1,150 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AutodetectReadCommandFailed" xml:space="preserve">
+    <value>Lesebefehl konnte nicht erkannt werden</value>
+  </data>
+  <data name="DeviceInquiryError" xml:space="preserve">
+    <value>Fehler bei der Abfrage des Laufwerks</value>
+  </data>
+  <data name="DeviceNotMMC" xml:space="preserve">
+    <value>Kein MMC-Gerät</value>
+  </data>
+  <data name="DeviceOpenError" xml:space="preserve">
+    <value>Öffnen fehlgeschlagen</value>
+  </data>
+  <data name="NoAudio" xml:space="preserve">
+    <value>Keine Audio-Tracks</value>
+  </data>
+  <data name="ReadCDError" xml:space="preserve">
+    <value>Fehler beim Lesen der CD</value>
+  </data>
+  <data name="ReadTOCError" xml:space="preserve">
+    <value>CD kann nicht geöffnet werden</value>
+  </data>
+  <data name="StatusDetectingDriveFeatures" xml:space="preserve">
+    <value>Laufwerkseigenschaften werden erkannt</value>
+  </data>
+  <data name="StatusDetectingGaps" xml:space="preserve">
+    <value>Lücken (Gaps) werden erkannt</value>
+  </data>
+  <data name="StatusRipping" xml:space="preserve">
+    <value>Rippen</value>
+  </data>
+</root>

--- a/CUETools/CUETools.csproj
+++ b/CUETools/CUETools.csproj
@@ -218,6 +218,7 @@
     <EmbeddedResource Include="frmSubmit.ru-RU.resx">
       <DependentUpon>frmSubmit.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.de-DE.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/CUETools/Properties/Resources.de-DE.resx
+++ b/CUETools/Properties/Resources.de-DE.resx
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Go" xml:space="preserve">
+    <value>&amp;Los</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>Stopp</value>
+  </data>
+  <data name="Verify" xml:space="preserve">
+    <value>Verifizieren</value>
+  </data>
+</root>

--- a/CUETools/frmCUETools.de-DE.resx
+++ b/CUETools/frmCUETools.de-DE.resx
@@ -121,14 +121,8 @@
   <data name="toolStripStatusLabelProcessed.Size" type="System.Drawing.Size, System.Drawing">
     <value>80, 21</value>
   </data>
-  <data name="toolStripStatusLabelProcessed.Text" xml:space="preserve">
-    <value>Restzeit</value>
-  </data>
   <data name="toolStripStatusLabelAR.ToolTipText" xml:space="preserve">
     <value>Album in AccurateRip-Datenbank gefunden.</value>
-  </data>
-  <data name="toolStripProgressBar1.ToolTipText" xml:space="preserve">
-    <value>Trackfortschritt</value>
   </data>
   <data name="toolStripProgressBar2.ToolTipText" xml:space="preserve">
     <value>Gesamtfortschritt</value>
@@ -206,19 +200,19 @@
     <value>131, 17</value>
   </data>
   <data name="rbActionCorrectFilenames.Text" xml:space="preserve">
-    <value>Korrigiere Dateinamen</value>
+    <value>Dateinamen korrigieren</value>
   </data>
   <data name="rbActionCorrectFilenames.ToolTip" xml:space="preserve">
-    <value />
+    <value>Dateinamen in CUE-Sheets korrigieren</value>
   </data>
   <data name="rbActionCreateCUESheet.Size" type="System.Drawing.Size, System.Drawing">
     <value>119, 17</value>
   </data>
   <data name="rbActionCreateCUESheet.Text" xml:space="preserve">
-    <value>Erzeuge leeres CUE</value>
+    <value>Leeres CUE-Sheet erzeugen</value>
   </data>
   <data name="rbActionCreateCUESheet.ToolTip" xml:space="preserve">
-    <value />
+    <value>Ein CUE-Sheet für Tracks erzeugen und eingebettete CUE-Sheets extrahieren</value>
   </data>
   <data name="rbActionVerifyAndEncode.Size" type="System.Drawing.Size, System.Drawing">
     <value>116, 17</value>
@@ -227,7 +221,7 @@
     <value>95, 17</value>
   </data>
   <data name="rbActionVerify.Text" xml:space="preserve">
-    <value>&amp;Nur AR verifiz.</value>
+    <value>&amp;Verifizieren</value>
   </data>
   <data name="rbActionVerify.ToolTip" xml:space="preserve">
     <value>Kontaktiert die AccurateRip-Datenbank und verifiziert das Image anhand dieser.</value>
@@ -239,7 +233,7 @@
     <value>&amp;Kodieren</value>
   </data>
   <data name="rbActionEncode.ToolTip" xml:space="preserve">
-    <value>Verif. und kodieren</value>
+    <value>In ein anderes Format kodieren. AccurateRip-Datenbank nicht zum Verifizieren kontaktieren</value>
   </data>
   <data name="comboBoxScript.ToolTip" xml:space="preserve">
     <value>Eigenes Script ausführen</value>
@@ -260,7 +254,7 @@
     <value>Das Pregap ist eine mit Stille oder versteckten Audiodaten gefüllte Zeitspanne vor dem Beginn der ersten Tonspur. Normalerweise ist diese aus dem CUE-Sheet bekannt, aber falls Sie ohne CUE-Sheet arbeiten, können Sie diesen Wert manuell ändern.</value>
   </data>
   <data name="txtDataTrackLength.ToolTip" xml:space="preserve">
-    <value>Nicht für normale Musik-CDs verwendet. Erweiterte CDs mit Datenspuren können nicht in der Datenbank gefunden werden, es sei denn, Sie kennen die Länge der Datenspur. Sie können sie oft im EAC-Log finden. Falls das EAC-Log beim CUE-Sheet gefunden wird, wird es automatisch ausgelesen, und Sie müssen hier nichts eingeben.</value>
+    <value>Wird nicht für normale Musik-CDs verwendet. Erweiterte CDs mit Datenspuren können nicht in der Datenbank gefunden werden, es sei denn, Sie kennen die Länge der Datenspur. Sie können sie oft im EAC-Log finden. Falls das EAC-Log beim CUE-Sheet gefunden wird, wird es automatisch ausgelesen, und Sie müssen hier nichts eingeben.</value>
   </data>
   <data name="labelDataTrack.Text" xml:space="preserve">
     <value>Datenspur</value>
@@ -281,16 +275,7 @@
     <value>&amp;Fortsetzen</value>
   </data>
   <data name="checkBoxVerifyUseLocal.ToolTip" xml:space="preserve">
-    <value>Verwende lokale Datenbank</value>
-  </data>
-  <data name="checkBoxVerifyUseCDRepair.ToolTip" xml:space="preserve">
-    <value>Verwende CTDB (CUETools-Datenbank)</value>
-  </data>
-  <data name="checkBoxUseAccurateRip.ToolTip" xml:space="preserve">
-    <value>Verwende AccurateRip</value>
-  </data>
-  <data name="checkBoxUseFreeDb.ToolTip" xml:space="preserve">
-    <value>Verwende freeDb</value>
+    <value>Lokale Datenbank verwenden</value>
   </data>
   <data name="groupBoxMode.Text" xml:space="preserve">
     <value>Modus</value>
@@ -305,7 +290,7 @@
     <value>&amp;Eingebettet</value>
   </data>
   <data name="rbEmbedCUE.ToolTip" xml:space="preserve">
-    <value>Erstelle einzelne Datei mit eingebettetem CUE-Sheet</value>
+    <value>Einzelne Datei mit eingebettetem CUE-Sheet erstellen.</value>
   </data>
   <data name="rbSingleFile.Size" type="System.Drawing.Size, System.Drawing">
     <value>126, 17</value>
@@ -314,13 +299,13 @@
     <value>Image + CUE</value>
   </data>
   <data name="rbSingleFile.ToolTip" xml:space="preserve">
-    <value>Erstelle einzelne Datei + CUE-Sheet</value>
+    <value>Einzelne Datei + CUE-Sheet erstellen</value>
   </data>
   <data name="rbTracks.Text" xml:space="preserve">
     <value>Einzelda&amp;teien</value>
   </data>
   <data name="rbTracks.ToolTip" xml:space="preserve">
-    <value>Erstelle eine Datei pro Stück. Die Verhalten bei Lücken kann in den erweiterten Einstellungen geändert werden.</value>
+    <value>Eine Datei pro Stück erstellen. Das Verhalten bei Lücken kann in den erweiterten Einstellungen geändert werden.</value>
   </data>
   <data name="grpOutputStyle.Text" xml:space="preserve">
     <value>CUE-Stil</value>
@@ -359,12 +344,6 @@
         AAAAAAAAAAAAAIABAADAAwAA4AcAAPAPAAA=
 </value>
   </data>
-  <data name="checkBoxUseAccurateRip.ToolTip" xml:space="preserve">
-    <value>Verwende AccurateRip</value>
-  </data>
-  <data name="checkBoxUseFreeDb.ToolTip" xml:space="preserve">
-    <value>FreeDB-Abfrage</value>
-  </data>
   <data name="checkBoxUseMusicBrainz.ToolTip" xml:space="preserve">
     <value>MusicBrainz-Abfrage</value>
   </data>
@@ -372,7 +351,7 @@
     <value>CUE-Pfade</value>
   </data>
   <data name="toolStripButtonAbout.Text" xml:space="preserve">
-    <value>Über</value>
+    <value>Info</value>
   </data>
   <data name="toolStripButtonCorrectorOverwrite.Text" xml:space="preserve">
     <value>Überschreiben</value>
@@ -401,14 +380,14 @@
   <data name="toolStripMenuItemCorrectorModeLocateFiles.ToolTipText" xml:space="preserve">
     <value>Versuche fehlende Dateien automatisch zu finden</value>
   </data>
-   <data name="toolStripDropDownButtonCorrectorMode.Text" xml:space="preserve">
+  <data name="toolStripDropDownButtonCorrectorMode.Text" xml:space="preserve">
     <value>Dateien suchen</value>
   </data>
   <data name="toolStripMenuItemCorrectorModeChangeExtension.Text" xml:space="preserve">
     <value>Andere Erweiterung</value>
   </data>
   <data name="toolStripMenuItemCorrectorModeChangeExtension.ToolTipText" xml:space="preserve">
-    <value>Ersetze Erweiterung für Audiodateien mit dieser:</value>
+    <value>Erweiterung für Audiodateien mit dieser ersetzen:</value>
   </data>
   <data name="toolStripMenuItemInputBrowserDrag.Text" xml:space="preserve">
     <value>Drag'n'drop-Modus</value>
@@ -429,7 +408,7 @@
     <value>Manuell</value>
   </data>
   <data name="toolStripMenuItemOutputTemplate.Text" xml:space="preserve">
-    <value>Verwende Vorlage</value>
+    <value>Vorlage verwenden</value>
   </data>
   <data name="labelOutputTemplate.Text" xml:space="preserve">
     <value>Vorlage:</value>
@@ -452,9 +431,6 @@
   <data name="toolStripDropDownButtonProfile.Text" xml:space="preserve">
     <value>Standard</value>
   </data>
-  <data name="toolStripDropDownButtonProfile.ToolTip" xml:space="preserve">
-    <value>Profil</value>
-  </data>
   <data name="setAsMyMusicFolderToolStripMenuItem.Text" xml:space="preserve">
     <value>Für meine Musik verwenden</value>
   </data>
@@ -472,5 +448,47 @@
   </data>
   <data name="locateInExplorerToolStripMenuItem.Text" xml:space="preserve">
     <value>Im Explorer anzeigen</value>
+  </data>
+  <data name="btnPause.Text" xml:space="preserve">
+    <value>&amp;Pause</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.ToolTip" xml:space="preserve">
+    <value>Mit AccurateRip verifizieren</value>
+  </data>
+  <data name="checkBoxCTDBVerify.ToolTip" xml:space="preserve">
+    <value>CTDB (CUETools-Datenbank) verwenden</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.ToolTip" xml:space="preserve">
+    <value>Mit CTDB verifizieren</value>
+  </data>
+  <data name="checkBoxEditTags.ToolTip" xml:space="preserve">
+    <value>Tags bearbeiten</value>
+  </data>
+  <data name="checkBoxSkipRecent.ToolTip" xml:space="preserve">
+    <value>Kürzlich verifizierte überspringen</value>
+  </data>
+  <data name="labelEncoderMaxMode.Text" xml:space="preserve">
+    <value>320</value>
+  </data>
+  <data name="labelEncoderMinMode.Text" xml:space="preserve">
+    <value>128</value>
+  </data>
+  <data name="labelEncoderMode.Text" xml:space="preserve">
+    <value>256</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorFormat.Text" xml:space="preserve">
+    <value>flac</value>
+  </data>
+  <data name="toolStripDropDownButtonProfile.ToolTipText" xml:space="preserve">
+    <value>Profil</value>
+  </data>
+  <data name="toolStripStatusLabelAR.Text" xml:space="preserve">
+    <value>55</value>
+  </data>
+  <data name="toolStripStatusLabelCTDB.Text" xml:space="preserve">
+    <value>77</value>
+  </data>
+  <data name="updateLocalDatabaseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Lokale Datenbank aktualisieren</value>
   </data>
 </root>

--- a/CUETools/frmCUETools.de-DE.resx
+++ b/CUETools/frmCUETools.de-DE.resx
@@ -272,7 +272,7 @@
     <value>40, 17</value>
   </data>
   <data name="btnResume.Text" xml:space="preserve">
-    <value>&amp;Fortsetzen</value>
+    <value>&amp;Weiter</value>
   </data>
   <data name="checkBoxVerifyUseLocal.ToolTip" xml:space="preserve">
     <value>Lokale Datenbank verwenden</value>
@@ -357,7 +357,7 @@
     <value>Überschreiben</value>
   </data>
   <data name="toolStripButtonHelp.Text" xml:space="preserve">
-    <value />
+    <value>CUETools-Webseite</value>
   </data>
   <data name="toolStripButtonSettings.Text" xml:space="preserve">
     <value>Einstellungen</value>

--- a/CUETools/frmChoice.de-DE.resx
+++ b/CUETools/frmChoice.de-DE.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,25 +117,34 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="button1.Text" xml:space="preserve">
-    <value>OK</value>
-  </data>
-  <data name="Title.Text" xml:space="preserve">
-    <value>Titel</value>
-  </data>
-  <data name="Length.Text" xml:space="preserve">
-    <value>Länge</value>
-  </data>
-  <data name="btnEdit.Text" xml:space="preserve">
-    <value>Ändern</value>
-  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Wählen Sie das beste Ergebnis aus</value>
   </data>
-  <data name="columnHeaderMetadataValue.Text" xml:space="preserve">
-    <value>Wert</value>
+  <data name="buttonMusicBrainz.Text" xml:space="preserve">
+    <value>&amp;Musicbrainz</value>
   </data>
-  <data name="columnHeaderMetadataName.Text" xml:space="preserve">
-    <value>Feld</value>
+  <data name="buttonNavigateCTDB.Text" xml:space="preserve">
+    <value>CT&amp;DB</value>
+  </data>
+  <data name="buttonOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="dataGridViewTextBoxColumnTrackLength.HeaderText" xml:space="preserve">
+    <value>Länge</value>
+  </data>
+  <data name="dataGridViewTextBoxColumnTrackNo.HeaderText" xml:space="preserve">
+    <value>#</value>
+  </data>
+  <data name="dataGridViewTextBoxColumnTrackStart.HeaderText" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="dataGridViewTextBoxColumnTrackTitle.HeaderText" xml:space="preserve">
+    <value>Titel</value>
+  </data>
+  <data name="Item.HeaderText" xml:space="preserve">
+    <value>Spalte1</value>
+  </data>
+  <data name="Value.HeaderText" xml:space="preserve">
+    <value>Spalte1</value>
   </data>
 </root>

--- a/CUETools/frmSettings.de-DE.resx
+++ b/CUETools/frmSettings.de-DE.resx
@@ -164,19 +164,19 @@
     <value>Logdatei extrahieren</value>
   </data>
   <data name="chkAllowMultipleInstances.Text" xml:space="preserve">
-    <value>Erlaube mehrere Instanzen</value>
+    <value>Mehrere Instanzen erlauben</value>
   </data>
   <data name="chkAllowMultipleInstances.ToolTip" xml:space="preserve">
     <value>Ermöglicht das Öffnen mehrerer CUETools-Fenster zur gleichen Zeit.</value>
   </data>
   <data name="chkReducePriority.Text" xml:space="preserve">
-    <value>Reduziere Prozesspriorität auf Untätig</value>
+    <value>Prozesspriorität auf untätig reduzieren</value>
   </data>
   <data name="chkReducePriority.ToolTip" xml:space="preserve">
-    <value>Reduziere Prozesspriorität, nutze Leerlaufzeit zum Arbeiten</value>
+    <value>Prozesspriorität reduzieren, indem Leerlaufzeit zum Arbeiten genutzt wird.</value>
   </data>
   <data name="checkBoxCheckForUpdates.ToolTip" xml:space="preserve">
-    <value>Prüfe auf Aktualisierungen beim Start des Programms</value>
+    <value>Beim Start des Programms auf Aktualisierungen prüfen</value>
   </data>
   <data name="chkTruncateExtra4206Samples.Text" xml:space="preserve">
     <value>Nullsamples abschneiden, falls vorhanden</value>
@@ -194,19 +194,19 @@
     <value>Erstelle .m3u-Abspiellisten</value>
   </data>
   <data name="chkCreateM3U.ToolTip" xml:space="preserve">
-    <value>Erstellt M3U-Playlistdateien für Einzeltracks.</value>
+    <value>Erstellt .m3u-Playlistdateien für Einzeltracks.</value>
   </data>
   <data name="chkFillUpCUE.Text" xml:space="preserve">
     <value>Fehlende CUE-Daten mit Tags füllen</value>
   </data>
   <data name="chkEmbedLog.Text" xml:space="preserve">
-    <value>Bette Logdatei als "LOG"-Tag ein</value>
+    <value>Logdatei als "LOG"-Tag einbetten</value>
   </data>
   <data name="chkEmbedLog.ToolTip" xml:space="preserve">
     <value>Die Datei sollte im gleichen Verzeichnis sein und die Erweiterung .log haben.</value>
   </data>
   <data name="checkBoxWriteCUETags.Text" xml:space="preserve">
-    <value>Schreibe Basistags aus CUE-Datei</value>
+    <value>Basistags aus CUE-Datei schreiben</value>
   </data>
   <data name="chkAutoCorrectFilenames.Text" xml:space="preserve">
     <value>Audiodaten suchen, falls fehlend</value>
@@ -218,13 +218,13 @@
     <value>Allgemein</value>
   </data>
   <data name="chkWriteArLogOnConvert.Text" xml:space="preserve">
-    <value>Schreibe AccurateRip-Log</value>
+    <value>AccurateRip-Log schreiben</value>
   </data>
   <data name="chkWriteArTagsOnConvert.Text" xml:space="preserve">
-    <value>Schreibe AccurateRip-Tags</value>
+    <value>AccurateRip-Tags schreiben</value>
   </data>
   <data name="chkWriteArTagsOnConvert.ToolTip" xml:space="preserve">
-    <value>Füge den Ausgabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzu. Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
+    <value>Den Ausgabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzufügen. Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
   </data>
   <data name="checkBoxARVerifyUseSourceFolder.Text" xml:space="preserve">
     <value>In Quellordner</value>
@@ -239,7 +239,7 @@
     <value>zu nächstem</value>
   </data>
   <data name="labelLogFileExtension.Text" xml:space="preserve">
-    <value>Erweiterung</value>
+    <value>Erweiterung:</value>
   </data>
   <data name="checkBoxARLogVerbose.Text" xml:space="preserve">
     <value>ausführlich</value>
@@ -260,13 +260,13 @@
     <value>Zur Kompatibilität mit Nicht-Unicode-Anwendungen nur Zeichen erlauben, die in der ANSI-Codepage vorhanden sind.</value>
   </data>
   <data name="chkWriteARTagsOnVerify.Text" xml:space="preserve">
-    <value>Schreibe AccurateRip-Tags</value>
+    <value>AccurateRip-Tags schreiben</value>
   </data>
   <data name="chkWriteARTagsOnVerify.ToolTip" xml:space="preserve">
-    <value>Füge den Eingabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzu. Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
+    <value>Den Eingabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzufügen. Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
   </data>
   <data name="chkHDCDDecode.Text" xml:space="preserve">
-    <value>Dekodiere HDCD auf 20 Bit</value>
+    <value>HDCD auf 20 Bit dekodieren</value>
   </data>
   <data name="chkHDCDDecode.ToolTip" xml:space="preserve">
     <value>HDCD-Dekodierung ist nicht umkehrbar. Die resultierenden Dateien können nicht auf CD gebrannt werden. 24-Bit-Audiodateien werden erstellt, aber die eigentliche Bitrate beträgt 20 Bit</value>
@@ -278,16 +278,16 @@
     <value>Nicht mehr nach HDCD-Informationen suchen, wenn sie in den ersten 10 Sekunden der CD nicht zu finden sind</value>
   </data>
   <data name="chkHDCD24bit.Text" xml:space="preserve">
-    <value>Speichere als 24-Bit-"verlustfrei"</value>
+    <value>Als 24-Bit-"verlustfrei" speichern</value>
   </data>
   <data name="chkHDCD24bit.ToolTip" xml:space="preserve">
     <value>Wenn lossyWAV nicht verwendet wird, für Kompatibilität auf 24 Bit erweitern</value>
   </data>
   <data name="chkHDCDLW16.Text" xml:space="preserve">
-    <value>Speichere als 16-Bit-LossyWAV</value>
+    <value>Als 16-Bit-LossyWAV speichern</value>
   </data>
   <data name="chkHDCDLW16.ToolTip" xml:space="preserve">
-    <value>Beim Konvertieren in lossyWAV auf 16 Bit beschneiden</value>
+    <value>Beim Konvertieren in lossyWAV auf 16-Bit beschneiden</value>
   </data>
   <data name="chkKeepOriginalFilenames.Text" xml:space="preserve">
     <value>Originale Dateinamen beibehalten</value>
@@ -296,10 +296,10 @@
     <value>Audiodateien denselben Namen wie im Original-CUE-Sheet geben, falls möglich</value>
   </data>
   <data name="chkRemoveSpecial.Text" xml:space="preserve">
-    <value>Entferne Sonderzeichen außer:</value>
+    <value>Sonderzeichen entfernen außer:</value>
   </data>
   <data name="chkReplaceSpaces.Text" xml:space="preserve">
-    <value>Ersetze Leerzeichen durch Unterstriche</value>
+    <value>Leerzeichen durch Unterstriche ersetzen</value>
   </data>
   <data name="txtTrackFilenameFormat.ToolTip" xml:space="preserve">
     <value>Vorlage für den Namen der Audiodateien bei Datei-pro-Track-Images</value>
@@ -326,7 +326,7 @@
     <value>Lücken &amp;angehängt + HTOA</value>
   </data>
   <data name="rbGapsPlusHTOA.ToolTip" xml:space="preserve">
-    <value>Lücken werden an vorige Spur angehängt. Die HTOA (Hidden Track One Audio, d.h. die Lücke vor der ersten Spur) wird in einer separaten Datei gespeichert.</value>
+    <value>Lücken werden an das vorige Stück angehängt. Die HTOA (Hidden Track One Audio, d.h. die Lücke vor dem ersten Stück) wird in einer separaten Datei gespeichert.</value>
   </data>
   <data name="rbGapsAppended.Text" xml:space="preserve">
     <value>Lücken angehängt</value>
@@ -347,7 +347,7 @@
     <value>Lücken werden ausgelassen und durch Stille ersetzt.</value>
   </data>
   <data name="chkWriteARLogOnVerify.Text" xml:space="preserve">
-    <value>Schreibe AccurateRip-Log</value>
+    <value>AccurateRip-Log schreiben</value>
   </data>
   <data name="groupBoxVerify.Text" xml:space="preserve">
     <value>Verifizieren</value>
@@ -431,12 +431,51 @@
     <value>HDCD-Optionen</value>
   </data>
   <data name="chkHDCDDetect.Text" xml:space="preserve">
-    <value>Erkenne HDCD-Kodierung</value>
+    <value>HDCD-Kodierung erkennen</value>
   </data>
   <data name="checkBox1.Text" xml:space="preserve">
     <value>Verifizieren</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Erweiterte Einstellungen</value>
+  </data>
+  <data name="btnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="checkBoxEncoderLossless.ToolTip" xml:space="preserve">
+    <value>Legt fest, ob es sich um einen verlustfreien Encoder handelt</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="labelEncoderName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="labelFormatDecoder.Text" xml:space="preserve">
+    <value>Decoder</value>
+  </data>
+  <data name="labelFormatDefaultDecoder.Text" xml:space="preserve">
+    <value>Decoder</value>
+  </data>
+  <data name="labelFormatEncoder.Text" xml:space="preserve">
+    <value>Encoder</value>
+  </data>
+  <data name="labelFormatTagger.Text" xml:space="preserve">
+    <value>Tagger</value>
+  </data>
+  <data name="tabPage2.Text" xml:space="preserve">
+    <value>AccurateRip</value>
+  </data>
+  <data name="tabPage4.Text" xml:space="preserve">
+    <value>HDCD</value>
+  </data>
+  <data name="textBoxDecoderName.ToolTip" xml:space="preserve">
+    <value>Name des Decoders</value>
+  </data>
+  <data name="textBoxEncoderModes.ToolTip" xml:space="preserve">
+    <value>Unterstützte Modi, getrennt durch Leerzeichen</value>
+  </data>
+  <data name="tabPageEncoders.Text" xml:space="preserve">
+    <value>Encoder</value>
   </data>
 </root>

--- a/CUETools/frmSettings.de-DE.resx
+++ b/CUETools/frmSettings.de-DE.resx
@@ -203,7 +203,7 @@
     <value>Logdatei als "LOG"-Tag einbetten</value>
   </data>
   <data name="chkEmbedLog.ToolTip" xml:space="preserve">
-    <value>Die Datei sollte im gleichen Verzeichnis sein und die Erweiterung .log haben.</value>
+    <value>Die Datei sollte im selben Verzeichnis sein und die Erweiterung .log haben.</value>
   </data>
   <data name="checkBoxWriteCUETags.Text" xml:space="preserve">
     <value>Basistags aus CUE-Datei schreiben</value>
@@ -224,7 +224,8 @@
     <value>AccurateRip-Tags schreiben</value>
   </data>
   <data name="chkWriteArTagsOnConvert.ToolTip" xml:space="preserve">
-    <value>Den Ausgabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzufügen. Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
+    <value>Den Ausgabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzufügen.
+Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
   </data>
   <data name="checkBoxARVerifyUseSourceFolder.Text" xml:space="preserve">
     <value>In Quellordner</value>
@@ -263,7 +264,8 @@
     <value>AccurateRip-Tags schreiben</value>
   </data>
   <data name="chkWriteARTagsOnVerify.ToolTip" xml:space="preserve">
-    <value>Den Eingabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzufügen. Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
+    <value>Den Eingabedateien ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL-Tags hinzufügen.
+Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Musik korrekt kopiert wurde oder wie beliebt sie ist.</value>
   </data>
   <data name="chkHDCDDecode.Text" xml:space="preserve">
     <value>HDCD auf 20 Bit dekodieren</value>

--- a/CUETools/frmSettings.de-DE.resx
+++ b/CUETools/frmSettings.de-DE.resx
@@ -123,9 +123,6 @@
   <data name="checkBoxCheckForUpdates.Text" xml:space="preserve">
     <value>Auf Aktualisierungen prüfen</value>
   </data>
-  <data name="checkBoxUseSystemProxy.Text" xml:space="preserve">
-    <value>Proxyeinstellungen von System übernehmen</value>
-  </data>
   <data name="checkBoxSeparateDecodingThread.Text" xml:space="preserve">
     <value>In eigenem Thread dekodieren</value>
   </data>
@@ -219,18 +216,6 @@
   </data>
   <data name="grpGeneral.Text" xml:space="preserve">
     <value>Allgemein</value>
-  </data>
-  <data name="chkFLACVerify.Text" xml:space="preserve">
-    <value>Verifizieren</value>
-  </data>
-  <data name="chkWVStoreMD5.Text" xml:space="preserve">
-    <value>Speichere MD5-Wert</value>
-  </data>
-  <data name="chkWVExtraMode.Text" xml:space="preserve">
-    <value>Extramodus:</value>
-  </data>
-  <data name="chkEncodeWhenZeroOffset.Text" xml:space="preserve">
-    <value>und Null-Offset</value>
   </data>
   <data name="chkWriteArLogOnConvert.Text" xml:space="preserve">
     <value>Schreibe AccurateRip-Log</value>
@@ -373,9 +358,6 @@
   <data name="tabPage7.Text" xml:space="preserve">
     <value>Erweitert</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Qualität:</value>
-  </data>
   <data name="groupBox5.Text" xml:space="preserve">
     <value>Kodieren, falls verifiziert</value>
   </data>
@@ -394,38 +376,14 @@
   <data name="checkBoxFormatAllowLossy.Text" xml:space="preserve">
     <value>Unterstützt verlustbehaftete Codierung</value>
   </data>
-  <data name="checkBoxFormatSupportsLossyWAV.Text" xml:space="preserve">
-    <value>Unterstützt LossyWAV</value>
-  </data>
   <data name="checkBoxFormatAllowLossless.Text" xml:space="preserve">
     <value>Unterstützt verlustfreie Codierung</value>
   </data>
   <data name="checkBoxFormatEmbedCUESheet.Text" xml:space="preserve">
     <value>Unterstützt eingebettete CUE-Sheets</value>
   </data>
-  <data name="tabPage10.Text" xml:space="preserve">
-    <value>Encoder</value>
-  </data>
   <data name="labelEncoderExtension.Text" xml:space="preserve">
     <value>Erweiterung</value>
-  </data>
-  <data name="groupBoxLibFLAC.Text" xml:space="preserve">
-    <value>libFLAC-Optionen</value>
-  </data>
-  <data name="checkBoxFlaCudaGPUOnly.Text" xml:space="preserve">
-    <value>nur GPU</value>
-  </data>
-  <data name="checkBoxFlaCudaVerify.Text" xml:space="preserve">
-    <value>Verifizieren</value>
-  </data>
-  <data name="groupBoxFlaCudaOptions.Text" xml:space="preserve">
-    <value>FlaCuda-Optionen</value>
-  </data>
-  <data name="groupBoxLibWavpack.Text" xml:space="preserve">
-    <value>WavPack-Optionen</value>
-  </data>
-  <data name="groupBoxLibMAC_SDK.Text" xml:space="preserve">
-    <value>Monkey's-Audio-Optionen</value>
   </data>
   <data name="groupBoxExternalEncoder.Text" xml:space="preserve">
     <value>Externer Encoder</value>
@@ -466,12 +424,6 @@
   <data name="labelDecoderParameters.Text" xml:space="preserve">
     <value>Parameter</value>
   </data>
-  <data name="groupBoxScriptConditions.Text" xml:space="preserve">
-    <value>Bedingungen</value>
-  </data>
-  <data name="buttonScriptCompile.Text" xml:space="preserve">
-    <value>Kompilieren</value>
-  </data>
   <data name="label3.Text" xml:space="preserve">
     <value>% der verif. Tracks &gt;=</value>
   </data>
@@ -481,14 +433,8 @@
   <data name="chkHDCDDetect.Text" xml:space="preserve">
     <value>Erkenne HDCD-Kodierung</value>
   </data>
-  <data name="chkHDCDDetect.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="checkBox1.Text" xml:space="preserve">
     <value>Verifizieren</value>
-  </data>
-  <data name="tabControl1.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Erweiterte Einstellungen</value>

--- a/CUETools/frmSettings.de-DE.resx
+++ b/CUETools/frmSettings.de-DE.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -178,9 +178,6 @@
   <data name="chkReducePriority.ToolTip" xml:space="preserve">
     <value>Reduziere Prozesspriorität, nutze Leerlaufzeit zum Arbeiten</value>
   </data>
-  <data name="checkBoxCheckForUpdates.Text" xml:space="preserve">
-    <value>Prüfe auf Aktualisierungen</value>
-  </data>
   <data name="checkBoxCheckForUpdates.ToolTip" xml:space="preserve">
     <value>Prüfe auf Aktualisierungen beim Start des Programms</value>
   </data>
@@ -222,12 +219,6 @@
   </data>
   <data name="grpGeneral.Text" xml:space="preserve">
     <value>Allgemein</value>
-  </data>
-  <data name="checkBoxSeparateDecodingThread.Text" xml:space="preserve">
-    <value>Separater Thread zum Dekodieren</value>
-  </data>
-  <data name="checkBoxSeparateDecodingThread.ToolTip" xml:space="preserve">
-    <value>Verbessert die Geschwindigkeit auf Mehrkernprozessoren</value>
   </data>
   <data name="chkFLACVerify.Text" xml:space="preserve">
     <value>Verifizieren</value>

--- a/CUETools/frmSettings.resx
+++ b/CUETools/frmSettings.resx
@@ -568,7 +568,8 @@
     <value>Write AccurateRip tags</value>
   </data>
   <data name="chkWriteArTagsOnConvert.ToolTip" xml:space="preserve">
-    <value>Add ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL tags to output files. You can set up foobar2000 to show those values, and see if your music was ripped correctly or how popular it is.</value>
+    <value>Add ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL tags to output files.
+You can set up foobar2000 to show those values, and see if your music was ripped correctly or how popular it is.</value>
   </data>
   <data name="&gt;&gt;chkWriteArTagsOnConvert.Name" xml:space="preserve">
     <value>chkWriteArTagsOnConvert</value>
@@ -841,7 +842,8 @@
     <value>Write AccurateRip tags</value>
   </data>
   <data name="chkWriteARTagsOnVerify.ToolTip" xml:space="preserve">
-    <value>Add ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL tags to input files. You can set up foobar2000 to show those values, and see if your music was ripped correctly or how popular it is.</value>
+    <value>Add ACCURATERIPCOUNT/ACCURATERIPCOUNTALLOFFSETS/ACCURATERIPTOTAL tags to input files.
+You can set up foobar2000 to show those values, and see if your music was ripped correctly or how popular it is.</value>
   </data>
   <data name="&gt;&gt;chkWriteARTagsOnVerify.Name" xml:space="preserve">
     <value>chkWriteARTagsOnVerify</value>

--- a/CUETools/frmSettings.resx
+++ b/CUETools/frmSettings.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1423,7 +1423,7 @@
     <value>2</value>
   </data>
   <data name="textBoxDecoderName.ToolTip" xml:space="preserve">
-    <value>Name of the encoder</value>
+    <value>Name of the decoder</value>
   </data>
   <data name="&gt;&gt;textBoxDecoderName.Name" xml:space="preserve">
     <value>textBoxDecoderName</value>

--- a/CUETools/frmSubmit.de-DE.resx
+++ b/CUETools/frmSubmit.de-DE.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="textBox1.Text" xml:space="preserve">
-    <value>Sie sind dabei, Informationen über diese CD an die CUETools-Datenbank zu übertragen. Diese Informationen werden anderen Nutzern helfen, ihre CD zu reparieren, falls sie Fehler enthält..</value>
+    <value>Sie sind dabei, Informationen über diese CD an die CUETools-Datenbank zu übertragen. Diese Informationen werden anderen Nutzern helfen, ihre CD zu reparieren, falls sie Fehler enthält.</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Abbrechen</value>
@@ -132,5 +132,8 @@
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>CTDB-Übertragung bestätigen</value>
+  </data>
+  <data name="buttonOk.Text" xml:space="preserve">
+    <value>OK</value>
   </data>
 </root>


### PR DESCRIPTION
Update German translation

- Use extension [ResXManager](https://marketplace.visualstudio.com/items?itemName=TomEnglert.ResXManager) 1.48.3862 for editing

- CUETools:
  - CUETools\frmCUETools.de-DE.resx:
    - Update and add German translations
    - Add line breaks to the long ToolTip texts of
      `chkWriteArTagsOnConvert` and `chkWriteARTagsOnVerify`
  - CUETools\frmChoice.de-DE.resx:
    Update German translation
    Remove translations without source entry
  - CUETools\frmSettings.de-DE.resx
    Update and add German translations
    Remove duplicate entries
    Remove translations without source entry. These translations were
    leftovers in frmSettings.de-DE.resx
  - CUETools\frmSettings.resx:
    Fix a typo in the source string of `textBoxDecoderName.ToolTip`:
    encoder->decoder
  - CUETools\frmSubmit.de-DE.resx:
    Minor updates

- CUERipper
  - Update German translation
  - CUERipper\frmCUERipper.resx:
    - The German translation of "Eject" is slightly too long for
      the width of the button. Add `AutoSize` property to
      `buttonEjectDisk`, so that the translation "Auswerfen" fits.
    - Correct `toolStripStatusAr.ToolTipText` in the source string and
      the German translation. This initial tooltip text is about the
      AccurateRip status and not yet, if a CD has been found in the
      AccurateRip database.

- Add German translation files:
  Bwg.Scsi\Messages.de-DE.resx
  CUERipper\Properties\Resources.de-DE.resx
  CUERipper\frmFreedbSubmit.de-DE.resx
  CUETools.CLParity\Properties\Resources.de-DE.resx
  CUETools.Codecs.FLACCL\Properties\Resources.de-DE.resx
  CUETools.Codecs.Flake\Properties\Resources.de-DE.resx
  CUETools.Codecs.WMA\Properties\Resources.de-DE.resx
  CUETools.Ripper.SCSI\Resource1.de-DE.resx
  CUETools\Properties\Resources.de-DE.resx
