### PR TITLE
[CUETools.Codecs.WMA] Fix constructors

### DIFF
--- a/CUETools.Codecs.WMA/AudioDecoder.cs
+++ b/CUETools.Codecs.WMA/AudioDecoder.cs
@@ -42,8 +42,9 @@ namespace CUETools.Codecs.WMA
         Stream m_IO;
         StreamWrapper m_streamWrapper;
 
-        public AudioDecoder(string path, Stream IO)
+        public AudioDecoder(DecoderSettings settings, string path, Stream IO)
         {
+            m_settings = settings;
             m_path = path;
             isValid(path);
             bool pfIsProtected;
@@ -219,6 +220,7 @@ namespace CUETools.Codecs.WMA
             //m_syncReader.GetMaxOutputSampleSize(m_dwAudioOutputNum, out cbMax);
         }
 
+        private DecoderSettings m_settings;
         public IAudioDecoderSettings Settings => null;
 
         public void isValid(string filename)

--- a/CUETools.Codecs.WMA/AudioEncoder.cs
+++ b/CUETools.Codecs.WMA/AudioEncoder.cs
@@ -32,7 +32,7 @@ namespace CUETools.Codecs.WMA
 
         public IAudioEncoderSettings Settings => m_settings;
 
-        public AudioEncoder(string path, EncoderSettings settings)
+        public AudioEncoder(EncoderSettings settings, string path, Stream IO = null)
         {
             this.m_settings = settings;
             this.outputPath = path;


### PR DESCRIPTION
- Fixes the following error messages, when using wma codec:
  `Exception: Constructor on type`
  `'CUETools.Codecs.WMA.AudioDecoder' not found.`
  `'CUETools.Codecs.WMA.AudioEncoder' not found.`
- Resolves #74
- Screenshots of error messages:
![wma_Exception_Constructor_on_type_CUETools Codecs WMA AudioDecoder_not_found](https://user-images.githubusercontent.com/371551/105407762-68b6e600-5c2e-11eb-87f3-f5e7b6ab28ff.PNG)
![wma_lossless_Exception_Constructor_on_type_not_found](https://user-images.githubusercontent.com/371551/105407828-79675c00-5c2e-11eb-875f-9d81ec57cc8b.PNG)
