### PR TITLE
[CUETools, CUERipper] Restore ImageScalingSize

### DIFF
--- a/CUERipper/frmCUERipper.Designer.cs
+++ b/CUERipper/frmCUERipper.Designer.cs
@@ -134,7 +134,6 @@ namespace CUERipper
             // 
             // statusStrip1
             // 
-            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1,
             this.toolStripStatusLabelMusicBrainz,
@@ -209,6 +208,7 @@ namespace CUERipper
             resources.ApplyResources(this.listTracks, "listTracks");
             this.listTracks.FullRowSelect = true;
             this.listTracks.GridLines = true;
+            this.listTracks.HideSelection = false;
             this.listTracks.LabelEdit = true;
             this.listTracks.Name = "listTracks";
             this.toolTip1.SetToolTip(this.listTracks, resources.GetString("listTracks.ToolTip"));
@@ -623,6 +623,7 @@ namespace CUERipper
             this.listMetadata.FullRowSelect = true;
             this.listMetadata.GridLines = true;
             this.listMetadata.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
+            this.listMetadata.HideSelection = false;
             this.listMetadata.LabelEdit = true;
             this.listMetadata.Name = "listMetadata";
             this.listMetadata.UseCompatibleStateImageBehavior = false;
@@ -755,8 +756,8 @@ namespace CUERipper
             // 
             // buttonEjectDisk
             // 
-            this.buttonEjectDisk.Image = global::CUERipper.Properties.Resources.cd_eject;
             resources.ApplyResources(this.buttonEjectDisk, "buttonEjectDisk");
+            this.buttonEjectDisk.Image = global::CUERipper.Properties.Resources.cd_eject;
             this.buttonEjectDisk.Name = "buttonEjectDisk";
             this.buttonEjectDisk.UseVisualStyleBackColor = true;
             this.buttonEjectDisk.Click += new System.EventHandler(this.buttonEjectDisk_Click);
@@ -815,6 +816,7 @@ namespace CUERipper
             this.panel2.ResumeLayout(false);
             this.panel7.ResumeLayout(false);
             this.panel3.ResumeLayout(false);
+            this.panel3.PerformLayout();
             this.panel4.ResumeLayout(false);
             this.panel5.ResumeLayout(false);
             this.panel5.PerformLayout();

--- a/CUERipper/frmCUERipper.resx
+++ b/CUERipper/frmCUERipper.resx
@@ -122,21 +122,21 @@
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="toolStripStatusLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>737, 30</value>
+    <value>487, 20</value>
   </data>
   <data name="toolStripStatusLabel1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
   </data>
   <data name="toolStripStatusLabelMusicBrainz.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 30</value>
+    <value>20, 20</value>
   </data>
   <data name="toolStripStatusCTDB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 30</value>
+    <value>20, 20</value>
   </data>
   <data name="toolStripStatusAr.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAMISURBVDhPbZINT5pnFIb5gduyrOmyLTOzpMWGttMxN9r6
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMISURBVDhPbZINT5pnFIb5gduyrOmyLTOzpMWGttMxN9r6
         AVIRnFpWJAWpa/3o1BJbO9cpXRCrqNTKEEOZ1qLoBBSJCIh8vcC1dy7LQuKd3DnJc3Jf50nOkZwnjweM
         /bs0mw65Zd2nayKOI1Dmn55A6ayeq6mhHE3yLPXfCshuQ40O6u5XUA5VUD+t0DtVxOHNVAPKFM8e3vwG
         6toUjVIxVA9fKvPIOkBhBs1Ihc5nFSwvSzxZEPDtFKohJu0Gqhv7YjjD5Zo8tXUVrigqfH8H2voEjDaw
@@ -156,32 +156,28 @@
     <value>White</value>
   </data>
   <data name="toolStripStatusAr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 30</value>
+    <value>20, 20</value>
   </data>
   <data name="toolStripStatusAr.ToolTipText" xml:space="preserve">
     <value>AccurateRip status</value>
   </data>
   <data name="toolStripProgressBar1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 29</value>
+    <value>100, 19</value>
   </data>
   <data name="toolStripProgressBar1.ToolTipText" xml:space="preserve">
     <value>Read progress</value>
   </data>
   <data name="toolStripStatusLabel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 30</value>
+    <value>0, 20</value>
   </data>
   <data name="toolStripStatusLabel2.Text" xml:space="preserve">
     <value>toolStripStatusAr</value>
   </data>
   <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 656</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="statusStrip1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 21, 0</value>
+    <value>0, 424</value>
   </data>
   <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>996, 35</value>
+    <value>664, 25</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
@@ -238,17 +234,15 @@
   <data name="Length.Width" type="System.Int32, mscorlib">
     <value>70</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="listTracks.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="listTracks.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="listTracks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="listTracks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 248</value>
+    <value>656, 158</value>
   </data>
   <data name="listTracks.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -278,13 +272,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonGo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
-  </data>
-  <data name="buttonGo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="buttonGo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 51</value>
+    <value>170, 33</value>
   </data>
   <data name="buttonGo.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -311,13 +302,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonAbort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>132, 5</value>
-  </data>
-  <data name="buttonAbort.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>88, 3</value>
   </data>
   <data name="buttonAbort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 51</value>
+    <value>85, 33</value>
   </data>
   <data name="buttonAbort.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -347,13 +335,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonPause.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
-  </data>
-  <data name="buttonPause.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="buttonPause.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 51</value>
+    <value>79, 33</value>
   </data>
   <data name="buttonPause.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -377,13 +362,10 @@
     <value>1</value>
   </data>
   <data name="numericWriteOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>406, 31</value>
-  </data>
-  <data name="numericWriteOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>271, 20</value>
   </data>
   <data name="numericWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 26</value>
+    <value>54, 20</value>
   </data>
   <data name="numericWriteOffset.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -410,13 +392,10 @@
     <value>NoControl</value>
   </data>
   <data name="lblWriteOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 34</value>
-  </data>
-  <data name="lblWriteOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>203, 22</value>
   </data>
   <data name="lblWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 20</value>
+    <value>62, 13</value>
   </data>
   <data name="lblWriteOffset.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -443,13 +422,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonEncoderSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 71</value>
-  </data>
-  <data name="buttonEncoderSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>83, 46</value>
   </data>
   <data name="buttonEncoderSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 32</value>
+    <value>21, 21</value>
   </data>
   <data name="buttonEncoderSettings.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -470,13 +446,10 @@
     <value>True</value>
   </data>
   <data name="checkBoxTestAndCopy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>318, 74</value>
-  </data>
-  <data name="checkBoxTestAndCopy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>212, 48</value>
   </data>
   <data name="checkBoxTestAndCopy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 24</value>
+    <value>83, 17</value>
   </data>
   <data name="checkBoxTestAndCopy.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -503,16 +476,13 @@
     <value>210, 56</value>
   </metadata>
   <data name="bnComboBoxLosslessOrNot.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 29</value>
-  </data>
-  <data name="bnComboBoxLosslessOrNot.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 19</value>
   </data>
   <data name="bnComboBoxLosslessOrNot.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>58, 0</value>
+    <value>40, 0</value>
   </data>
   <data name="bnComboBoxLosslessOrNot.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 27</value>
+    <value>70, 21</value>
   </data>
   <data name="bnComboBoxLosslessOrNot.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -536,16 +506,13 @@
     <value>1217, 56</value>
   </metadata>
   <data name="bnComboBoxEncoder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>158, 71</value>
-  </data>
-  <data name="bnComboBoxEncoder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>105, 46</value>
   </data>
   <data name="bnComboBoxEncoder.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>58, 0</value>
+    <value>40, 0</value>
   </data>
   <data name="bnComboBoxEncoder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>133, 27</value>
+    <value>90, 21</value>
   </data>
   <data name="bnComboBoxEncoder.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -569,13 +536,10 @@
     <value>NoControl</value>
   </data>
   <data name="labelSecureMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>314, 158</value>
-  </data>
-  <data name="labelSecureMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>209, 103</value>
   </data>
   <data name="labelSecureMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>164, 28</value>
+    <value>109, 18</value>
   </data>
   <data name="labelSecureMode.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -599,13 +563,10 @@
     <value>1045, 56</value>
   </metadata>
   <data name="bnComboBoxFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 29</value>
-  </data>
-  <data name="bnComboBoxFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>83, 19</value>
   </data>
   <data name="bnComboBoxFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 27</value>
+    <value>112, 21</value>
   </data>
   <data name="bnComboBoxFormat.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -638,13 +599,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelEncoderMinMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 163</value>
+    <value>12, 106</value>
   </data>
   <data name="labelEncoderMinMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="labelEncoderMinMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 21</value>
+    <value>25, 13</value>
   </data>
   <data name="labelEncoderMinMode.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -668,16 +629,13 @@
     <value>526, 56</value>
   </metadata>
   <data name="bnComboBoxImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 71</value>
-  </data>
-  <data name="bnComboBoxImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 46</value>
   </data>
   <data name="bnComboBoxImage.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>58, 0</value>
+    <value>40, 0</value>
   </data>
   <data name="bnComboBoxImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>103, 27</value>
+    <value>70, 21</value>
   </data>
   <data name="bnComboBoxImage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -707,13 +665,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelEncoderMaxMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 163</value>
+    <value>166, 106</value>
   </data>
   <data name="labelEncoderMaxMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="labelEncoderMaxMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
+    <value>29, 13</value>
   </data>
   <data name="labelEncoderMaxMode.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -743,13 +701,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelEncoderMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 163</value>
+    <value>6, 106</value>
   </data>
   <data name="labelEncoderMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="labelEncoderMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>284, 23</value>
+    <value>189, 15</value>
   </data>
   <data name="labelEncoderMode.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -776,13 +734,13 @@
     <value>NoControl</value>
   </data>
   <data name="trackBarEncoderMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 117</value>
+    <value>6, 76</value>
   </data>
   <data name="trackBarEncoderMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="trackBarEncoderMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>284, 69</value>
+    <value>189, 45</value>
   </data>
   <data name="trackBarEncoderMode.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -803,13 +761,10 @@
     <value>NoControl</value>
   </data>
   <data name="trackBarSecureMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>297, 117</value>
-  </data>
-  <data name="trackBarSecureMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>198, 76</value>
   </data>
   <data name="trackBarSecureMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>190, 69</value>
+    <value>127, 45</value>
   </data>
   <data name="trackBarSecureMode.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -832,14 +787,8 @@
   <data name="groupBoxSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="groupBoxSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="groupBoxSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="groupBoxSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>508, 209</value>
+    <value>339, 136</value>
   </data>
   <data name="groupBoxSettings.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -867,7 +816,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAABy
-        CQAAAk1TRnQBSQFMAgEBBAEAAVQBAwFUAQMBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        CQAAAk1TRnQBSQFMAgEBBAEAAWQBAwFkAQMBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
         AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
         AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
@@ -923,10 +872,7 @@
     <value>624, 17</value>
   </metadata>
   <data name="progressBarErrors.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 140</value>
-  </data>
-  <data name="progressBarErrors.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 91</value>
   </data>
   <metadata name="plainProgressPainter1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>454, 17</value>
@@ -935,7 +881,7 @@
     <value>789, 17</value>
   </metadata>
   <data name="progressBarErrors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 35</value>
+    <value>170, 23</value>
   </data>
   <data name="progressBarErrors.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -944,7 +890,7 @@
     <value>progressBarErrors</value>
   </data>
   <data name="&gt;&gt;progressBarErrors.Type" xml:space="preserve">
-    <value>ProgressODoom.ProgressBarEx, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.ProgressBarEx, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;progressBarErrors.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -953,16 +899,13 @@
     <value>4</value>
   </data>
   <data name="progressBarCD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 98</value>
-  </data>
-  <data name="progressBarCD.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 64</value>
   </data>
   <metadata name="plainProgressPainter2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>356, 56</value>
   </metadata>
   <data name="progressBarCD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 35</value>
+    <value>170, 23</value>
   </data>
   <data name="progressBarCD.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -974,7 +917,7 @@
     <value>progressBarCD</value>
   </data>
   <data name="&gt;&gt;progressBarCD.Type" xml:space="preserve">
-    <value>ProgressODoom.ProgressBarEx, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.ProgressBarEx, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;progressBarCD.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -986,13 +929,10 @@
     <value>Fill</value>
   </data>
   <data name="txtOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 6</value>
-  </data>
-  <data name="txtOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>0, 4</value>
   </data>
   <data name="txtOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 26</value>
+    <value>656, 20</value>
   </data>
   <data name="txtOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1025,206 +965,201 @@
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAACG
-        KwAAAk1TRnQBSQFMAgEBCgEAATgBAAE4AQABEAEAARABAAT/ASEBAAj/AUIBTQE2BwABNgMAASgDAAFA
-        AwABMAMAAQEBAAEgBgABMCoAAWcBbwF3Af8BZwFvAXcB/wFnAW8BdwH/AWcBbwF3Af8cAAFdAckC/wE6
-        AYMBrAH/AToBgwGsAf8BXQHJAv8BXQHJAv8BXQHJAv8BXQHJAv8BXQHJAv8BXQHJAv8BXQHJAv8BXQHJ
-        Av8BXQHJAv8BXQHJAv8BXQHJAv+UAAFnAW8BdwH/Az4B/wM+Af8BJQI1Af8DDAH/AwwB/wMAAf8DDAH/
-        EAABOgGDAawB/wEAAgIB/wEoASYBJAH/AUUBSAFDAf8BAAICAf8BIAESARYB/wFdAckC/wFdAckC/wFd
-        AckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/4wAAz4B/wG9AsYB/wFn
-        AW8BdwH/Az4B/wEdAiUB/wMMAf8DDAH/AwAB/wMAAf8DDAH/DQACAgH/AcsB0QHKAf8B/AP/AfwD/wH8
-        A/8BRQFIAUMB/wEgARIBFgH/AV0ByQL/AV0ByQL/AV0ByQL/AV0ByQL/AV0ByQL/AV0ByQL/AV0ByQL/
-        AV0ByQL/AV0ByQL/iAABHQIlAf8DPgH/AWcBbwF3Af8BvQLGAf8BZwFvAXcB/wEdAiUB/wMMAf8DDAH/
-        AwAB/wMAAf8DAAH/AwwB/wkAAgIB/wHLAdEBygH/AfwD/wH8A/8B/AP/AfwD/wEAAgIB/wFdAckC/wFd
-        AckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/wFdAckC/4QAAR0CJQH/ASUCNQH/
-        Az4B/wM+Af8BZwFvAXcB/wFnAW8BdwH/ASUCNQH/AR0CJQH/AwwB/wMAAf8DAAH/AwAB/wMAAf8BHQIl
-        Af8EAAE6AYMBrAH/ASABEgEWAf8BcwJqAf8BvAK9Af8BvAK9Af8BywHRAcoB/wEAAgIB/wEoASYBJAH/
-        AQACAgH/AQACAgH/AQACAgH/AQACAgH/ASgBJgEkAf8BXQHJAv8BXQHJAv8BXQHJAv+EAAMMAf8BHQIl
-        Af8BHQIlAf8BJQI1Af8BJQI1Af8DDAH/ARQBXwFnAf8BFAFfAWcB/wMEAf8DBAH/AwAB/wMAAf8DAAH/
-        AwAB/wQAAV0ByQL/AToBgwGsAf8BIAESARYB/wEAAgIB/wEAAgIB/wH8A/8BAAICAf8BIAESARYB/wGk
-        AakBoQH/AfwD/wH8A/8BkwGeAZwB/wEoASYBJAH/ASgBJgEkAf8BXQHJAv8BXQHJAv+AAAFnAW8BdwH/
-        AwAB/wMMAf8DDAH/AwwB/wMMAf8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wMEAf8DAAH/
-        AwAB/wMAAf8DAAH/AWcBbwF3Af8BXQHJAv8BXQHJAv8BXQHJAv8BXQHJAv8BAAICAf8B/AP/AQACAgH/
-        ASgBJgEkAf8B/AP/AfwD/wH8A/8B/AP/AcsB0QHKAf8BAAICAf8BXQHJAv8BXQHJAv+AAAFnAW8BdwH/
-        AwAB/wMAAf8DAAH/AQACBAH/ARQBXwFnAf8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wEU
-        AV8BZwH/AwAB/wMAAf8DAAH/AwAB/wFnAW8BdwH/Aa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFv
-        Af8BAAICAf8B/AP/AQACAgH/AQACAgH/AUUBSAFDAf8BywHRAcoB/wH8A/8B/AP/AfwD/wEAAgIB/wGu
-        AWgBbwH/Aa4BaAFvAf+AAAFnAW8BdwH/AwAB/wMAAf8DAAH/AwAB/wEUAV8BZwH/AQABxgHWAf8BAAHG
-        AdYB/wEAAcYB1gH/AQABxgHWAf8BFAFfAWcB/wMMAf8DDAH/AwwB/wMMAf8BZwFvAXcB/wGuAWgBbwH/
-        Aa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/AQACAgH/AfwD/wEAAgIB/wFgAUYBSQH/ASABEgEWAf8BAAIC
-        Af8BAAICAf8BAAICAf8B/AP/AQACAgH/Aa4BaAFvAf8BrgFoAW8B/4AAAWcBbwF3Af8DAAH/AwAB/wMA
-        Af8DAAH/AwwB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wEAAcYB1gH/AwwB/wEdAiUB/wEdAiUB/wMM
-        Af8DDAH/AWcBbwF3Af8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFvAf8BrgFoAW8B/wEAAgIB/wH8A/8BIAES
-        ARYB/wEAAgIB/wEoASYBJAH/AWABRgFJAf8BYAFGAUkB/wEAAgIB/wH8A/8BAAICAf8BrgFoAW8B/wGu
-        AWgBbwH/hAADDAH/AwAB/wMAAf8DAAH/AwAB/wMMAf8BFAFfAWcB/wEUAV8BZwH/AwwB/wM+Af8DPgH/
-        AR0CJQH/AR0CJQH/AR0CJQH/BAABrgFoAW8B/wGuAWgBbwH/Aa4BaAFvAf8BrgFoAW8B/wEAAgIB/wH8
-        A/8B/AP/AZMBngGcAf8BKAEmASQB/wEAAgIB/wEgARIBFgH/AQACAgH/AfwD/wEAAgIB/wGuAWgBbwH/
-        Aa4BaAFvAf+EAAM+Af8DAAH/AwAB/wMAAf8DDAH/AwwB/wEdAiUB/wM+Af8BZwFvAXcB/wFnAq0B/wM+
-        Af8DPgH/AR0CJQH/Az4B/wQAAa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFvAf8BAAICAf8BvAK9
-        Af8B/AP/AfwD/wH8A/8BywHRAcoB/wFVAV4BXQH/AQACAgH/AfwD/wEAAgIB/wGuAWgBbwH/Aa4BaAFv
-        Af+IAAEdAiUB/wMAAf8DAAH/AwwB/wMMAf8BHQIlAf8BJQI1Af8BZwFvAXcB/wG9AsYB/wFnAW8BdwH/
-        ASUCNQH/Az4B/wgAAa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFvAf8BKAEmASQB/wFFAUgBQwH/
-        AbwCvQH/AfwD/wH8A/8B/AP/AfwD/wH8A/8B/AP/AQACAgH/Aa4BaAFvAf8BrgFoAW8B/4wAAz4B/wMA
-        Af8DDAH/AwwB/wEdAiUB/wElAjUB/wM+Af8BZwFvAXcB/wFnAW8BdwH/AWcBbwF3Af8MAAGuAWgBbwH/
-        Aa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFvAf8BKAEmASQB/wEAAgIB/wEoASYBJAH/AZMBngGc
-        Af8B/AP/AfwD/wH8A/8B/AP/AQACAgH/Aa4BaAFvAf8BrgFoAW8B/5AAASUCNQH/ASUCNQH/AwwB/wMM
-        Af8DDAH/AR0CJQH/Az4B/wM+Af8QAAGuAWgBbwH/Aa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFv
-        Af8BrgFoAW8B/wGuAWgBbwH/ASgBJgEkAf8BAAICAf8BIAESARYB/wFzAmoB/wHLAdEBygH/AfwD/wEA
-        AgIB/wGuAWgBbwH/Aa4BaAFvAf+YAAFnAW8BdwH/AWcBbwF3Af8BZwFvAXcB/wFnAW8BdwH/HAABrgFo
-        AW8B/wGuAWgBbwH/Aa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/Aa4BaAFvAf8BrgFoAW8B/wGuAWgBbwH/
-        Aa4BaAFvAf8BIAESARYB/wEAAgIB/wFFAUgBQwH/ASgBJgEkAf8BrgFoAW8B/4gAA8AB/wNwAf8DcAH/
-        A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8EAAMLAQ8DFAEbAx0BKQMi
-        ATIBUQFSAVEBpgFQAV4BUAHRAVABXgFQAdEDPAFmBAADPAFmAVABXgFQAdEBUAFeAVAB0QFQAV4BUAHR
-        AVABXgFQAdEBUQFSAVEBqQMjATMQAAMnATsBTwJOAZQBbgFmAVwBzgGQAXcBWQHrAZABdwFZAesBbgFm
-        AVwBzgFPAk4BlAIAAeIB/wIAAeIB/wwAAaYCjAH/AUcCDAH/AUACAgH/ATwCAAH/ATwCAAH/ATwCAAH/
-        ATwCAAH/ATwCAAH/ATwCAAH/ATwCAAH/ATwCAAH/ATwCAAH/ATwCAAH/AToCAAH/ATYCAAH/ARYCAAH/
-        A3AB/wMAAf8DFQH/AywB/wMAAf8DDwH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/
-        A8AB/wMGAQgDCgEOAxABFQMSARkBUgFcAVEBzAEdAdUBDAH/ATgBjAEyAe8DTgGZBAADTgGZATgBjAEy
-        Ae8BHQHVAQwB/wEdAdUBDAH/AR0B1QEMAf8BUAFgAVAB0QMTARoIAAMKAQ0BTwJOAZYBqQF+AVIB+gHh
-        Ac0BuQH/AfEB4AHOAf8B+QHnAdYB/wH4AeYB1AH/AfAB3QHMAf8B4QHNAbkB/wIAAeIB/wIAAeIB/wMK
-        AQ0IAAG/AYUBhgH/AYMBEAESAf8BeQEEAQYB/wF1AgAB/wF1AgAB/wPqAf8D6gH/A+oB/wF1AgAB/wPq
-        Af8D6gH/A+oB/wF1AgAB/wFwAgAB/wFrAgAB/wE3AgAB/wMAAf8DwA3/AywB/wMPAf8DwAH/A8AB/wPA
-        Af8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8QAAFSAV4BUQHMASABzQEPAf8BUAFdAVAB0QMjATMEAAMj
-        ATMBUAFdAVAB0QEdAcwBDAH/AR0BzAEMAf8BHQHMAQwB/wFRAWMBUAHRCAADCgENAWABXAFXAbgB2QG/
-        AaUB/wH+AfIB5AL/AecBzwH/AfwB2wG7Af8B+QHTAbIB/wH2AdABrAH/AfQB0QGuAf8B9gHYAbsB/wIA
-        AeIB/wIAAeIB/wFgAVwBVwG4AwoBDQQAAcABggGDAf8BiQERARMB/wGDAQUBBwH/AXsCAAH/A/YB/wF7
-        AgAB/wF7AgAB/wP2Af8BewIAAf8D9gH/AXsCAAH/AXsCAAH/A/YB/wF2AgAB/wFxAgAB/wE6AgAB/wMA
-        Af8DwBH/AwAB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wErASwBKwFDAVQBWQFU
-        AbgBVAFZAVQBuAErASwBKwFDAVIBXwFRAcwBJAHEARMB/wFQAVwBUAHRAzwBZgQAAzwBZgFQAVwBUAHR
-        AR0BwQEMAf8BHQHBAQwB/wEdAcEBDAH/AVEBYwFQAdEIAAFPAk4BlgHZAb8BpQL/AfgB6wL/AesB0QL/
-        AeEBwwH/Af4B2wG6Af8B+wHWAbIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIA
-        AeIB/wIAAeIB/wHCAYIBgwH/AY4BEgEUAf8BiAEGAQgB/wGEAgAF/wGEAgAB/wGEAgAF/wGEAgAF/wGE
-        AgAB/wGEAgAF/wF7AgAB/wF1AgAB/wE8AgAB/wNwAf8DDwH/A1gB/wOyAf8DsgH/A8AB/wMAAf8DFQH/
-        AwAB/wMAAf8DAAH/AwAB/wMVAf8DwAH/A8AB/wPAAf8BVAFWAVMBsgFKAcYBOQH/AUsBlQE9AfMBUgFf
-        AVEBzAFNAWYBSwHZAR4BtwENAf8BPAGBATQB7wFOAV0BTgHTAVEBWQFRAcwBTgFdAU4B0wE5AX8BMwHv
-        AR8BtwEOAf8BHgG2AQ0B/wEdAbYBDAH/AVEBYwFQAdEEAAMmATgBtAGHAVMB/QL+AfoC/wH5AekC/wHv
-        AdgC/wHnAc0C/wHhAcIB/wH8AdwBuwH/AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/
-        AgAB4gH/AgAB4gH/AcIBggGDAf8BjgESARQB/wGIAQYBCAH/AYQCAAH/AYQCAA3/AYQCAA3/AYQCAAH/
-        AXsCAAH/AXUCAAH/ATwCAAH/A8AB/wNwAf8DDwH/AwAB/wMABf8DAAH/Aw8B/wOWCf8DhgH/AxUB/wMV
-        Af8DwAH/A8AB/wFSAWEBUQHMAUkBxQE4Af8BPwG7AS4B/wFIAcQBNwH/AT4BvQEtAf8BHQGrAQwB/wEf
-        AawBDgH/ASMBrwESAf8BIwGvARIB/wEiAa8BEQH/ATwBgwE0Ae8BUAFjAVAB0QFQAWMBUAHRATkBggEz
-        Ae8BUQFjAVAB0QQAAU8CTgGWAeIBzgG6Af8B9wHeAcYC/wHpAdEC/wH2AeIC/wHyAd0C/wHwAd0B/wH4
-        AeoB2QH/AfgB5gHUAf8B+wHfAccB/wH1Ac8BqwH/AgAB4gH/AgAB4gH/AfgB3QHDAf8B4gHOAboB/wFP
-        Ak4BlgHCAYIBgwH/AY4BEgEUAf8BiAEGAQgB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAF/wGEAgAF/wGE
-        AgAB/wGEAgAB/wGEAgAB/wF7AgAB/wF1AgAB/wE8AgAB/wPAAf8DwAH/A8AB/wPAAf8DAAX/AwAB/wMV
-        Ef8DwAH/AwAB/wPAAf8DwAH/AVQBWAFTAbIBUQHNAUAB/wFMAZoBPwHzAVIBYQFRAcwBUgFpAU0B2QEv
-        AbABHgH/AR4BogENAf8BHQGhAQwB/wEdAaEBDAH/ASQBqAETAf8BTwFiAU4B0wM8AWYDIwEzA04BmQM8
-        AWYEAAFwAWUBWwHQAe8B4AHQAf8B5wG+AZYB/wHnAbwBlAH/AfABzAGpAf8B/gHsAdoB/wHdAcQBrAH/
-        AYgBdAFcAecBiAF0AVwB5wHdAcMBqgH/AfgB3QHEAf8CAAHiAf8CAAHiAf8B9QHWAbgB/wHxAd8BzwH/
-        AXABZQFbAdABwgGCAYMB/wGOARIBFAH/AYgBBgEIAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIABf8BhAIA
-        Bf8BhAIAAf8BhAIAAf8BhAIAAf8BewIAAf8BdQIAAf8BPAIAAf8DWAH/A1gB/wNYAf8DWAH/AwAF/wMA
-        Af8DAAH/AywB/wPADf8DAAH/A1gB/wNYAf8BKwEsASsBQwFUAVkBVAG4AVQBWQFUAbgBKwEsASsBQwFS
-        AWIBUQHMAUsBxwE6Af8BOgG3ASkB/wEwAa0BHwH/ASYBpAEVAf8BLQGqARwB/wFRAV8BUQHMFAABkQF3
-        AVkB7AH1AeQB1QH/AekBvgGXAf8B6AG8AZYB/wHnAbwBlAH/AfMB3gHKAf8BigFyAVkB5gMUARsDFAEb
-        AYoBcgFZAeYB9gHjAdMB/wIAAeIB/wIAAeIB/wHtAckBpAH/AfYB5AHSAf8BkQF3AVkB7AHCAYIBgwH/
-        AY4BEgEUAf8BiAEGAQgB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAB/wGE
-        AgAB/wGEAgAB/wGEAgAB/wF7AgAB/wF1AgAB/wE8AgAB/wNYAf8DWAH/A1gB/wNYAf8DAAX/AwAB/wMy
-        Af8DDwH/AwAB/wMAAf8DAAX/AwAB/wNYAf8DWAH/EAABUgFiAVEBzAFOAcoBPQH/AUABvAEvAf8BQAG8
-        AS8B/wFAAbwBLwH/AUgBxAE3Af8BTwFiAU8B0wM8AWYDIwEzA04BmQM8AWYEAAGRAXcBWQHsAfUB5AHV
-        Af8B6QG/AZkB/wHpAcABmQH/AekBwQGaAf8B8wHdAckB/wGKAXIBWQHmAxQBGwMUARsBigFyAVkB5gH4
-        AegB2QH/AfIB0gGyAf8B8AHMAasB/wHwAcwBqwH/AfYB5AHTAf8BkQF3AVkB7DT/A/YB/wPqAf8DeQH/
-        A1gB/wNYAf8DWAH/A1gB/wMABf8DDwH/AwAB/wMVAf8DMgH/AzIB/wMABf8DAAH/A1gB/wNYAf8QAAFS
-        AWIBUQHMAVMBzwFCAf8BRQHBATQB/wFFAcEBNAH/AUUBwQE0Af8BRwHDATYB/wFMAY8BRgHvAVABYwFQ
-        AdEBUAFjAVAB0QFMAY4BRgHvAVIBYgFRAcwEAAFwAWUBWwHQAfAB4QHRAf8B6gHEAaEB/wHpAcEBmwH/
-        AekBwAGXAf8B8QHOAbIB/wHcAcMBqgH/AYgBdAFcAecBiAF0AVwB5wHdAcQBrAL/AfwB8wL/AfQB5QL/
-        Ae4B2gH/AfwB5QHRAf8B8QHhAdEB/wFwAWUBWwHQBP8BjgESARQJ/wGEAgAN/wGEAgAB/wGEAgAN/wF7
-        AgAB/wF1AgAB/wN5Af8DWAH/A1gB/wNYAf8DWAH/AwAJ/wOGAf8DFQH/AwAB/wMPAf8DAAX/AwAB/wNY
-        Af8DWAH/EAABUgFiAVEBzAFgAdwBTwH/AVgB1AFHAf8BVwHTAUYB/wFWAdIBRQH/AVABzAE/Af8BSgHG
-        ATkB/wFSAc4BQQH/AVsB1wFKAf8BWQHVAUgB/wFSAWIBUQHMBAABTwJOAZYB4gHOAboB/wHxAdIBtgH/
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAD0
+        KgAAAk1TRnQBSQFMAgEBCgEAAUgBAAFIAQABEAEAARABAAT/ASEBAAj/AUIBTQE2BwABNgMAASgDAAFA
+        AwABMAMAAQEBAAEgBgABMCoAAWUBbQF1Af8BZQFtAXUB/wFlAW0BdQH/AWUBbQF1Af8cAAFbAckC/wE4
+        AYMBrAH/ATgBgwGsAf8BWwHJAv8BWwHJAv8BWwHJAv8BWwHJAv8BWwHJAv8BWwHJAv8BWwHJAv8BWwHJ
+        Av8BWwHJAv8BWwHJAv8BWwHJAv+UAAFlAW0BdQH/AzwB/wM8Af8BIwIzAf8DCgH/AwoB/wMAAf8DCgH/
+        EAABOAGDAawB/wMAAf8BJgEkASIB/wFDAUYBQQH/AwAB/wEeARABFAH/AVsByQL/AVsByQL/AVsByQL/
+        AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/jAADPAH/Ab0CxgH/AWUBbQF1
+        Af8DPAH/ARsCIwH/AwoB/wMKAf8DAAH/AwAB/wMKAf8PAAH/AcsB0QHKAf8B/AP/AfwD/wH8A/8BQwFG
+        AUEB/wEeARABFAH/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/
+        AVsByQL/iAABGwIjAf8DPAH/AWUBbQF1Af8BvQLGAf8BZQFtAXUB/wEbAiMB/wMKAf8DCgH/AwAB/wMA
+        Af8DAAH/AwoB/wsAAf8BywHRAcoB/wH8A/8B/AP/AfwD/wH8A/8DAAH/AVsByQL/AVsByQL/AVsByQL/
+        AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/AVsByQL/hAABGwIjAf8BIwIzAf8DPAH/AzwB/wFl
+        AW0BdQH/AWUBbQF1Af8BIwIzAf8BGwIjAf8DCgH/AwAB/wMAAf8DAAH/AwAB/wEbAiMB/wQAATgBgwGs
+        Af8BHgEQARQB/wFxAmgB/wG8Ar0B/wG8Ar0B/wHLAdEBygH/AwAB/wEmASQBIgH/AwAB/wMAAf8DAAH/
+        AwAB/wEmASQBIgH/AVsByQL/AVsByQL/AVsByQL/hAADCgH/ARsCIwH/ARsCIwH/ASMCMwH/ASMCMwH/
+        AwoB/wESAV0BZQH/ARIBXQFlAf8DAgH/AwIB/wMAAf8DAAH/AwAB/wMAAf8EAAFbAckC/wE4AYMBrAH/
+        AR4BEAEUAf8DAAH/AwAB/wH8A/8DAAH/AR4BEAEUAf8BpAGpAaEB/wH8A/8B/AP/AZMBngGcAf8BJgEk
+        ASIB/wEmASQBIgH/AVsByQL/AVsByQL/gAABZQFtAXUB/wMAAf8DCgH/AwoB/wMKAf8DCgH/AQABxgHW
+        Af8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8DAgH/AwAB/wMAAf8DAAH/AwAB/wFlAW0BdQH/AVsByQL/
+        AVsByQL/AVsByQL/AVsByQL/AwAB/wH8A/8DAAH/ASYBJAEiAf8B/AP/AfwD/wH8A/8B/AP/AcsB0QHK
+        Af8DAAH/AVsByQL/AVsByQL/gAABZQFtAXUB/wMAAf8DAAH/AwAB/wEAAgIB/wESAV0BZQH/AQABxgHW
+        Af8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BEgFdAWUB/wMAAf8DAAH/AwAB/wMAAf8BZQFtAXUB/wGu
+        AWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/AwAB/wH8A/8DAAH/AwAB/wFDAUYBQQH/AcsB0QHK
+        Af8B/AP/AfwD/wH8A/8DAAH/Aa4BZgFtAf8BrgFmAW0B/4AAAWUBbQF1Af8DAAH/AwAB/wMAAf8DAAH/
+        ARIBXQFlAf8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wESAV0BZQH/AwoB/wMKAf8DCgH/
+        AwoB/wFlAW0BdQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/Aa4BZgFtAf8DAAH/AfwD/wMAAf8BXgFE
+        AUcB/wEeARABFAH/AwAB/wMAAf8DAAH/AfwD/wMAAf8BrgFmAW0B/wGuAWYBbQH/gAABZQFtAXUB/wMA
+        Af8DAAH/AwAB/wMAAf8DCgH/AQABxgHWAf8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8DCgH/ARsCIwH/
+        ARsCIwH/AwoB/wMKAf8BZQFtAXUB/wGuAWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/AwAB/wH8
+        A/8BHgEQARQB/wMAAf8BJgEkASIB/wFeAUQBRwH/AV4BRAFHAf8DAAH/AfwD/wMAAf8BrgFmAW0B/wGu
+        AWYBbQH/hAADCgH/AwAB/wMAAf8DAAH/AwAB/wMKAf8BEgFdAWUB/wESAV0BZQH/AwoB/wM8Af8DPAH/
+        ARsCIwH/ARsCIwH/ARsCIwH/BAABrgFmAW0B/wGuAWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wMAAf8B/AP/
+        AfwD/wGTAZ4BnAH/ASYBJAEiAf8DAAH/AR4BEAEUAf8DAAH/AfwD/wMAAf8BrgFmAW0B/wGuAWYBbQH/
+        hAADPAH/AwAB/wMAAf8DAAH/AwoB/wMKAf8BGwIjAf8DPAH/AWUBbQF1Af8BZQKtAf8DPAH/AzwB/wEb
+        AiMB/wM8Af8EAAGuAWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/AwAB/wG8Ar0B/wH8A/8B/AP/
+        AfwD/wHLAdEBygH/AVMBXAFbAf8DAAH/AfwD/wMAAf8BrgFmAW0B/wGuAWYBbQH/iAABGwIjAf8DAAH/
+        AwAB/wMKAf8DCgH/ARsCIwH/ASMCMwH/AWUBbQF1Af8BvQLGAf8BZQFtAXUB/wEjAjMB/wM8Af8IAAGu
+        AWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/ASYBJAEiAf8BQwFGAUEB/wG8Ar0B/wH8A/8B/AP/
+        AfwD/wH8A/8B/AP/AfwD/wMAAf8BrgFmAW0B/wGuAWYBbQH/jAADPAH/AwAB/wMKAf8DCgH/ARsCIwH/
+        ASMCMwH/AzwB/wFlAW0BdQH/AWUBbQF1Af8BZQFtAXUB/wwAAa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/
+        Aa4BZgFtAf8BrgFmAW0B/wEmASQBIgH/AwAB/wEmASQBIgH/AZMBngGcAf8B/AP/AfwD/wH8A/8B/AP/
+        AwAB/wGuAWYBbQH/Aa4BZgFtAf+QAAEjAjMB/wEjAjMB/wMKAf8DCgH/AwoB/wEbAiMB/wM8Af8DPAH/
+        EAABrgFmAW0B/wGuAWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wEm
+        ASQBIgH/AwAB/wEeARABFAH/AXECaAH/AcsB0QHKAf8B/AP/AwAB/wGuAWYBbQH/Aa4BZgFtAf+YAAFl
+        AW0BdQH/AWUBbQF1Af8BZQFtAXUB/wFlAW0BdQH/HAABrgFmAW0B/wGuAWYBbQH/Aa4BZgFtAf8BrgFm
+        AW0B/wGuAWYBbQH/Aa4BZgFtAf8BrgFmAW0B/wGuAWYBbQH/Aa4BZgFtAf8BHgEQARQB/wMAAf8BQwFG
+        AUEB/wEmASQBIgH/Aa4BZgFtAf+IAAPAAf8DbgH/A24B/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPA
+        Af8DwAH/A8AB/wPAAf8DwAH/BAADCwEPAxQBGwMdASkDIgEyA1IBpgFXAVwBVwHRAVcBXAFXAdEDPAFm
+        BAADPAFmAVcBXAFXAdEBVwFcAVcB0QFXAVwBVwHRAVcBXAFXAdEDUgGpAyMBMxAAAycBOwNOAZQBZQFf
+        AVwBzgGEAXEBWQHrAYQBcQFZAesBZQFfAVwBzgNOAZQCAAHiAf8CAAHiAf8MAAGmAowB/wFFAgoB/wE+
+        AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6AgAB/wE6
+        AgAB/wE4AgAB/wE0AgAB/wEUAgAB/wNuAf8DAAH/AxMB/wMqAf8DAAH/Aw0B/wPAAf8DwAH/A8AB/wPA
+        Af8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DBgEIAwoBDgMQARUDEgEZAVgBXAFXAcwBGwHVAQoB/wE/
+        AYIBPAHvA04BmQQAA04BmQE/AYIBPAHvARsB1QEKAf8BGwHVAQoB/wEbAdUBCgH/AVcBXgFXAdEDEwEa
+        CAADCgENA04BlgGkAXwBUAH6AeEBzQG5Af8B8QHgAc4B/wH5AecB1gH/AfgB5gHUAf8B8AHdAcwB/wHh
+        Ac0BuQH/AgAB4gH/AgAB4gH/AwoBDQgAAb8BhQGGAf8BgwEOARAB/wF3AQIBBAH/AXMCAAH/AXMCAAH/
+        A+oB/wPqAf8D6gH/AXMCAAH/A+oB/wPqAf8D6gH/AXMCAAH/AW4CAAH/AWkCAAH/ATUCAAH/AwAB/wPA
+        Df8DKgH/Aw0B/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/xAAAVgBXAFXAcwBHgHN
+        AQ0B/wFXAVwBVwHRAyMBMwQAAyMBMwFXAVwBVwHRARsBzAEKAf8BGwHMAQoB/wEbAcwBCgH/AVcBXwFX
+        AdEIAAMKAQ0BWQJXAbgB2QG/AaUB/wH+AfIB5AL/AecBzwH/AfwB2wG7Af8B+QHTAbIB/wH2AdABrAH/
+        AfQB0QGuAf8B9gHYAbsB/wIAAeIB/wIAAeIB/wFZAlcBuAMKAQ0EAAHAAYIBgwH/AYkBDwERAf8BgwED
+        AQUB/wF5AgAB/wP2Af8BeQIAAf8BeQIAAf8D9gH/AXkCAAH/A/YB/wF5AgAB/wF5AgAB/wP2Af8BdAIA
+        Af8BbwIAAf8BOAIAAf8DAAH/A8AR/wMAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPA
+        Af8BKwEsASsBQwFWAVcBVgG4AVYBVwFWAbgBKwEsASsBQwFYAVwBVwHMASIBxAERAf8BVwFcAVcB0QM8
+        AWYEAAM8AWYBVwFcAVcB0QEbAcEBCgH/ARsBwQEKAf8BGwHBAQoB/wFXAV8BVwHRCAADTgGWAdkBvwGl
+        Av8B+AHrAv8B6wHRAv8B4QHDAf8B/gHbAboB/wH7AdYBsgH/AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/
+        AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/AcIBggGDAf8BjgEQARIB/wGIAQQBBgH/AYQCAAX/AYQCAAH/
+        AYQCAAX/AYQCAAX/AYQCAAH/AYQCAAX/AXkCAAH/AXMCAAH/AToCAAH/A24B/wMNAf8DVgH/A7IB/wOy
+        Af8DwAH/AwAB/wMTAf8DAAH/AwAB/wMAAf8DAAH/AxMB/wPAAf8DwAH/A8AB/wNVAbIBSAHGATcB/wFM
+        AYwBQQHzAVgBXAFXAcwBVQFhAVMB2QEcAbcBCwH/AUIBegE8Ae8BVgFdAVYB0wFXAVkBVwHMAVYBXQFW
+        AdMBPwF2ATwB7wEdAbcBDAH/ARwBtgELAf8BGwG2AQoB/wFXAV8BVwHRBAADJgE4AbIBhwFRAf0C/gH6
+        Av8B+QHpAv8B7wHYAv8B5wHNAv8B4QHCAf8B/AHcAbsB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIA
+        AeIB/wIAAeIB/wIAAeIB/wIAAeIB/wHCAYIBgwH/AY4BEAESAf8BiAEEAQYB/wGEAgAB/wGEAgAN/wGE
+        AgAN/wGEAgAB/wF5AgAB/wFzAgAB/wE6AgAB/wPAAf8DbgH/Aw0B/wMAAf8DAAX/AwAB/wMNAf8Dlgn/
+        A4YB/wMTAf8DEwH/A8AB/wPAAf8BWAFeAVcBzAFHAcUBNgH/AT0BuwEsAf8BRgHEATUB/wE8Ab0BKwH/
+        ARsBqwEKAf8BHQGsAQwB/wEhAa8BEAH/ASEBrwEQAf8BIAGvAQ8B/wFCAXsBPAHvAVcBXwFXAdEBVwFf
+        AVcB0QE/AXoBPAHvAVcBXwFXAdEEAANOAZYB4gHOAboB/wH3Ad4BxgL/AekB0QL/AfYB4gL/AfIB3QL/
+        AfAB3QH/AfgB6gHZAf8B+AHmAdQB/wH7Ad8BxwH/AfUBzwGrAf8CAAHiAf8CAAHiAf8B+AHdAcMB/wHi
+        Ac4BugH/A04BlgHCAYIBgwH/AY4BEAESAf8BiAEEAQYB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAF/wGE
+        AgAF/wGEAgAB/wGEAgAB/wGEAgAB/wF5AgAB/wFzAgAB/wE6AgAB/wPAAf8DwAH/A8AB/wPAAf8DAAX/
+        AwAB/wMTEf8DwAH/AwAB/wPAAf8DwAH/A1UBsgFPAc0BPgH/AUwBkQFEAfMBWAFeAVcBzAFWAWMBVQHZ
+        AS0BsAEcAf8BHAGiAQsB/wEbAaEBCgH/ARsBoQEKAf8BIgGoAREB/wFWAV4BVgHTAzwBZgMjATMDTgGZ
+        AzwBZgQAAWUBYAFbAdAB7wHgAdAB/wHnAb4BlgH/AecBvAGUAf8B8AHMAakB/wH+AewB2gH/Ad0BxAGs
+        Af8BfAFtAVwB5wF8AW0BXAHnAd0BwwGqAf8B+AHdAcQB/wIAAeIB/wIAAeIB/wH1AdYBuAH/AfEB3wHP
+        Af8BZQFgAVsB0AHCAYIBgwH/AY4BEAESAf8BiAEEAQYB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAF/wGE
+        AgAF/wGEAgAB/wGEAgAB/wGEAgAB/wF5AgAB/wFzAgAB/wE6AgAB/wNWAf8DVgH/A1YB/wNWAf8DAAX/
+        AwAB/wMAAf8DKgH/A8AN/wMAAf8DVgH/A1YB/wErASwBKwFDAVYBVwFWAbgBVgFXAVYBuAErASwBKwFD
+        AVgBXgFXAcwBSQHHATgB/wE4AbcBJwH/AS4BrQEdAf8BJAGkARMB/wErAaoBGgH/AVcBXAFXAcwUAAGF
+        AXABWQHsAfUB5AHVAf8B6QG+AZcB/wHoAbwBlgH/AecBvAGUAf8B8wHeAcoB/wF8AWsBWQHmAxQBGwMU
+        ARsBfAFrAVkB5gH2AeMB0wH/AgAB4gH/AgAB4gH/Ae0ByQGkAf8B9gHkAdIB/wGFAXABWQHsAcIBggGD
+        Af8BjgEQARIB/wGIAQQBBgH/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAH/
+        AYQCAAH/AYQCAAH/AYQCAAH/AXkCAAH/AXMCAAH/AToCAAH/A1YB/wNWAf8DVgH/A1YB/wMABf8DAAH/
+        AzAB/wMNAf8DAAH/AwAB/wMABf8DAAH/A1YB/wNWAf8QAAFYAV4BVwHMAUwBygE7Af8BPgG8AS0B/wE+
+        AbwBLQH/AT4BvAEtAf8BRgHEATUB/wFWAV4BVgHTAzwBZgMjATMDTgGZAzwBZgQAAYUBcAFZAewB9QHk
+        AdUB/wHpAb8BmQH/AekBwAGZAf8B6QHBAZoB/wHzAd0ByQH/AXwBawFZAeYDFAEbAxQBGwF8AWsBWQHm
+        AfgB6AHZAf8B8gHSAbIB/wHwAcwBqwH/AfABzAGrAf8B9gHkAdMB/wGFAXABWQHsNP8D9gH/A+oB/wN3
+        Af8DVgH/A1YB/wNWAf8DVgH/AwAF/wMNAf8DAAH/AxMB/wMwAf8DMAH/AwAF/wMAAf8DVgH/A1YB/xAA
+        AVgBXgFXAcwBUQHPAUAB/wFDAcEBMgH/AUMBwQEyAf8BQwHBATIB/wFFAcMBNAH/AU4BgwFKAe8BVwFf
+        AVcB0QFXAV8BVwHRAU4BgwFKAe8BWAFeAVcBzAQAAWUBYAFbAdAB8AHhAdEB/wHqAcQBoQH/AekBwQGb
+        Af8B6QHAAZcB/wHxAc4BsgH/AdwBwwGqAf8BfAFtAVwB5wF8AW0BXAHnAd0BxAGsAv8B/AHzAv8B9AHl
+        Av8B7gHaAf8B/AHlAdEB/wHxAeEB0QH/AWUBYAFbAdAE/wGOARABEgn/AYQCAA3/AYQCAAH/AYQCAA3/
+        AXkCAAH/AXMCAAH/A3cB/wNWAf8DVgH/A1YB/wNWAf8DAAn/A4YB/wMTAf8DAAH/Aw0B/wMABf8DAAH/
+        A1YB/wNWAf8QAAFYAV4BVwHMAV4B3AFNAf8BVgHUAUUB/wFVAdMBRAH/AVQB0gFDAf8BTgHMAT0B/wFI
+        AcYBNwH/AVABzgE/Af8BWQHXAUgB/wFXAdUBRgH/AVgBXgFXAcwEAANOAZYB4gHOAboB/wHxAdIBtgH/
         AesBwQGbAf8B6wG/AZkC/wHkAdMC/wHoAdsB/wHzAdoBxwH/AfgB8QHkAv8B+AHtAv8B9wHpAv8B/gHx
-        Av8B/AHvAv8B/AHyAf8B4gHOAboB/wFPAk4BlgT/AY4BEgEUCf8BhAIACf8BhAIAEf8BhAIAAf8D9gH/
-        A+oB/wN5Af8DWAH/A1gB/wNYAf8DWAH/AwAB/wOyDf8DwAH/A0YB/wMABf8DAAH/A1gB/wNYAf8QAANO
-        AZkBUgFkAVEBzAFSAWQBUQHMAVIBZAFRAcwBUgFkAVEBzAFSAW8BTQHZAVYB0gFFAf8BUgFvAU0B2QFS
-        AWQBUQHMAVIBZAFRAcwDTgGZBAADJgE4AbQBhwFTAf0B+gHtAeEB/wHsAccBowL/AewB2gX/AfcBzQG2
-        Af8B7AG9AZcC/wH0AdwD/wH3Av8B9wHoA/8B8wP/AfkB/wL+AfkB/wG0AYcBUwH9AyYBOAT/AY4BEgEU
-        Cf8BhAIACf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIABf8BhAIAAf8BewIAAf8BdQIAAf8BPAIAAf8DWAH/
-        A1gB/wNYAf8DWAH/AxUB/wMsAf8Dshn/AwAB/wNYAf8DWAH/IAABKwEsASsBQwFSAWQBUQHMAWEB3QFQ
-        Af8BUgFkAVEBzAErASwBKwFDEAABTwJOAZYB2QG/AaUC/wH6AfAG/wH9AfMB/wHwAcEBowH/Ae4BxgGg
-        Af8B/QHwAdED/wH+Av8B/QHwAv8B/QHxBf8B2QG/AaUB/wFPAk4BlgQABP8BjgESARQB/wGIAQYBCAX/
-        AYQCAAn/AYQCAAn/AYQCAAX/AYQCAAH/A/YB/wPqAf8BPAIAAf8DWAH/A1gB/wNYAf8DWAH/A1gB/wMV
-        Af8DAAH/AxUB/wOGEf8DAAH/A1gB/wNYAf8gAAFUAVsBVAG4AV0BqAFMAfMBXAHYAUsB/wFcAagBTAHz
-        AVQBWwFUAbgQAAMKAQ0BYAFcAVcBuAHZAb8BpQH/Af4B/QH8Av8B8QHkAf8B8gHKAa4B/wHyAdIBrQH/
-        AfkB7QHIA/8B9wP/Af0B/wH+Af0B/AH/AdkBvwGlAf8BYAFcAVcBuAMKAQ0EAAT/AZEBGQEbCf8BiAEG
-        AQgB/wGIAQYBCAn/AYgBBgEIAf8BiAEGAQgN/wGDAQUBBwH/AXkBBAEGAf8DgAH/A1gB/wNYAf8DWAH/
-        A1gB/wNYAf8DWAH/A1gB/wMVAf8DAAH/Aw8B/wNYAf8DwAX/AwAB/wNYAf8DWAH/IAABVAFbAVQBuAFt
-        AekBXAH/AWgB5AFXAf8BbAHoAVsB/wFUAVsBVAG4FAADCgENAU8CTgGWAakBfgFSAfoB4QHNAbkB/wHx
-        AeIB1AH/AfkB7AHfAf8B+wHzAeUB/wH0Ae0B5AH/AeIBzgG7Af8BqQF+AVIB+gFPAk4BlgMKAQ0IAAT/
-        AZUBIwElLf8D9wH/A+wB/wOCAf8EAANYAf8DWAH/A1gB/wNYAf8DWAH/A1gB/wNYAf8DWAH/A1gB/wMP
-        Af8DAAH/AywB/wMVAf8DWAH/JAABKwEsASsBQwFUAVkBUwGyAVIBZAFRAcwBVAFZAVMBsgErASwBKwFD
-        HAADJwE7AU8CTgGUAW4BZgFcAc4BkAF3AVkB6wGTAXYBWAHvAXcBaQFbAdkBUAJPAZcDJwE7EAAI/wHD
-        AYUBhin/A/wB/wP3Af8DvwH//wAFAAGZAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFf
-        AswB/wPqAf8gAAGkAqAB/wNfAf8DzAH/tAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wFfAswB/wFf
-        AswB/wPxAf8gAAPXAf8DXwH/CAADmQH/A1gB/wNOAf8DTgH/AzsB/wMyAf8DLAH/AyIB/wOGAf8MAAGZ
-        AswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wPqAf8YAAGZ
-        AswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wFfAswB/wPqAf8UAAGZ
-        AswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AV8CzAH/AZkBzAL/ASwCmQH/AV8CzAH/AV8CzAH/AZkCzAH/
-        EAAD6gH/A18B/wPqAf8IAANYAf8DXwH/A04B/wM7Af8DOwH/A04B/wNfAf8DcAH/AyIB/wwAAZkCzAH/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wFfAswB/wFfAswB/wPxAf8UAAGZAswB/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BXwLMAf8BXwLMAf8D8QH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wFfAswB/wFfAswB/wFfAswB/wEsAswB/wGZA/8BmQLMAf8QAAOyAf8DhgH/A4YB/wgAAaQCoAH/
-        A18B/wNYAf8DWAH/A1gB/wNOAf8DTgH/AzsB/wOGAf8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BXwLMAf8BmQHMAv8BXwLMAf8D8QH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AV8CzAH/AZkBzAL/AV8CzAH/A/EB/wwAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BLALMAf8BmQP/ASwCmQH/AV8CzAH/AZkCzAH/TAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AV8CzAH/AV8CzAH/AV8CzAH/AZkCzAH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AV8CzAH/AV8CzAH/AV8CzAH/AZkCzAH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wEsAswB/wGZA/8BLALMAf8BmQP/AZkCzAH/CAADcAH/A3AB/wNfAf84AAGZ
+        Av8B/AHvAv8B/AHyAf8B4gHOAboB/wNOAZYE/wGOARABEgn/AYQCAAn/AYQCABH/AYQCAAH/A/YB/wPq
+        Af8DdwH/A1YB/wNWAf8DVgH/A1YB/wMAAf8Dsg3/A8AB/wNEAf8DAAX/AwAB/wNWAf8DVgH/EAADTgGZ
+        AVgBXwFXAcwBWAFfAVcBzAFYAV8BVwHMAVgBXwFXAcwBVgFlAVUB2QFUAdIBQwH/AVYBZQFVAdkBWAFf
+        AVcBzAFYAV8BVwHMA04BmQQAAyYBOAGyAYcBUQH9AfoB7QHhAf8B7AHHAaMC/wHsAdoF/wH3Ac0BtgH/
+        AewBvQGXAv8B9AHcA/8B9wL/AfcB6AP/AfMD/wH5Af8C/gH5Af8BsgGHAVEB/QMmATgE/wGOARABEgn/
+        AYQCAAn/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAX/AYQCAAH/AXkCAAH/AXMCAAH/AToCAAH/A1YB/wNW
+        Af8DVgH/A1YB/wMTAf8DKgH/A7IZ/wMAAf8DVgH/A1YB/yAAASsBLAErAUMBWAFfAVcBzAFfAd0BTgH/
+        AVgBXwFXAcwBKwEsASsBQxAAA04BlgHZAb8BpQL/AfoB8Ab/Af0B8wH/AfABwQGjAf8B7gHGAaAB/wH9
+        AfAB0QP/Af4C/wH9AfAC/wH9AfEF/wHZAb8BpQH/A04BlgQABP8BjgEQARIB/wGIAQQBBgX/AYQCAAn/
+        AYQCAAn/AYQCAAX/AYQCAAH/A/YB/wPqAf8BOgIAAf8DVgH/A1YB/wNWAf8DVgH/A1YB/wMTAf8DAAH/
+        AxMB/wOGEf8DAAH/A1YB/wNWAf8gAAFWAVcBVgG4AV0BmgFMAfMBWgHYAUkB/wFdAZoBTAHzAVYBVwFW
+        AbgQAAMKAQ0BWQJXAbgB2QG/AaUB/wH+Af0B/AL/AfEB5AH/AfIBygGuAf8B8gHSAa0B/wH5Ae0ByAP/
+        AfcD/wH9Af8B/gH9AfwB/wHZAb8BpQH/AVkCVwG4AwoBDQQABP8BkQEXARkJ/wGIAQQBBgH/AYgBBAEG
+        Cf8BiAEEAQYB/wGIAQQBBg3/AYMBAwEFAf8BdwECAQQB/wOAAf8DVgH/A1YB/wNWAf8DVgH/A1YB/wNW
+        Af8DVgH/AxMB/wMAAf8DDQH/A1YB/wPABf8DAAH/A1YB/wNWAf8gAAFWAVcBVgG4AWsB6QFaAf8BZgHk
+        AVUB/wFqAegBWQH/AVYBVwFWAbgUAAMKAQ0DTgGWAaQBfAFQAfoB4QHNAbkB/wHxAeIB1AH/AfkB7AHf
+        Af8B+wHzAeUB/wH0Ae0B5AH/AeIBzgG7Af8BpAF8AVAB+gNOAZYDCgENCAAE/wGVASEBIy3/A/cB/wPs
+        Af8DggH/BAADVgH/A1YB/wNWAf8DVgH/A1YB/wNWAf8DVgH/A1YB/wNWAf8DDQH/AwAB/wMqAf8DEwH/
+        A1YB/yQAASsBLAErAUMDVQGyAVgBXwFXAcwDVQGyASsBLAErAUMcAAMnATsDTgGUAWUBXwFcAc4BhAFx
+        AVkB6wGHAXABWAHvAWkBYwFbAdkDTwGXAycBOxAACP8BwwGFAYYp/wP8Af8D9wH/A78B//8ABQABmQLM
+        Af8BXQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8D6gH/IAABpAKgAf8DXQH/A8wB/7QA
+        AZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BXQLMAf8BXQLMAf8D8QH/IAAD1wH/A10B/wgAA5kB/wNW
+        Af8DTAH/A0wB/wM5Af8DMAH/AyoB/wMgAf8DhgH/DAABmQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8BXQLM
+        Af8BXQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8D6gH/GAABmQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8BXQLM
+        Af8BXQLMAf8BXQLMAf8BXQLMAf8BXQLMAf8D6gH/FAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wFd
+        AswB/wGZAcwC/wEqApkB/wFdAswB/wFdAswB/wGZAswB/xAAA+oB/wNdAf8D6gH/CAADVgH/A10B/wNM
+        Af8DOQH/AzkB/wNMAf8DXQH/A24B/wMgAf8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        A/8BXQLMAf8BXQLMAf8D8QH/FAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AV0CzAH/
+        AV0CzAH/A/EB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BXQLMAf8BXQLMAf8BXQLMAf8BKgLM
+        Af8BmQP/AZkCzAH/EAADsgH/A4YB/wOGAf8IAAGkAqAB/wNdAf8DVgH/A1YB/wNWAf8DTAH/A0wB/wM5
+        Af8DhgH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AV0CzAH/AZkBzAL/AV0CzAH/
+        A/EB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wFdAswB/wGZAcwC/wFdAswB/wPx
+        Af8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/ASoCzAH/AZkD/wEqApkB/wFd
+        AswB/wGZAswB/0wAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wFdAswB/wFdAswB/wFd
+        AswB/wGZAswB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wFdAswB/wFdAswB/wFd
+        AswB/wGZAswB/wwAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BKgLMAf8BmQP/
+        ASoCzAH/AZkD/wGZAswB/wgAA24B/wNuAf8DXQH/OAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AZkD/wGZA/8BmQP/AZkCzAH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEq
+        AswB/wGZA/8BKgLMAf8BmQP/AZkCzAH/CAAD8QH/A5YF/wgAAaQCoAH/A10B/wNdAf8DXQH/A10B/wNd
+        Af8DVgH/A1YB/wOZAf8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        A/8BmQLMAf8QAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQLM
+        Af8MAAGZAswB/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/ASoCzAH/AZkD/wEqAswB/wGZ
+        A/8BmQLMAf8MAAPxAf8DlgH/CAADXQH/A10B/wNMAf8DRAH/AzkB/wNMAf8DXQH/A24B/wNWAf8MAAGZ
         AswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQLMAf8QAAGZAswB/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQLMAf8MAAGZAswB/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/ASwCzAH/AZkD/wEsAswB/wGZA/8BmQLMAf8IAAPxAf8DlgX/
-        CAABpAKgAf8DXwH/A18B/wNfAf8DXwH/A18B/wNYAf8DWAH/A5kB/wwAAZkCzAH/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/wwAAZkCzAH/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BLALMAf8BmQP/ASwCzAH/AZkD/wGZAswB/wwAA/EB/wOWAf8IAANfAf8DXwH/A04B/wNG
-        Af8DOwH/A04B/wNfAf8DcAH/A1gB/wwAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZAswB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZAswB/wwAAcYB1gHvAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEsAswB/wGZ
-        A/8BLALMAf8BmQP/AZkCzAH/CAADsgH/A4YB/wOyAf8IAAOyAf8DcAH/A18B/wNfAf8DXwH/A18B/wNf
-        Af8DXwH/AaQCoAH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkCzAH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8CmQFfAf8BmQHM
-        AZkB/wwAAcYB1gHvAf8BzAP/AcwD/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEsAswB/wGZA/8BLALM
-        Af8BmQP/AZkCzAH/TAABmQLMAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkCzAH/EAABmQLMAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQFfASwB/wGZ
-        AV8BLAH/A+MB/wgAAdYC5wH/AcYB1gHvAf8BXwLMAf8BXwLMAf8BXwLMAf8BXwLMAf8BXwLMAf8BXwLM
-        Af8BXwLMAf8BXwLMAf8BmQP/ASwCzAH/AZkD/wGZAswB/wgAA4YB/wOGAf8DhgH/OAABmQLMAf8BzAP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BzAP/AZkD/wGZ
-        A/8BmQP/AZkD/wKZAV8B/wHMAZkBLAH/AcwBmQEsAf8BzAGZASwB/wHMAZkBLAL/AcwBLAH/AcwBmQFf
-        Af8D4wH/DAABxgHWAe8B/wHMA/8BzAP/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/ASwCzAH/AZkD/wGZ
-        AswB/wwAA4YB/wwAA7IB/wOGAf8DcAH/A3AB/wNwAf8DcAH/A18B/wNfAf8BpAKgAf8MAAHGAdYB7wH/
-        AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wHGAdYB7wH/EAABxgHWAe8B/wHM
-        A/8BmQP/AZkD/wGZA/8BmQP/AcwBmQEsAv8BzAGZAv8BzAFfAv8BzAFfAv8BzAFfAv8BzAFfAv8BzAFf
-        Af8BzAGZAV8B/wwAAdYC5wH/AcYB1gHvAf8BXwLMAf8BXwLMAf8BXwLMAf8BXwLMAf8BXwLMAf8BXwLM
-        Af8BXwLMAf8BXwLMAf8BmQP/AcYB1gHvAf8MAAOGAf8MAAOGAf8DXwH/A04B/wNOAf8DRgH/A0YB/wNO
-        Af8DXwH/A18B/wwAAcYB1gHvAf8BzAP/AcwD/wHMA/8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AcYB1gHvAf8QAAHGAdYB7wH/AcwD/wHMA/8BzAP/AcwD/wGZA/8CzAGZAf8BzAGZAV8B/wHMAZkBXwH/
-        AcwBmQFfAf8BzAGZAV8C/wHMAZkB/wHMAZkBXwH/A+MB/xQAAcYB1gHvAf8BzAP/AcwD/wHMA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wHGAdYB7wH/CAADsgH/A4YB/wwAA7IB/wOGAf8DhgH/A4YB/wOGAf8DcAH/
-        A3AB/wNwAf8DsgH/DAAB1gLnAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/
-        AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHWAucB/xAAAdYC5wH/AcYB1gHv
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQLMAf8MAAHGAdYB7wH/AcwD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BKgLMAf8BmQP/ASoCzAH/AZkD/wGZAswB/wgAA7IB/wOG
+        Af8DsgH/CAADsgH/A24B/wNdAf8DXQH/A10B/wNdAf8DXQH/A10B/wGkAqAB/wwAAZkCzAH/AZkD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/xAAAZkCzAH/AZkD/wGZA/8BmQP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/ApkBXQH/AZkBzAGZAf8MAAHGAdYB7wH/AcwD/wHMA/8BzAP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BKgLMAf8BmQP/ASoCzAH/AZkD/wGZAswB/0wAAZkCzAH/AcwD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/xAAAZkCzAH/AcwD/wGZA/8BmQP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkBXQEqAf8BmQFdASoB/wPjAf8IAAHWAucB/wHGAdYB7wH/
+        AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AZkD/wEqAswB/wGZ
+        A/8BmQLMAf8IAAOGAf8DhgH/A4YB/zgAAZkCzAH/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        A/8BmQP/AZkD/wGZAswB/xAAAZkCzAH/AcwD/wGZA/8BmQP/AZkD/wGZA/8CmQFdAf8BzAGZASoB/wHM
+        AZkBKgH/AcwBmQEqAf8BzAGZASoC/wHMASoB/wHMAZkBXQH/A+MB/wwAAcYB1gHvAf8BzAP/AcwD/wHM
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEqAswB/wGZA/8BmQLMAf8MAAOGAf8MAAOyAf8DhgH/A24B/wNu
+        Af8DbgH/A24B/wNdAf8DXQH/AaQCoAH/DAABxgHWAe8B/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        A/8BmQP/AZkD/wGZA/8BxgHWAe8B/xAAAcYB1gHvAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wHMAZkBKgL/
+        AcwBmQL/AcwBXQL/AcwBXQL/AcwBXQL/AcwBXQL/AcwBXQH/AcwBmQFdAf8MAAHWAucB/wHGAdYB7wH/
+        AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AV0CzAH/AZkD/wHGAdYB7wH/
+        DAADhgH/DAADhgH/A10B/wNMAf8DTAH/A0QB/wNEAf8DTAH/A10B/wNdAf8MAAHGAdYB7wH/AcwD/wHM
+        A/8BzAP/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wHGAdYB7wH/EAABxgHWAe8B/wHMA/8BzAP/
+        AcwD/wHMA/8BmQP/AswBmQH/AcwBmQFdAf8BzAGZAV0B/wHMAZkBXQH/AcwBmQFdAv8BzAGZAf8BzAGZ
+        AV0B/wPjAf8UAAHGAdYB7wH/AcwD/wHMA/8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BxgHWAe8B/wgA
+        A7IB/wOGAf8MAAOyAf8DhgH/A4YB/wOGAf8DhgH/A24B/wNuAf8DbgH/A7IB/wwAAdYC5wH/AcYB1gHv
         Af8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHG
-        AdYB7wH/AcwBmQFfAf8BzAGZAV8B/wPqAf8YAAHWAucB/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHG
-        AdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8B1gLnAf+0AAHwAcoBpgH/A+oB/wgA
-        AUIBTQE+BwABPgMAASgDAAFAAwABMAMAAQEBAAEBBQABgAEBFgAD/wEAAfwBPwGAAQEEAAHwAQ8GAAHg
-        AQcGAAHAAQMGAAGAAQEGAAGAAQEmAAGAAQEGAAGAAQEGAAHAAQMGAAHgAQcGAAHwAQ8GAAH8AT8BgAEB
-        BAABgAEBAQABgAHwAQcFAAGAAcABAwQAAfABgQGAAQEFAAGBAYAGAAEBBwABAQcAAQEHAAEfBgAB8AEB
-        BgAB8AEBBgAB8AEBBgAB8AEBBgAB/wEHAYABAQQAAf8BBwGAAQEEAAH/AQcBwAEDAgABgAEBAf8BBwHw
-        AQ8CAAj/AYABfwGPBf8BgAE/AcwBAQHAAQ8BwAEPAYABBwGMAQEBwAEHAcABBwGAAQcBjAEBAcABAwHA
-        AQMBgAEBAv8BwAEDAcABAwGAAQEBjwH/AcABAwHAAQMBgAEBAYwBAQHAAQMBwAEDAYABAQHMAQEBwAED
-        AcABAwGAAQEBjAEBAcABAwHAAQMBgAEBAv8BwAEDAcABAQGAAQEBjwH/AcABAwHAAQAB4AEBAdwBAQHA
-        AQMBwAEAAeABAQHcAQEBwAEDAcABAAH4AQEBnAEBAcABAwHAAQEB+AEBBf8B8ws=
+        AdYB7wH/AcYB1gHvAf8B1gLnAf8QAAHWAucB/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/
+        AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHMAZkBXQH/AcwBmQFdAf8D6gH/
+        GAAB1gLnAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHW
+        Ae8B/wHGAdYB7wH/AdYC5wH/tAAB8AHKAaYB/wPqAf8IAAFCAU0BPgcAAT4DAAEoAwABQAMAATADAAEB
+        AQABAQUAAYABARYAA/8BAAH8AT8BgAEBBAAB8AEPBgAB4AEHBgABwAEDBgABgAEBBgABgAEBJgABgAEB
+        BgABgAEBBgABwAEDBgAB4AEHBgAB8AEPBgAB/AE/AYABAQQAAYABAQEAAYAB8AEHBQABgAHAAQMEAAHw
+        AYEBgAEBBQABgQGABgABAQcAAQEHAAEBBwABHwYAAfABAQYAAfABAQYAAfABAQYAAfABAQYAAf8BBwGA
+        AQEEAAH/AQcBgAEBBAAB/wEHAcABAwIAAYABAQH/AQcB8AEPAgAI/wGAAX8BjwX/AYABPwHMAQEBwAEP
+        AcABDwGAAQcBjAEBAcABBwHAAQcBgAEHAYwBAQHAAQMBwAEDAYABAQL/AcABAwHAAQMBgAEBAY8B/wHA
+        AQMBwAEDAYABAQGMAQEBwAEDAcABAwGAAQEBzAEBAcABAwHAAQMBgAEBAYwBAQHAAQMBwAEDAYABAQL/
+        AcABAwHAAQEBgAEBAY8B/wHAAQMBwAEAAeABAQHcAQEBwAEDAcABAAHgAQEB3AEBAcABAwHAAQAB+AEB
+        AZwBAQHAAQMBwAEBAfgBAQX/AfML
 </value>
   </data>
   <data name="bnComboBoxRelease.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 43</value>
-  </data>
-  <data name="bnComboBoxRelease.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>0, 28</value>
   </data>
   <data name="bnComboBoxRelease.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>90, 0</value>
+    <value>61, 0</value>
   </data>
   <data name="bnComboBoxRelease.Size" type="System.Drawing.Size, System.Drawing">
-    <value>982, 27</value>
+    <value>656, 21</value>
   </data>
   <data name="bnComboBoxRelease.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1250,14 +1185,11 @@
   <data name="bnComboBoxDrives.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="bnComboBoxDrives.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="bnComboBoxDrives.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>90, 0</value>
+    <value>61, 0</value>
   </data>
   <data name="bnComboBoxDrives.Size" type="System.Drawing.Size, System.Drawing">
-    <value>982, 27</value>
+    <value>656, 21</value>
   </data>
   <data name="bnComboBoxDrives.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1281,16 +1213,13 @@
     <value>Fill</value>
   </data>
   <data name="bnComboBoxOutputFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 6</value>
-  </data>
-  <data name="bnComboBoxOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>0, 4</value>
   </data>
   <data name="bnComboBoxOutputFormat.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>58, 0</value>
+    <value>40, 0</value>
   </data>
   <data name="bnComboBoxOutputFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 27</value>
+    <value>656, 21</value>
   </data>
   <data name="bnComboBoxOutputFormat.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1334,11 +1263,8 @@
   <data name="listMetadata.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="listMetadata.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="listMetadata.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 248</value>
+    <value>656, 158</value>
   </data>
   <data name="listMetadata.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1359,13 +1285,10 @@
     <value>1</value>
   </data>
   <data name="buttonMetadata.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 88</value>
-  </data>
-  <data name="buttonMetadata.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 57</value>
   </data>
   <data name="buttonMetadata.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 35</value>
+    <value>80, 23</value>
   </data>
   <data name="buttonMetadata.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1392,13 +1315,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonVA.Location" type="System.Drawing.Point, System.Drawing">
-    <value>405, 88</value>
-  </data>
-  <data name="buttonVA.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>270, 57</value>
   </data>
   <data name="buttonVA.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonVA.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1425,13 +1345,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonReload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>141, 88</value>
-  </data>
-  <data name="buttonReload.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>94, 57</value>
   </data>
   <data name="buttonReload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonReload.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1458,13 +1375,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonEncoding.Location" type="System.Drawing.Point, System.Drawing">
-    <value>537, 88</value>
-  </data>
-  <data name="buttonEncoding.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>358, 57</value>
   </data>
   <data name="buttonEncoding.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonEncoding.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1491,13 +1405,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonTracks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 88</value>
-  </data>
-  <data name="buttonTracks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 57</value>
   </data>
   <data name="buttonTracks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonTracks.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1527,13 +1438,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonFreedbSubmit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>669, 88</value>
-  </data>
-  <data name="buttonFreedbSubmit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>446, 57</value>
   </data>
   <data name="buttonFreedbSubmit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonFreedbSubmit.TabIndex" type="System.Int32, mscorlib">
     <value>41</value>
@@ -1560,13 +1468,10 @@
     <value>Right</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>720, 0</value>
-  </data>
-  <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>480, 0</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 209</value>
+    <value>176, 136</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>42</value>
@@ -1587,16 +1492,13 @@
     <value>Fill</value>
   </data>
   <data name="pictureBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
-  </data>
-  <data name="pictureBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>5, 5</value>
   </data>
   <data name="pictureBox1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>150, 154</value>
+    <value>100, 100</value>
   </data>
   <data name="pictureBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 193</value>
+    <value>131, 126</value>
   </data>
   <data name="pictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>Zoom</value>
@@ -1623,13 +1525,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>801, 88</value>
-  </data>
-  <data name="buttonSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>534, 57</value>
   </data>
   <data name="buttonSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonSettings.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -1656,16 +1555,13 @@
     <value>Fill</value>
   </data>
   <data name="panel7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>508, 0</value>
-  </data>
-  <data name="panel7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>339, 0</value>
   </data>
   <data name="panel7.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>5, 5, 5, 5</value>
   </data>
   <data name="panel7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>212, 209</value>
+    <value>141, 136</value>
   </data>
   <data name="panel7.TabIndex" type="System.Int32, mscorlib">
     <value>44</value>
@@ -1686,13 +1582,10 @@
     <value>Bottom</value>
   </data>
   <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 441</value>
-  </data>
-  <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 284</value>
   </data>
   <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 209</value>
+    <value>656, 136</value>
   </data>
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -1716,13 +1609,10 @@
     <value>NoControl</value>
   </data>
   <data name="buttonEjectDisk.Location" type="System.Drawing.Point, System.Drawing">
-    <value>273, 88</value>
-  </data>
-  <data name="buttonEjectDisk.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>182, 57</value>
   </data>
   <data name="buttonEjectDisk.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 37</value>
+    <value>80, 24</value>
   </data>
   <data name="buttonEjectDisk.TabIndex" type="System.Int32, mscorlib">
     <value>45</value>
@@ -1749,13 +1639,13 @@
     <value>Top</value>
   </data>
   <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>4, 4</value>
   </data>
   <data name="panel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 138</value>
+    <value>656, 90</value>
   </data>
   <data name="panel3.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -1776,13 +1666,10 @@
     <value>Fill</value>
   </data>
   <data name="panel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 144</value>
-  </data>
-  <data name="panel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 94</value>
   </data>
   <data name="panel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 248</value>
+    <value>656, 158</value>
   </data>
   <data name="panel4.TabIndex" type="System.Int32, mscorlib">
     <value>47</value>
@@ -1803,16 +1690,13 @@
     <value>Bottom</value>
   </data>
   <data name="panel5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 392</value>
-  </data>
-  <data name="panel5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 252</value>
   </data>
   <data name="panel5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 6, 0, 0</value>
+    <value>0, 4, 0, 0</value>
   </data>
   <data name="panel5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>984, 49</value>
+    <value>656, 32</value>
   </data>
   <data name="panel5.TabIndex" type="System.Int32, mscorlib">
     <value>48</value>
@@ -1835,14 +1719,11 @@
   <data name="panel6.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="panel6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="panel6.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="panel6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>996, 656</value>
+    <value>664, 424</value>
   </data>
   <data name="panel6.TabIndex" type="System.Int32, mscorlib">
     <value>49</value>
@@ -1866,10 +1747,10 @@
     <value>50</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>996, 691</value>
+    <value>664, 449</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -2268,11 +2149,8 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAACAAQAAwAMAAPAPAAA=
 </value>
   </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>1009, 719</value>
+    <value>680, 487</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>
@@ -2398,31 +2276,31 @@
     <value>plainBackgroundPainter1</value>
   </data>
   <data name="&gt;&gt;plainBackgroundPainter1.Type" xml:space="preserve">
-    <value>ProgressODoom.PlainBackgroundPainter, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.PlainBackgroundPainter, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;styledBorderPainter1.Name" xml:space="preserve">
     <value>styledBorderPainter1</value>
   </data>
   <data name="&gt;&gt;styledBorderPainter1.Type" xml:space="preserve">
-    <value>ProgressODoom.StyledBorderPainter, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.StyledBorderPainter, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;plainProgressPainter1.Name" xml:space="preserve">
     <value>plainProgressPainter1</value>
   </data>
   <data name="&gt;&gt;plainProgressPainter1.Type" xml:space="preserve">
-    <value>ProgressODoom.PlainProgressPainter, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.PlainProgressPainter, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;gradientGlossPainter1.Name" xml:space="preserve">
     <value>gradientGlossPainter1</value>
   </data>
   <data name="&gt;&gt;gradientGlossPainter1.Type" xml:space="preserve">
-    <value>ProgressODoom.GradientGlossPainter, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.GradientGlossPainter, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;plainProgressPainter2.Name" xml:space="preserve">
     <value>plainProgressPainter2</value>
   </data>
   <data name="&gt;&gt;plainProgressPainter2.Type" xml:space="preserve">
-    <value>ProgressODoom.PlainProgressPainter, ProgressODoom, Version=1.0.6789.37646, Culture=neutral, PublicKeyToken=null</value>
+    <value>ProgressODoom.PlainProgressPainter, ProgressODoom, Version=1.0.7709.32791, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
     <value>toolTip1</value>

--- a/CUETools/frmCUETools.Designer.cs
+++ b/CUETools/frmCUETools.Designer.cs
@@ -185,7 +185,6 @@ namespace JDP {
             // statusStrip1
             // 
             resources.ApplyResources(this.statusStrip1, "statusStrip1");
-            this.statusStrip1.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1,
             this.toolStripStatusLabelProcessed,
@@ -384,7 +383,6 @@ namespace JDP {
             // 
             resources.ApplyResources(this.toolStripCorrectorFormat, "toolStripCorrectorFormat");
             this.toolStripCorrectorFormat.BackColor = System.Drawing.Color.Transparent;
-            this.toolStripCorrectorFormat.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.toolStripCorrectorFormat.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripButtonCorrectorOverwrite,
             this.toolStripDropDownButtonCorrectorMode,
@@ -634,14 +632,13 @@ namespace JDP {
             // 
             resources.ApplyResources(this.toolStripInput, "toolStripInput");
             this.toolStripInput.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStripInput.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.toolStripInput.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabelInput,
             this.toolStripSplitButtonInputBrowser});
             this.toolStripInput.Name = "toolStripInput";
             this.toolStripInput.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStripInput.Click += new System.EventHandler(this.toolStripInput_Click);
             this.toolStripInput.TabStop = true;
+            this.toolStripInput.Click += new System.EventHandler(this.toolStripInput_Click);
             // 
             // toolStripLabelInput
             // 
@@ -692,15 +689,14 @@ namespace JDP {
             resources.ApplyResources(this.toolStripOutput, "toolStripOutput");
             this.toolStripOutput.GripMargin = new System.Windows.Forms.Padding(0);
             this.toolStripOutput.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStripOutput.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.toolStripOutput.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabelOutput,
             this.toolStripSplitButtonOutputBrowser});
             this.toolStripOutput.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.toolStripOutput.Name = "toolStripOutput";
             this.toolStripOutput.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStripOutput.Click += new System.EventHandler(this.toolStripOutput_Click);
             this.toolStripOutput.TabStop = true;
+            this.toolStripOutput.Click += new System.EventHandler(this.toolStripOutput_Click);
             // 
             // toolStripLabelOutput
             // 
@@ -898,7 +894,6 @@ namespace JDP {
             this.toolStripMenu.BackColor = System.Drawing.SystemColors.GradientInactiveCaption;
             resources.ApplyResources(this.toolStripMenu, "toolStripMenu");
             this.toolStripMenu.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStripMenu.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.toolStripMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripDropDownButtonProfile,
             this.toolStripSeparator3,
@@ -997,7 +992,6 @@ namespace JDP {
             // 
             // contextMenuStripFileTree
             // 
-            this.contextMenuStripFileTree.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.contextMenuStripFileTree.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.SelectedNodeName,
             this.toolStripSeparator2,

--- a/CUETools/frmCUETools.resx
+++ b/CUETools/frmCUETools.resx
@@ -126,19 +126,19 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="toolStripStatusLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 46</value>
+    <value>429, 24</value>
   </data>
   <data name="toolStripStatusLabel1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
   </data>
   <data name="toolStripStatusLabelProcessed.Size" type="System.Drawing.Size, System.Drawing">
-    <value>4, 46</value>
+    <value>4, 24</value>
   </data>
   <data name="toolStripStatusLabelCTDB.Font" type="System.Drawing.Font, System.Drawing">
     <value>Segoe UI, 9pt</value>
   </data>
   <data name="toolStripStatusLabelCTDB.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 46</value>
+    <value>39, 24</value>
   </data>
   <data name="toolStripStatusLabelCTDB.Text" xml:space="preserve">
     <value>77</value>
@@ -154,7 +154,7 @@
     <value>White</value>
   </data>
   <data name="toolStripStatusLabelAR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 46</value>
+    <value>44, 24</value>
   </data>
   <data name="toolStripStatusLabelAR.Text" xml:space="preserve">
     <value>55</value>
@@ -163,7 +163,7 @@
     <value>Album found in AccurateRip database.</value>
   </data>
   <data name="toolStripProgressBar2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 45</value>
+    <value>120, 23</value>
   </data>
   <data name="toolStripProgressBar2.ToolTipText" xml:space="preserve">
     <value>Disk progress</value>
@@ -172,7 +172,7 @@
     <value>0, 0</value>
   </data>
   <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 51</value>
+    <value>684, 29</value>
   </data>
   <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -214,7 +214,7 @@
     <value>Courier New, 8.25pt</value>
   </data>
   <data name="textBatchReport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 533</value>
+    <value>0, 330</value>
   </data>
   <data name="textBatchReport.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -226,7 +226,7 @@
     <value>Both</value>
   </data>
   <data name="textBatchReport.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 195</value>
+    <value>684, 118</value>
   </data>
   <data name="textBatchReport.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -246,6 +246,21 @@
   <data name="&gt;&gt;textBatchReport.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="fileSystemTreeView1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="fileSystemTreeView1.Indent" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="fileSystemTreeView1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="fileSystemTreeView1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>192, 304</value>
+  </data>
+  <data name="fileSystemTreeView1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
   <data name="&gt;&gt;fileSystemTreeView1.Name" xml:space="preserve">
     <value>fileSystemTreeView1</value>
   </data>
@@ -262,16 +277,13 @@
     <value>Fill</value>
   </data>
   <data name="grpInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
-  </data>
-  <data name="grpInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="grpInput.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="grpInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>298, 523</value>
+    <value>198, 324</value>
   </data>
   <data name="grpInput.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -294,9 +306,264 @@
   <data name="tableLayoutPanel2.ColumnCount" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <metadata name="toolStripCorrectorFormat.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>3, 17</value>
+  <data name="tableLayoutPanelCUEStyle.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="rbTracks.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbTracks.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="rbTracks.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbTracks.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 40</value>
+  </data>
+  <data name="rbTracks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="rbTracks.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 20</value>
+  </data>
+  <data name="rbTracks.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="rbTracks.Text" xml:space="preserve">
+    <value>&amp;Tracks</value>
+  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>153, 8</value>
   </metadata>
+  <data name="rbTracks.ToolTip" xml:space="preserve">
+    <value>File per track. Gap handling can be selected in advanced settings.</value>
+  </data>
+  <data name="&gt;&gt;rbTracks.Name" xml:space="preserve">
+    <value>rbTracks</value>
+  </data>
+  <data name="&gt;&gt;rbTracks.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbTracks.Parent" xml:space="preserve">
+    <value>tableLayoutPanelCUEStyle</value>
+  </data>
+  <data name="&gt;&gt;rbTracks.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="rbEmbedCUE.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbEmbedCUE.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="rbEmbedCUE.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbEmbedCUE.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="rbEmbedCUE.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="rbEmbedCUE.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 20</value>
+  </data>
+  <data name="rbEmbedCUE.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="rbEmbedCUE.Text" xml:space="preserve">
+    <value>&amp;Embedded</value>
+  </data>
+  <data name="rbEmbedCUE.ToolTip" xml:space="preserve">
+    <value>Create single file with embedded CUE sheet.</value>
+  </data>
+  <data name="&gt;&gt;rbEmbedCUE.Name" xml:space="preserve">
+    <value>rbEmbedCUE</value>
+  </data>
+  <data name="&gt;&gt;rbEmbedCUE.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbEmbedCUE.Parent" xml:space="preserve">
+    <value>tableLayoutPanelCUEStyle</value>
+  </data>
+  <data name="&gt;&gt;rbEmbedCUE.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="rbSingleFile.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbSingleFile.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="rbSingleFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbSingleFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 20</value>
+  </data>
+  <data name="rbSingleFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 0</value>
+  </data>
+  <data name="rbSingleFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 20</value>
+  </data>
+  <data name="rbSingleFile.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="rbSingleFile.Text" xml:space="preserve">
+    <value>Image + CUE</value>
+  </data>
+  <data name="rbSingleFile.ToolTip" xml:space="preserve">
+    <value>Create single file + CUE sheet</value>
+  </data>
+  <data name="&gt;&gt;rbSingleFile.Name" xml:space="preserve">
+    <value>rbSingleFile</value>
+  </data>
+  <data name="&gt;&gt;rbSingleFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbSingleFile.Parent" xml:space="preserve">
+    <value>tableLayoutPanelCUEStyle</value>
+  </data>
+  <data name="&gt;&gt;rbSingleFile.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="checkBoxEditTags.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxEditTags.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="checkBoxEditTags.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="checkBoxEditTags.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 84</value>
+  </data>
+  <data name="checkBoxEditTags.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="checkBoxEditTags.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 16</value>
+  </data>
+  <data name="checkBoxEditTags.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 26</value>
+  </data>
+  <data name="checkBoxEditTags.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="checkBoxEditTags.ToolTip" xml:space="preserve">
+    <value>Edit Tags</value>
+  </data>
+  <data name="&gt;&gt;checkBoxEditTags.Name" xml:space="preserve">
+    <value>checkBoxEditTags</value>
+  </data>
+  <data name="&gt;&gt;checkBoxEditTags.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxEditTags.Parent" xml:space="preserve">
+    <value>tableLayoutPanelCUEStyle</value>
+  </data>
+  <data name="&gt;&gt;checkBoxEditTags.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>95, 84</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 16</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 26</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="checkBoxARVerifyOnEncode.ToolTip" xml:space="preserve">
+    <value>Verify using AccurateRip</value>
+  </data>
+  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Name" xml:space="preserve">
+    <value>checkBoxARVerifyOnEncode</value>
+  </data>
+  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Parent" xml:space="preserve">
+    <value>tableLayoutPanelCUEStyle</value>
+  </data>
+  <data name="&gt;&gt;checkBoxARVerifyOnEncode.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>47, 84</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 16</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 26</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="checkBoxCTDBVerifyOnEncode.ToolTip" xml:space="preserve">
+    <value>Verify using CTDB</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Name" xml:space="preserve">
+    <value>checkBoxCTDBVerifyOnEncode</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Parent" xml:space="preserve">
+    <value>tableLayoutPanelCUEStyle</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanelCUEStyle.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanelCUEStyle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="tableLayoutPanelCUEStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="tableLayoutPanelCUEStyle.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanelCUEStyle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 110</value>
+  </data>
+  <data name="tableLayoutPanelCUEStyle.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
   <data name="&gt;&gt;tableLayoutPanelCUEStyle.Name" xml:space="preserve">
     <value>tableLayoutPanelCUEStyle</value>
   </data>
@@ -312,6 +579,72 @@
   <data name="tableLayoutPanelCUEStyle.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="rbTracks" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbEmbedCUE" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbSingleFile" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="checkBoxEditTags" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxARVerifyOnEncode" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxCTDBVerifyOnEncode" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33.33332,Percent,33.33334,Percent,33.33334" /&gt;&lt;Rows Styles="Percent,18.18229,Percent,18.18229,Percent,18.18229,Percent,22.72658,Percent,22.72658" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
+  <metadata name="toolStripCorrectorFormat.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>3, 17</value>
+  </metadata>
+  <data name="toolStripCorrectorFormat.AutoSize" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="toolStripCorrectorFormat.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="toolStripButtonCorrectorOverwrite.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripButtonCorrectorOverwrite.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 20</value>
+  </data>
+  <data name="toolStripButtonCorrectorOverwrite.Text" xml:space="preserve">
+    <value>Overwrite</value>
+  </data>
+  <data name="toolStripMenuItemCorrectorModeLocateFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>169, 22</value>
+  </data>
+  <data name="toolStripMenuItemCorrectorModeLocateFiles.Text" xml:space="preserve">
+    <value>Locate files</value>
+  </data>
+  <data name="toolStripMenuItemCorrectorModeLocateFiles.ToolTipText" xml:space="preserve">
+    <value>Try to locate missing files automatically</value>
+  </data>
+  <data name="toolStripMenuItemCorrectorModeChangeExtension.Size" type="System.Drawing.Size, System.Drawing">
+    <value>169, 22</value>
+  </data>
+  <data name="toolStripMenuItemCorrectorModeChangeExtension.Text" xml:space="preserve">
+    <value>Change extension</value>
+  </data>
+  <data name="toolStripMenuItemCorrectorModeChangeExtension.ToolTipText" xml:space="preserve">
+    <value>Replace extension for audio files with this:</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorMode.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 19</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorMode.Text" xml:space="preserve">
+    <value>Locate files</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorFormat.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorFormat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 19</value>
+  </data>
+  <data name="toolStripDropDownButtonCorrectorFormat.Text" xml:space="preserve">
+    <value>flac</value>
+  </data>
+  <data name="toolStripCorrectorFormat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="toolStripCorrectorFormat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 1, 0</value>
+  </data>
+  <data name="toolStripCorrectorFormat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 110</value>
+  </data>
+  <data name="toolStripCorrectorFormat.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
   <data name="&gt;&gt;toolStripCorrectorFormat.Name" xml:space="preserve">
     <value>toolStripCorrectorFormat</value>
   </data>
@@ -323,6 +656,123 @@
   </data>
   <data name="&gt;&gt;toolStripCorrectorFormat.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="tableLayoutPanelVerifyMode.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="checkBoxSkipRecent.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxSkipRecent.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="checkBoxSkipRecent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="checkBoxSkipRecent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>99, 3</value>
+  </data>
+  <data name="checkBoxSkipRecent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 29</value>
+  </data>
+  <data name="checkBoxSkipRecent.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="checkBoxSkipRecent.ToolTip" xml:space="preserve">
+    <value>Skip recently verified</value>
+  </data>
+  <data name="&gt;&gt;checkBoxSkipRecent.Name" xml:space="preserve">
+    <value>checkBoxSkipRecent</value>
+  </data>
+  <data name="&gt;&gt;checkBoxSkipRecent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxSkipRecent.Parent" xml:space="preserve">
+    <value>tableLayoutPanelVerifyMode</value>
+  </data>
+  <data name="&gt;&gt;checkBoxSkipRecent.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.Location" type="System.Drawing.Point, System.Drawing">
+    <value>51, 3</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 29</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="checkBoxVerifyUseLocal.ToolTip" xml:space="preserve">
+    <value>Use local database</value>
+  </data>
+  <data name="&gt;&gt;checkBoxVerifyUseLocal.Name" xml:space="preserve">
+    <value>checkBoxVerifyUseLocal</value>
+  </data>
+  <data name="&gt;&gt;checkBoxVerifyUseLocal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxVerifyUseLocal.Parent" xml:space="preserve">
+    <value>tableLayoutPanelVerifyMode</value>
+  </data>
+  <data name="&gt;&gt;checkBoxVerifyUseLocal.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="checkBoxCTDBVerify.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxCTDBVerify.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="checkBoxCTDBVerify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="checkBoxCTDBVerify.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="checkBoxCTDBVerify.Size" type="System.Drawing.Size, System.Drawing">
+    <value>42, 29</value>
+  </data>
+  <data name="checkBoxCTDBVerify.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="checkBoxCTDBVerify.ToolTip" xml:space="preserve">
+    <value>Use CTDB (CUETools database)</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerify.Name" xml:space="preserve">
+    <value>checkBoxCTDBVerify</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerify.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerify.Parent" xml:space="preserve">
+    <value>tableLayoutPanelVerifyMode</value>
+  </data>
+  <data name="&gt;&gt;checkBoxCTDBVerify.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanelVerifyMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanelVerifyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="tableLayoutPanelVerifyMode.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="tableLayoutPanelVerifyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 110</value>
+  </data>
+  <data name="tableLayoutPanelVerifyMode.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanelVerifyMode.Name" xml:space="preserve">
     <value>tableLayoutPanelVerifyMode</value>
@@ -337,22 +787,16 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanelVerifyMode.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="checkBoxSkipRecent" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxVerifyUseLocal" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxCTDBVerify" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333,Absolute,30" /&gt;&lt;Rows Styles="Percent,32.72727,Percent,67.27273" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="checkBoxSkipRecent" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxVerifyUseLocal" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxCTDBVerify" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333,Absolute,20" /&gt;&lt;Rows Styles="Percent,32.72727,Percent,67.27273" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="groupBoxMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="groupBoxMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>259, 163</value>
-  </data>
-  <data name="groupBoxMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="groupBoxMode.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>173, 101</value>
   </data>
   <data name="groupBoxMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 211</value>
+    <value>150, 130</value>
   </data>
   <data name="groupBoxMode.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -372,6 +816,21 @@
   <data name="&gt;&gt;groupBoxMode.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="buttonEncoderSettings.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>Flat</value>
+  </data>
+  <data name="buttonEncoderSettings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="buttonEncoderSettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 115</value>
+  </data>
+  <data name="buttonEncoderSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 20</value>
+  </data>
+  <data name="buttonEncoderSettings.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
   <data name="&gt;&gt;buttonEncoderSettings.Name" xml:space="preserve">
     <value>buttonEncoderSettings</value>
   </data>
@@ -383,6 +842,33 @@
   </data>
   <data name="&gt;&gt;buttonEncoderSettings.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="labelEncoderMaxMode.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="labelEncoderMaxMode.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="labelEncoderMaxMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelEncoderMaxMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>100, 174</value>
+  </data>
+  <data name="labelEncoderMaxMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="labelEncoderMaxMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 13</value>
+  </data>
+  <data name="labelEncoderMaxMode.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="labelEncoderMaxMode.Text" xml:space="preserve">
+    <value>320</value>
+  </data>
+  <data name="labelEncoderMaxMode.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
   </data>
   <data name="&gt;&gt;labelEncoderMaxMode.Name" xml:space="preserve">
     <value>labelEncoderMaxMode</value>
@@ -396,6 +882,33 @@
   <data name="&gt;&gt;labelEncoderMaxMode.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="labelEncoderMinMode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelEncoderMinMode.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="labelEncoderMinMode.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="labelEncoderMinMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelEncoderMinMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 174</value>
+  </data>
+  <data name="labelEncoderMinMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="labelEncoderMinMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>25, 13</value>
+  </data>
+  <data name="labelEncoderMinMode.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="labelEncoderMinMode.Text" xml:space="preserve">
+    <value>128</value>
+  </data>
   <data name="&gt;&gt;labelEncoderMinMode.Name" xml:space="preserve">
     <value>labelEncoderMinMode</value>
   </data>
@@ -407,6 +920,33 @@
   </data>
   <data name="&gt;&gt;labelEncoderMinMode.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="labelEncoderMode.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="labelEncoderMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelEncoderMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 174</value>
+  </data>
+  <data name="labelEncoderMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="labelEncoderMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 15</value>
+  </data>
+  <data name="labelEncoderMode.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="labelEncoderMode.Text" xml:space="preserve">
+    <value>256</value>
+  </data>
+  <data name="labelEncoderMode.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopCenter</value>
+  </data>
+  <data name="labelEncoderMode.ToolTip" xml:space="preserve">
+    <value>For lossless formats, the level of compression. For lossy formats, target quality</value>
   </data>
   <data name="&gt;&gt;labelEncoderMode.Name" xml:space="preserve">
     <value>labelEncoderMode</value>
@@ -420,6 +960,24 @@
   <data name="&gt;&gt;labelEncoderMode.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="trackBarEncoderMode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="trackBarEncoderMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="trackBarEncoderMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 143</value>
+  </data>
+  <data name="trackBarEncoderMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="trackBarEncoderMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 45</value>
+  </data>
+  <data name="trackBarEncoderMode.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
   <data name="&gt;&gt;trackBarEncoderMode.Name" xml:space="preserve">
     <value>trackBarEncoderMode</value>
   </data>
@@ -431,6 +989,21 @@
   </data>
   <data name="&gt;&gt;trackBarEncoderMode.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="comboBoxEncoder.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboBoxEncoder.Location" type="System.Drawing.Point, System.Drawing">
+    <value>38, 116</value>
+  </data>
+  <data name="comboBoxEncoder.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 21</value>
+  </data>
+  <data name="comboBoxEncoder.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="comboBoxEncoder.ToolTip" xml:space="preserve">
+    <value>Encoder to use</value>
   </data>
   <data name="&gt;&gt;comboBoxEncoder.Name" xml:space="preserve">
     <value>comboBoxEncoder</value>
@@ -444,6 +1017,27 @@
   <data name="&gt;&gt;comboBoxEncoder.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="radioButtonAudioNone.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonAudioNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="radioButtonAudioNone.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 53</value>
+  </data>
+  <data name="radioButtonAudioNone.Size" type="System.Drawing.Size, System.Drawing">
+    <value>50, 17</value>
+  </data>
+  <data name="radioButtonAudioNone.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="radioButtonAudioNone.Text" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="radioButtonAudioNone.ToolTip" xml:space="preserve">
+    <value>No audio output</value>
+  </data>
   <data name="&gt;&gt;radioButtonAudioNone.Name" xml:space="preserve">
     <value>radioButtonAudioNone</value>
   </data>
@@ -455,6 +1049,27 @@
   </data>
   <data name="&gt;&gt;radioButtonAudioNone.ZOrder" xml:space="preserve">
     <value>6</value>
+  </data>
+  <data name="radioButtonAudioLossy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonAudioLossy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="radioButtonAudioLossy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 36</value>
+  </data>
+  <data name="radioButtonAudioLossy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="radioButtonAudioLossy.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="radioButtonAudioLossy.Text" xml:space="preserve">
+    <value>Lossy</value>
+  </data>
+  <data name="radioButtonAudioLossy.ToolTip" xml:space="preserve">
+    <value>Codecs which reduce audio quality</value>
   </data>
   <data name="&gt;&gt;radioButtonAudioLossy.Name" xml:space="preserve">
     <value>radioButtonAudioLossy</value>
@@ -468,6 +1083,27 @@
   <data name="&gt;&gt;radioButtonAudioLossy.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="radioButtonAudioLossless.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="radioButtonAudioLossless.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="radioButtonAudioLossless.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 19</value>
+  </data>
+  <data name="radioButtonAudioLossless.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 17</value>
+  </data>
+  <data name="radioButtonAudioLossless.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="radioButtonAudioLossless.Text" xml:space="preserve">
+    <value>Lossless</value>
+  </data>
+  <data name="radioButtonAudioLossless.ToolTip" xml:space="preserve">
+    <value>Codecs that preserve bit-exact audio copy</value>
+  </data>
   <data name="&gt;&gt;radioButtonAudioLossless.Name" xml:space="preserve">
     <value>radioButtonAudioLossless</value>
   </data>
@@ -480,6 +1116,24 @@
   <data name="&gt;&gt;radioButtonAudioLossless.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
+  <data name="labelFormat.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelFormat.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelFormat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>11, 90</value>
+  </data>
+  <data name="labelFormat.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="labelFormat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="labelFormat.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
   <data name="&gt;&gt;labelFormat.Name" xml:space="preserve">
     <value>labelFormat</value>
   </data>
@@ -491,6 +1145,21 @@
   </data>
   <data name="&gt;&gt;labelFormat.ZOrder" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="comboBoxAudioFormat.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboBoxAudioFormat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>38, 88</value>
+  </data>
+  <data name="comboBoxAudioFormat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 21</value>
+  </data>
+  <data name="comboBoxAudioFormat.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="comboBoxAudioFormat.ToolTip" xml:space="preserve">
+    <value>Audio file format</value>
   </data>
   <data name="&gt;&gt;comboBoxAudioFormat.Name" xml:space="preserve">
     <value>comboBoxAudioFormat</value>
@@ -508,16 +1177,10 @@
     <value>Fill</value>
   </data>
   <data name="grpAudioOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>494, 163</value>
-  </data>
-  <data name="grpAudioOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="grpAudioOutput.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>329, 101</value>
   </data>
   <data name="grpAudioOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 314</value>
+    <value>148, 194</value>
   </data>
   <data name="grpAudioOutput.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -544,13 +1207,10 @@
     <value>NoControl</value>
   </data>
   <data name="pictureBoxMotd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 384</value>
-  </data>
-  <data name="pictureBoxMotd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 237</value>
   </data>
   <data name="pictureBoxMotd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>247, 144</value>
+    <value>164, 90</value>
   </data>
   <data name="pictureBoxMotd.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
     <value>Zoom</value>
@@ -580,13 +1240,13 @@
     <value>NoControl</value>
   </data>
   <data name="labelOutputTemplate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 78</value>
+    <value>0, 48</value>
   </data>
   <data name="labelOutputTemplate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="labelOutputTemplate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 40</value>
+    <value>97, 24</value>
   </data>
   <data name="labelOutputTemplate.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -613,20 +1273,14 @@
     <value>Fill</value>
   </data>
   <data name="comboBoxOutputFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 83</value>
-  </data>
-  <data name="comboBoxOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>100, 51</value>
   </data>
   <data name="comboBoxOutputFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>549, 29</value>
+    <value>365, 21</value>
   </data>
   <data name="comboBoxOutputFormat.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>153, 8</value>
-  </metadata>
   <data name="comboBoxOutputFormat.ToolTip" xml:space="preserve">
     <value>Template for output files (foobar2000 format)</value>
   </data>
@@ -646,13 +1300,10 @@
     <value>Fill</value>
   </data>
   <data name="txtInputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 5</value>
-  </data>
-  <data name="txtInputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>100, 3</value>
   </data>
   <data name="txtInputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>549, 27</value>
+    <value>365, 21</value>
   </data>
   <data name="txtInputPath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -676,13 +1327,10 @@
     <value>Fill</value>
   </data>
   <data name="txtOutputPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 44</value>
-  </data>
-  <data name="txtOutputPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>100, 27</value>
   </data>
   <data name="txtOutputPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>549, 27</value>
+    <value>365, 21</value>
   </data>
   <data name="txtOutputPath.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -708,6 +1356,45 @@
   <data name="toolStripInput.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <data name="toolStripLabelInput.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 21</value>
+  </data>
+  <data name="toolStripLabelInput.Text" xml:space="preserve">
+    <value>Input:</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserFiles.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 22</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserFiles.Text" xml:space="preserve">
+    <value>Folder browser</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserMulti.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 22</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserMulti.Text" xml:space="preserve">
+    <value>Multiselect Browser</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserDrag.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 22</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserDrag.Text" xml:space="preserve">
+    <value>Drag'n'drop mode</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserHide.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 22</value>
+  </data>
+  <data name="toolStripMenuItemInputBrowserHide.Text" xml:space="preserve">
+    <value>Hide browser</value>
+  </data>
+  <data name="toolStripSplitButtonInputBrowser.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripSplitButtonInputBrowser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 21</value>
+  </data>
+  <data name="toolStripSplitButtonInputBrowser.Text" xml:space="preserve">
+    <value>Open/close input browser</value>
+  </data>
   <data name="toolStripInput.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -715,7 +1402,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="toolStripInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 39</value>
+    <value>97, 24</value>
   </data>
   <data name="toolStripInput.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -741,14 +1428,47 @@
   <data name="toolStripOutput.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <data name="toolStripLabelOutput.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 24</value>
+  </data>
+  <data name="toolStripLabelOutput.Text" xml:space="preserve">
+    <value>Output:</value>
+  </data>
+  <data name="toolStripMenuItemOutputBrowse.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 22</value>
+  </data>
+  <data name="toolStripMenuItemOutputBrowse.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="toolStripMenuItemOutputManual.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 22</value>
+  </data>
+  <data name="toolStripMenuItemOutputManual.Text" xml:space="preserve">
+    <value>Manual</value>
+  </data>
+  <data name="toolStripMenuItemOutputTemplate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>143, 22</value>
+  </data>
+  <data name="toolStripMenuItemOutputTemplate.Text" xml:space="preserve">
+    <value>Use template</value>
+  </data>
+  <data name="toolStripSplitButtonOutputBrowser.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripSplitButtonOutputBrowser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 21</value>
+  </data>
+  <data name="toolStripSplitButtonOutputBrowser.Text" xml:space="preserve">
+    <value>toolStripSplitButtonOutputBrowser</value>
+  </data>
   <data name="toolStripOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 39</value>
+    <value>0, 24</value>
   </data>
   <data name="toolStripOutput.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="toolStripOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 39</value>
+    <value>97, 24</value>
   </data>
   <data name="toolStripOutput.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -772,7 +1492,7 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanelPaths.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
+    <value>3, 17</value>
   </data>
   <data name="tableLayoutPanelPaths.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -781,7 +1501,7 @@
     <value>3</value>
   </data>
   <data name="tableLayoutPanelPaths.Size" type="System.Drawing.Size, System.Drawing">
-    <value>704, 118</value>
+    <value>468, 72</value>
   </data>
   <data name="tableLayoutPanelPaths.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -805,16 +1525,10 @@
     <value>Fill</value>
   </data>
   <data name="grpOutputPathGeneration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
-  </data>
-  <data name="grpOutputPathGeneration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="grpOutputPathGeneration.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="grpOutputPathGeneration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>712, 148</value>
+    <value>474, 92</value>
   </data>
   <data name="grpOutputPathGeneration.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -834,6 +1548,21 @@
   <data name="&gt;&gt;grpOutputPathGeneration.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="comboBoxScript.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="comboBoxScript.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 94</value>
+  </data>
+  <data name="comboBoxScript.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 21</value>
+  </data>
+  <data name="comboBoxScript.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="comboBoxScript.ToolTip" xml:space="preserve">
+    <value>Run custom script</value>
+  </data>
   <data name="&gt;&gt;comboBoxScript.Name" xml:space="preserve">
     <value>comboBoxScript</value>
   </data>
@@ -845,6 +1574,27 @@
   </data>
   <data name="&gt;&gt;comboBoxScript.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="rbActionCorrectFilenames.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbActionCorrectFilenames.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbActionCorrectFilenames.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 71</value>
+  </data>
+  <data name="rbActionCorrectFilenames.Size" type="System.Drawing.Size, System.Drawing">
+    <value>109, 17</value>
+  </data>
+  <data name="rbActionCorrectFilenames.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="rbActionCorrectFilenames.Text" xml:space="preserve">
+    <value>Correct filenames</value>
+  </data>
+  <data name="rbActionCorrectFilenames.ToolTip" xml:space="preserve">
+    <value>Correct filenames in CUE sheets</value>
   </data>
   <data name="&gt;&gt;rbActionCorrectFilenames.Name" xml:space="preserve">
     <value>rbActionCorrectFilenames</value>
@@ -858,6 +1608,27 @@
   <data name="&gt;&gt;rbActionCorrectFilenames.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="rbActionCreateCUESheet.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbActionCreateCUESheet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbActionCreateCUESheet.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 54</value>
+  </data>
+  <data name="rbActionCreateCUESheet.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 17</value>
+  </data>
+  <data name="rbActionCreateCUESheet.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="rbActionCreateCUESheet.Text" xml:space="preserve">
+    <value>Create CUE Sheet</value>
+  </data>
+  <data name="rbActionCreateCUESheet.ToolTip" xml:space="preserve">
+    <value>Create a CUE sheet for sets of tracks and extract embedded CUE sheets</value>
+  </data>
   <data name="&gt;&gt;rbActionCreateCUESheet.Name" xml:space="preserve">
     <value>rbActionCreateCUESheet</value>
   </data>
@@ -870,6 +1641,27 @@
   <data name="&gt;&gt;rbActionCreateCUESheet.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="rbActionVerify.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbActionVerify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbActionVerify.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 37</value>
+  </data>
+  <data name="rbActionVerify.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 17</value>
+  </data>
+  <data name="rbActionVerify.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="rbActionVerify.Text" xml:space="preserve">
+    <value>&amp;Verify</value>
+  </data>
+  <data name="rbActionVerify.ToolTip" xml:space="preserve">
+    <value>Contact the AccurateRip database for validation and compare the image against database</value>
+  </data>
   <data name="&gt;&gt;rbActionVerify.Name" xml:space="preserve">
     <value>rbActionVerify</value>
   </data>
@@ -881,6 +1673,27 @@
   </data>
   <data name="&gt;&gt;rbActionVerify.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="rbActionEncode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rbActionEncode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="rbActionEncode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 20</value>
+  </data>
+  <data name="rbActionEncode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 17</value>
+  </data>
+  <data name="rbActionEncode.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="rbActionEncode.Text" xml:space="preserve">
+    <value>&amp;Encode</value>
+  </data>
+  <data name="rbActionEncode.ToolTip" xml:space="preserve">
+    <value>Convert to another format. Don't contact the AccurateRip database for validation</value>
   </data>
   <data name="&gt;&gt;rbActionEncode.Name" xml:space="preserve">
     <value>rbActionEncode</value>
@@ -898,16 +1711,10 @@
     <value>Fill</value>
   </data>
   <data name="grpAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 163</value>
-  </data>
-  <data name="grpAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="grpAction.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 101</value>
   </data>
   <data name="grpAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>247, 211</value>
+    <value>164, 130</value>
   </data>
   <data name="grpAction.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -926,6 +1733,240 @@
   </data>
   <data name="&gt;&gt;grpAction.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="labelPregap.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelPregap.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="labelPregap.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelPregap.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="labelPregap.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="labelPregap.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="labelPregap.Text" xml:space="preserve">
+    <value>Pregap</value>
+  </data>
+  <data name="labelPregap.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;labelPregap.Name" xml:space="preserve">
+    <value>labelPregap</value>
+  </data>
+  <data name="&gt;&gt;labelPregap.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelPregap.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;labelPregap.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblWriteOffset.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblWriteOffset.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="lblWriteOffset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblWriteOffset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 46</value>
+  </data>
+  <data name="lblWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 24</value>
+  </data>
+  <data name="lblWriteOffset.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="lblWriteOffset.Text" xml:space="preserve">
+    <value>Offset</value>
+  </data>
+  <data name="lblWriteOffset.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;lblWriteOffset.Name" xml:space="preserve">
+    <value>lblWriteOffset</value>
+  </data>
+  <data name="&gt;&gt;lblWriteOffset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblWriteOffset.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;lblWriteOffset.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="txtPreGapLength.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="txtPreGapLength.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Consolas, 8.25pt</value>
+  </data>
+  <data name="txtPreGapLength.Location" type="System.Drawing.Point, System.Drawing">
+    <value>84, 3</value>
+  </data>
+  <data name="txtPreGapLength.Mask" xml:space="preserve">
+    <value>00:00:00</value>
+  </data>
+  <data name="txtPreGapLength.PromptChar" type="System.Char, mscorlib" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="txtPreGapLength.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 20</value>
+  </data>
+  <data name="txtPreGapLength.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="txtPreGapLength.ToolTip" xml:space="preserve">
+    <value>Pregap is a certain amount of silence or hidden audio before track one. Normally it is known from the CUE sheet, but if converting/verifying a set of separate tracks without a CUE sheet you might want to set this.</value>
+  </data>
+  <data name="&gt;&gt;txtPreGapLength.Name" xml:space="preserve">
+    <value>txtPreGapLength</value>
+  </data>
+  <data name="&gt;&gt;txtPreGapLength.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MaskedTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtPreGapLength.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;txtPreGapLength.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="labelDataTrack.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="labelDataTrack.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="labelDataTrack.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="labelDataTrack.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 23</value>
+  </data>
+  <data name="labelDataTrack.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="labelDataTrack.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="labelDataTrack.Text" xml:space="preserve">
+    <value>Data track</value>
+  </data>
+  <data name="labelDataTrack.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;labelDataTrack.Name" xml:space="preserve">
+    <value>labelDataTrack</value>
+  </data>
+  <data name="&gt;&gt;labelDataTrack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;labelDataTrack.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;labelDataTrack.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="txtDataTrackLength.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="txtDataTrackLength.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Consolas, 8.25pt</value>
+  </data>
+  <data name="txtDataTrackLength.Location" type="System.Drawing.Point, System.Drawing">
+    <value>84, 26</value>
+  </data>
+  <data name="txtDataTrackLength.Mask" xml:space="preserve">
+    <value>00:00:00</value>
+  </data>
+  <data name="txtDataTrackLength.PromptChar" type="System.Char, mscorlib" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="txtDataTrackLength.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 20</value>
+  </data>
+  <data name="txtDataTrackLength.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="txtDataTrackLength.ToolTip" xml:space="preserve">
+    <value>Not used for normal music CDs. Enhanced CDs with data tracks cannot be found in database unless you know the length of the data track. You can often find it in EAC log. If EAC log is found next to the CUE sheet, it will be parsed automatically and you won't have to enter anything here.</value>
+  </data>
+  <data name="&gt;&gt;txtDataTrackLength.Name" xml:space="preserve">
+    <value>txtDataTrackLength</value>
+  </data>
+  <data name="&gt;&gt;txtDataTrackLength.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MaskedTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtDataTrackLength.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;txtDataTrackLength.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="textBoxOffset.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="textBoxOffset.Location" type="System.Drawing.Point, System.Drawing">
+    <value>84, 49</value>
+  </data>
+  <data name="textBoxOffset.MaxLength" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="textBoxOffset.Size" type="System.Drawing.Size, System.Drawing">
+    <value>57, 21</value>
+  </data>
+  <data name="textBoxOffset.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="textBoxOffset.Text" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="textBoxOffset.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="&gt;&gt;textBoxOffset.Name" xml:space="preserve">
+    <value>textBoxOffset</value>
+  </data>
+  <data name="&gt;&gt;textBoxOffset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textBoxOffset.Parent" xml:space="preserve">
+    <value>tableLayoutPanel4</value>
+  </data>
+  <data name="&gt;&gt;textBoxOffset.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="tableLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="tableLayoutPanel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 70</value>
+  </data>
+  <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="&gt;&gt;tableLayoutPanel4.Name" xml:space="preserve">
     <value>tableLayoutPanel4</value>
@@ -946,16 +1987,10 @@
     <value>Fill</value>
   </data>
   <data name="grpExtra.Location" type="System.Drawing.Point, System.Drawing">
-    <value>259, 384</value>
-  </data>
-  <data name="grpExtra.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="grpExtra.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>173, 237</value>
   </data>
   <data name="grpExtra.Size" type="System.Drawing.Size, System.Drawing">
-    <value>227, 144</value>
+    <value>150, 90</value>
   </data>
   <data name="grpExtra.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -975,6 +2010,27 @@
   <data name="&gt;&gt;grpExtra.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="btnConvert.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="btnConvert.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnConvert.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="btnConvert.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="btnConvert.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 26</value>
+  </data>
+  <data name="btnConvert.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="btnConvert.Text" xml:space="preserve">
+    <value>&amp;Go</value>
+  </data>
   <data name="&gt;&gt;btnConvert.Name" xml:space="preserve">
     <value>btnConvert</value>
   </data>
@@ -986,6 +2042,27 @@
   </data>
   <data name="&gt;&gt;btnConvert.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="btnStop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnStop.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="btnStop.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="btnStop.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="btnStop.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="btnStop.Text" xml:space="preserve">
+    <value>&amp;Stop</value>
+  </data>
+  <data name="btnStop.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="&gt;&gt;btnStop.Name" xml:space="preserve">
     <value>btnStop</value>
@@ -999,6 +2076,30 @@
   <data name="&gt;&gt;btnStop.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="btnResume.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnResume.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnResume.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 0</value>
+  </data>
+  <data name="btnResume.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="btnResume.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="btnResume.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnResume.Text" xml:space="preserve">
+    <value>&amp;Resume</value>
+  </data>
+  <data name="btnResume.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="&gt;&gt;btnResume.Name" xml:space="preserve">
     <value>btnResume</value>
   </data>
@@ -1010,6 +2111,30 @@
   </data>
   <data name="&gt;&gt;btnResume.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="btnPause.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnPause.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnPause.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 0</value>
+  </data>
+  <data name="btnPause.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="btnPause.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 25</value>
+  </data>
+  <data name="btnPause.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnPause.Text" xml:space="preserve">
+    <value>&amp;Pause</value>
+  </data>
+  <data name="btnPause.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="&gt;&gt;btnPause.Name" xml:space="preserve">
     <value>btnPause</value>
@@ -1027,13 +2152,13 @@
     <value>Fill</value>
   </data>
   <data name="panelGo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>508, 487</value>
+    <value>338, 301</value>
   </data>
   <data name="panelGo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>18, 5, 18, 5</value>
+    <value>12, 3, 12, 3</value>
   </data>
   <data name="panelGo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 41</value>
+    <value>130, 26</value>
   </data>
   <data name="panelGo.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1054,7 +2179,7 @@
     <value>Fill</value>
   </data>
   <data name="tableLayoutPanel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>306, 0</value>
+    <value>204, 0</value>
   </data>
   <data name="tableLayoutPanel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
@@ -1063,7 +2188,7 @@
     <value>4</value>
   </data>
   <data name="tableLayoutPanel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>720, 533</value>
+    <value>480, 330</value>
   </data>
   <data name="tableLayoutPanel2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1096,7 +2221,7 @@
     <value>2</value>
   </data>
   <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 728</value>
+    <value>684, 448</value>
   </data>
   <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1114,13 +2239,13 @@
     <value>0</value>
   </data>
   <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="textBatchReport" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="grpInput" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,720" /&gt;&lt;Rows Styles="Absolute,533,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="textBatchReport" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="grpInput" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="tableLayoutPanel2" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,Absolute,480" /&gt;&lt;Rows Styles="Absolute,330,Percent,100" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="toolStripContainer1.ContentPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="toolStripContainer1.ContentPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 728</value>
+    <value>684, 448</value>
   </data>
   <data name="&gt;&gt;toolStripContainer1.ContentPanel.Name" xml:space="preserve">
     <value>toolStripContainer1.ContentPanel</value>
@@ -1138,7 +2263,7 @@
     <value>Fill</value>
   </data>
   <data name="toolStripContainer1.LeftToolStripPanel.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>48, 0</value>
+    <value>32, 0</value>
   </data>
   <data name="&gt;&gt;toolStripContainer1.LeftToolStripPanel.Name" xml:space="preserve">
     <value>toolStripContainer1.LeftToolStripPanel</value>
@@ -1155,9 +2280,6 @@
   <data name="toolStripContainer1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="toolStripContainer1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="&gt;&gt;toolStripContainer1.RightToolStripPanel.Name" xml:space="preserve">
     <value>toolStripContainer1.RightToolStripPanel</value>
   </data>
@@ -1171,7 +2293,7 @@
     <value>2</value>
   </data>
   <data name="toolStripContainer1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 811</value>
+    <value>684, 502</value>
   </data>
   <data name="toolStripContainer1.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1185,11 +2307,89 @@
   <data name="toolStripMenu.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>None</value>
   </data>
+  <data name="toolStripTextBoxAddProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>100, 23</value>
+  </data>
+  <data name="toolStripTextBoxAddProfile.ToolTipText" xml:space="preserve">
+    <value>Create a new profile</value>
+  </data>
+  <data name="toolStripMenuItemDeleteProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 22</value>
+  </data>
+  <data name="toolStripMenuItemDeleteProfile.Text" xml:space="preserve">
+    <value>delete</value>
+  </data>
+  <data name="toolStripMenuItemDeleteProfile.ToolTipText" xml:space="preserve">
+    <value>Delete current profile</value>
+  </data>
+  <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>157, 6</value>
+  </data>
+  <data name="defaultToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 22</value>
+  </data>
+  <data name="defaultToolStripMenuItem.Text" xml:space="preserve">
+    <value>default</value>
+  </data>
+  <data name="toolStripDropDownButtonProfile.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripDropDownButtonProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 22</value>
+  </data>
+  <data name="toolStripDropDownButtonProfile.Text" xml:space="preserve">
+    <value>default</value>
+  </data>
+  <data name="toolStripDropDownButtonProfile.ToolTipText" xml:space="preserve">
+    <value>Profile</value>
+  </data>
+  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>6, 25</value>
+  </data>
+  <data name="toolStripButtonAbout.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripButtonAbout.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 22</value>
+  </data>
+  <data name="toolStripButtonAbout.Text" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="toolStripButtonHelp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripButtonHelp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 22</value>
+  </data>
+  <data name="toolStripButtonHelp.Text" xml:space="preserve">
+    <value>CUETools website</value>
+  </data>
+  <data name="toolStripButtonSettings.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripButtonSettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 22</value>
+  </data>
+  <data name="toolStripButtonSettings.Text" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="toolStripButtonShowLog.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="toolStripButtonShowLog.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="toolStripButtonShowLog.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 22</value>
+  </data>
+  <data name="toolStripButtonShowLog.Text" xml:space="preserve">
+    <value>Batch log</value>
+  </data>
   <data name="toolStripMenu.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
   <data name="toolStripMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 32</value>
+    <value>684, 25</value>
   </data>
   <data name="toolStripMenu.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1230,1883 +2430,71 @@
   <data name="&gt;&gt;toolStripContainer1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="fileSystemTreeView1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="fileSystemTreeView1.Indent" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="fileSystemTreeView1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 27</value>
-  </data>
-  <data name="fileSystemTreeView1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="fileSystemTreeView1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 491</value>
-  </data>
-  <data name="fileSystemTreeView1.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;fileSystemTreeView1.Name" xml:space="preserve">
-    <value>fileSystemTreeView1</value>
-  </data>
-  <data name="&gt;&gt;fileSystemTreeView1.Type" xml:space="preserve">
-    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;fileSystemTreeView1.Parent" xml:space="preserve">
-    <value>grpInput</value>
-  </data>
-  <data name="&gt;&gt;fileSystemTreeView1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.ColumnCount" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.Name" xml:space="preserve">
-    <value>rbTracks</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.Name" xml:space="preserve">
-    <value>rbEmbedCUE</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.Name" xml:space="preserve">
-    <value>rbSingleFile</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.Name" xml:space="preserve">
-    <value>checkBoxEditTags</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Name" xml:space="preserve">
-    <value>checkBoxARVerifyOnEncode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Name" xml:space="preserve">
-    <value>checkBoxCTDBVerifyOnEncode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.RowCount" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 181</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelCUEStyle.Name" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelCUEStyle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelCUEStyle.Parent" xml:space="preserve">
-    <value>groupBoxMode</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelCUEStyle.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanelCUEStyle.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="rbTracks" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbEmbedCUE" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbSingleFile" Row="1" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="checkBoxEditTags" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxARVerifyOnEncode" Row="4" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxCTDBVerifyOnEncode" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33.33332,Percent,33.33334,Percent,33.33334" /&gt;&lt;Rows Styles="Percent,18.18229,Percent,18.18229,Percent,18.18229,Percent,22.72658,Percent,22.72658" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>153, 8</value>
-  </metadata>
-  <data name="rbTracks.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbTracks.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="rbTracks.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbTracks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 64</value>
-  </data>
-  <data name="rbTracks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="rbTracks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>211, 32</value>
-  </data>
-  <data name="rbTracks.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="rbTracks.Text" xml:space="preserve">
-    <value>&amp;Tracks</value>
-  </data>
-  <data name="rbTracks.ToolTip" xml:space="preserve">
-    <value>File per track. Gap handling can be selected in advanced settings.</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.Name" xml:space="preserve">
-    <value>rbTracks</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;rbTracks.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="rbEmbedCUE.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbEmbedCUE.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="rbEmbedCUE.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbEmbedCUE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 0</value>
-  </data>
-  <data name="rbEmbedCUE.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="rbEmbedCUE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>211, 32</value>
-  </data>
-  <data name="rbEmbedCUE.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="rbEmbedCUE.Text" xml:space="preserve">
-    <value>&amp;Embedded</value>
-  </data>
-  <data name="rbEmbedCUE.ToolTip" xml:space="preserve">
-    <value>Create single file with embedded CUE sheet.</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.Name" xml:space="preserve">
-    <value>rbEmbedCUE</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;rbEmbedCUE.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="rbSingleFile.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbSingleFile.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="rbSingleFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbSingleFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 32</value>
-  </data>
-  <data name="rbSingleFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="rbSingleFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>211, 32</value>
-  </data>
-  <data name="rbSingleFile.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="rbSingleFile.Text" xml:space="preserve">
-    <value>Image + CUE</value>
-  </data>
-  <data name="rbSingleFile.ToolTip" xml:space="preserve">
-    <value>Create single file + CUE sheet</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.Name" xml:space="preserve">
-    <value>rbSingleFile</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;rbSingleFile.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="checkBoxEditTags.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxEditTags.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="checkBoxEditTags.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxEditTags.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 137</value>
-  </data>
-  <data name="checkBoxEditTags.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="checkBoxEditTags.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 26</value>
-  </data>
-  <data name="checkBoxEditTags.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 44</value>
-  </data>
-  <data name="checkBoxEditTags.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="checkBoxEditTags.ToolTip" xml:space="preserve">
-    <value>Edit Tags</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.Name" xml:space="preserve">
-    <value>checkBoxEditTags</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;checkBoxEditTags.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>145, 137</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 26</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 44</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="checkBoxARVerifyOnEncode.ToolTip" xml:space="preserve">
-    <value>Verify using AccurateRip</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Name" xml:space="preserve">
-    <value>checkBoxARVerifyOnEncode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;checkBoxARVerifyOnEncode.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>72, 137</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 26</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 44</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="checkBoxCTDBVerifyOnEncode.ToolTip" xml:space="preserve">
-    <value>Verify using CTDB</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Name" xml:space="preserve">
-    <value>checkBoxCTDBVerifyOnEncode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.Parent" xml:space="preserve">
-    <value>tableLayoutPanelCUEStyle</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerifyOnEncode.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <metadata name="toolStripCorrectorFormat.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>3, 17</value>
-  </metadata>
-  <data name="toolStripCorrectorFormat.AutoSize" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="toolStripCorrectorFormat.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="toolStripCorrectorFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
-  </data>
-  <data name="toolStripCorrectorFormat.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 2, 0</value>
-  </data>
-  <data name="toolStripCorrectorFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 181</value>
-  </data>
-  <data name="toolStripCorrectorFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;toolStripCorrectorFormat.Name" xml:space="preserve">
-    <value>toolStripCorrectorFormat</value>
-  </data>
-  <data name="&gt;&gt;toolStripCorrectorFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripCorrectorFormat.Parent" xml:space="preserve">
-    <value>groupBoxMode</value>
-  </data>
-  <data name="&gt;&gt;toolStripCorrectorFormat.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="toolStripButtonCorrectorOverwrite.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripButtonCorrectorOverwrite.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 29</value>
-  </data>
-  <data name="toolStripButtonCorrectorOverwrite.Text" xml:space="preserve">
-    <value>Overwrite</value>
-  </data>
-  <data name="toolStripDropDownButtonCorrectorMode.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripDropDownButtonCorrectorMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 29</value>
-  </data>
-  <data name="toolStripDropDownButtonCorrectorMode.Text" xml:space="preserve">
-    <value>Locate files</value>
-  </data>
-  <data name="toolStripMenuItemCorrectorModeLocateFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 30</value>
-  </data>
-  <data name="toolStripMenuItemCorrectorModeLocateFiles.Text" xml:space="preserve">
-    <value>Locate files</value>
-  </data>
-  <data name="toolStripMenuItemCorrectorModeLocateFiles.ToolTipText" xml:space="preserve">
-    <value>Try to locate missing files automatically</value>
-  </data>
-  <data name="toolStripMenuItemCorrectorModeChangeExtension.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 30</value>
-  </data>
-  <data name="toolStripMenuItemCorrectorModeChangeExtension.Text" xml:space="preserve">
-    <value>Change extension</value>
-  </data>
-  <data name="toolStripMenuItemCorrectorModeChangeExtension.ToolTipText" xml:space="preserve">
-    <value>Replace extension for audio files with this:</value>
-  </data>
-  <data name="toolStripDropDownButtonCorrectorFormat.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripDropDownButtonCorrectorFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 29</value>
-  </data>
-  <data name="toolStripDropDownButtonCorrectorFormat.Text" xml:space="preserve">
-    <value>flac</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.ColumnCount" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.Name" xml:space="preserve">
-    <value>checkBoxSkipRecent</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.Parent" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.Name" xml:space="preserve">
-    <value>checkBoxVerifyUseLocal</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.Parent" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.Name" xml:space="preserve">
-    <value>checkBoxCTDBVerify</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.Parent" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.RowCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 181</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelVerifyMode.Name" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelVerifyMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelVerifyMode.Parent" xml:space="preserve">
-    <value>groupBoxMode</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanelVerifyMode.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="tableLayoutPanelVerifyMode.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="checkBoxSkipRecent" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxVerifyUseLocal" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="checkBoxCTDBVerify" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333,Absolute,30" /&gt;&lt;Rows Styles="Percent,32.72727,Percent,67.27273" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="checkBoxSkipRecent.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxSkipRecent.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="checkBoxSkipRecent.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxSkipRecent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 5</value>
-  </data>
-  <data name="checkBoxSkipRecent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="checkBoxSkipRecent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 49</value>
-  </data>
-  <data name="checkBoxSkipRecent.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="checkBoxSkipRecent.ToolTip" xml:space="preserve">
-    <value>Skip recently verified</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.Name" xml:space="preserve">
-    <value>checkBoxSkipRecent</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.Parent" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxSkipRecent.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.Location" type="System.Drawing.Point, System.Drawing">
-    <value>77, 5</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 49</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="checkBoxVerifyUseLocal.ToolTip" xml:space="preserve">
-    <value>Use local database</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.Name" xml:space="preserve">
-    <value>checkBoxVerifyUseLocal</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.Parent" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxVerifyUseLocal.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="checkBoxCTDBVerify.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxCTDBVerify.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="checkBoxCTDBVerify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxCTDBVerify.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
-  </data>
-  <data name="checkBoxCTDBVerify.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="checkBoxCTDBVerify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 49</value>
-  </data>
-  <data name="checkBoxCTDBVerify.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="checkBoxCTDBVerify.ToolTip" xml:space="preserve">
-    <value>Use CTDB (CUETools database)</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.Name" xml:space="preserve">
-    <value>checkBoxCTDBVerify</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.Parent" xml:space="preserve">
-    <value>tableLayoutPanelVerifyMode</value>
-  </data>
-  <data name="&gt;&gt;checkBoxCTDBVerify.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="buttonEncoderSettings.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-    <value>Flat</value>
-  </data>
-  <data name="buttonEncoderSettings.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonEncoderSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 186</value>
-  </data>
-  <data name="buttonEncoderSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="buttonEncoderSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 32</value>
-  </data>
-  <data name="buttonEncoderSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;buttonEncoderSettings.Name" xml:space="preserve">
-    <value>buttonEncoderSettings</value>
-  </data>
-  <data name="&gt;&gt;buttonEncoderSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonEncoderSettings.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;buttonEncoderSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="labelEncoderMaxMode.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="labelEncoderMaxMode.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8.25pt</value>
-  </data>
-  <data name="labelEncoderMaxMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelEncoderMaxMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 281</value>
-  </data>
-  <data name="labelEncoderMaxMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelEncoderMaxMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 21</value>
-  </data>
-  <data name="labelEncoderMaxMode.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="labelEncoderMaxMode.Text" xml:space="preserve">
-    <value>320</value>
-  </data>
-  <data name="labelEncoderMaxMode.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopRight</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMaxMode.Name" xml:space="preserve">
-    <value>labelEncoderMaxMode</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMaxMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMaxMode.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMaxMode.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="labelEncoderMinMode.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelEncoderMinMode.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="labelEncoderMinMode.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8.25pt</value>
-  </data>
-  <data name="labelEncoderMinMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelEncoderMinMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 281</value>
-  </data>
-  <data name="labelEncoderMinMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelEncoderMinMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 21</value>
-  </data>
-  <data name="labelEncoderMinMode.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="labelEncoderMinMode.Text" xml:space="preserve">
-    <value>128</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMinMode.Name" xml:space="preserve">
-    <value>labelEncoderMinMode</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMinMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMinMode.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMinMode.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="labelEncoderMode.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8.25pt</value>
-  </data>
-  <data name="labelEncoderMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelEncoderMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 281</value>
-  </data>
-  <data name="labelEncoderMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="labelEncoderMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 24</value>
-  </data>
-  <data name="labelEncoderMode.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="labelEncoderMode.Text" xml:space="preserve">
-    <value>256</value>
-  </data>
-  <data name="labelEncoderMode.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopCenter</value>
-  </data>
-  <data name="labelEncoderMode.ToolTip" xml:space="preserve">
-    <value>For lossless formats, the level of compression. For lossy formats, target quality</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMode.Name" xml:space="preserve">
-    <value>labelEncoderMode</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMode.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;labelEncoderMode.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="trackBarEncoderMode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="trackBarEncoderMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="trackBarEncoderMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 231</value>
-  </data>
-  <data name="trackBarEncoderMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="trackBarEncoderMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>213, 69</value>
-  </data>
-  <data name="trackBarEncoderMode.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;trackBarEncoderMode.Name" xml:space="preserve">
-    <value>trackBarEncoderMode</value>
-  </data>
-  <data name="&gt;&gt;trackBarEncoderMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;trackBarEncoderMode.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;trackBarEncoderMode.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="comboBoxEncoder.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboBoxEncoder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>57, 187</value>
-  </data>
-  <data name="comboBoxEncoder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="comboBoxEncoder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 29</value>
-  </data>
-  <data name="comboBoxEncoder.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="comboBoxEncoder.ToolTip" xml:space="preserve">
-    <value>Encoder to use</value>
-  </data>
-  <data name="&gt;&gt;comboBoxEncoder.Name" xml:space="preserve">
-    <value>comboBoxEncoder</value>
-  </data>
-  <data name="&gt;&gt;comboBoxEncoder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboBoxEncoder.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;comboBoxEncoder.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="radioButtonAudioNone.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButtonAudioNone.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="radioButtonAudioNone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 86</value>
-  </data>
-  <data name="radioButtonAudioNone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="radioButtonAudioNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 25</value>
-  </data>
-  <data name="radioButtonAudioNone.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="radioButtonAudioNone.Text" xml:space="preserve">
-    <value>None</value>
-  </data>
-  <data name="radioButtonAudioNone.ToolTip" xml:space="preserve">
-    <value>No audio output</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioNone.Name" xml:space="preserve">
-    <value>radioButtonAudioNone</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioNone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioNone.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioNone.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="radioButtonAudioLossy.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButtonAudioLossy.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="radioButtonAudioLossy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 58</value>
-  </data>
-  <data name="radioButtonAudioLossy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="radioButtonAudioLossy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 25</value>
-  </data>
-  <data name="radioButtonAudioLossy.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="radioButtonAudioLossy.Text" xml:space="preserve">
-    <value>Lossy</value>
-  </data>
-  <data name="radioButtonAudioLossy.ToolTip" xml:space="preserve">
-    <value>Codecs which reduce audio quality</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossy.Name" xml:space="preserve">
-    <value>radioButtonAudioLossy</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossy.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossy.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="radioButtonAudioLossless.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButtonAudioLossless.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="radioButtonAudioLossless.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 31</value>
-  </data>
-  <data name="radioButtonAudioLossless.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="radioButtonAudioLossless.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 25</value>
-  </data>
-  <data name="radioButtonAudioLossless.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="radioButtonAudioLossless.Text" xml:space="preserve">
-    <value>Lossless</value>
-  </data>
-  <data name="radioButtonAudioLossless.ToolTip" xml:space="preserve">
-    <value>Codecs that preserve bit-exact audio copy</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossless.Name" xml:space="preserve">
-    <value>radioButtonAudioLossless</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossless.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossless.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;radioButtonAudioLossless.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="labelFormat.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelFormat.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 145</value>
-  </data>
-  <data name="labelFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="labelFormat.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>24, 26</value>
-  </data>
-  <data name="labelFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 26</value>
-  </data>
-  <data name="labelFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;labelFormat.Name" xml:space="preserve">
-    <value>labelFormat</value>
-  </data>
-  <data name="&gt;&gt;labelFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelFormat.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;labelFormat.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="comboBoxAudioFormat.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboBoxAudioFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>57, 142</value>
-  </data>
-  <data name="comboBoxAudioFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="comboBoxAudioFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 29</value>
-  </data>
-  <data name="comboBoxAudioFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="comboBoxAudioFormat.ToolTip" xml:space="preserve">
-    <value>Audio file format</value>
-  </data>
-  <data name="&gt;&gt;comboBoxAudioFormat.Name" xml:space="preserve">
-    <value>comboBoxAudioFormat</value>
-  </data>
-  <data name="&gt;&gt;comboBoxAudioFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboBoxAudioFormat.Parent" xml:space="preserve">
-    <value>grpAudioOutput</value>
-  </data>
-  <data name="&gt;&gt;comboBoxAudioFormat.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="toolStripLabelInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 36</value>
-  </data>
-  <data name="toolStripLabelInput.Text" xml:space="preserve">
-    <value>Input:</value>
-  </data>
-  <data name="toolStripSplitButtonInputBrowser.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripSplitButtonInputBrowser.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 36</value>
-  </data>
-  <data name="toolStripSplitButtonInputBrowser.Text" xml:space="preserve">
-    <value>Open/close input browser</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 30</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserFiles.Text" xml:space="preserve">
-    <value>Folder browser</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserMulti.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 30</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserMulti.Text" xml:space="preserve">
-    <value>Multiselect Browser</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserDrag.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 30</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserDrag.Text" xml:space="preserve">
-    <value>Drag'n'drop mode</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserHide.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 30</value>
-  </data>
-  <data name="toolStripMenuItemInputBrowserHide.Text" xml:space="preserve">
-    <value>Hide browser</value>
-  </data>
-  <data name="toolStripLabelOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 39</value>
-  </data>
-  <data name="toolStripLabelOutput.Text" xml:space="preserve">
-    <value>Output:</value>
-  </data>
-  <data name="toolStripSplitButtonOutputBrowser.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripSplitButtonOutputBrowser.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 36</value>
-  </data>
-  <data name="toolStripSplitButtonOutputBrowser.Text" xml:space="preserve">
-    <value>toolStripSplitButtonOutputBrowser</value>
-  </data>
-  <data name="toolStripMenuItemOutputBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 30</value>
-  </data>
-  <data name="toolStripMenuItemOutputBrowse.Text" xml:space="preserve">
-    <value>Browse</value>
-  </data>
-  <data name="toolStripMenuItemOutputManual.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 30</value>
-  </data>
-  <data name="toolStripMenuItemOutputManual.Text" xml:space="preserve">
-    <value>Manual</value>
-  </data>
-  <data name="toolStripMenuItemOutputTemplate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 30</value>
-  </data>
-  <data name="toolStripMenuItemOutputTemplate.Text" xml:space="preserve">
-    <value>Use template</value>
-  </data>
-  <data name="comboBoxScript.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="comboBoxScript.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 152</value>
-  </data>
-  <data name="comboBoxScript.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="comboBoxScript.Size" type="System.Drawing.Size, System.Drawing">
-    <value>224, 29</value>
-  </data>
-  <data name="comboBoxScript.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="comboBoxScript.ToolTip" xml:space="preserve">
-    <value>Run custom script</value>
-  </data>
-  <data name="&gt;&gt;comboBoxScript.Name" xml:space="preserve">
-    <value>comboBoxScript</value>
-  </data>
-  <data name="&gt;&gt;comboBoxScript.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comboBoxScript.Parent" xml:space="preserve">
-    <value>grpAction</value>
-  </data>
-  <data name="&gt;&gt;comboBoxScript.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="rbActionCorrectFilenames.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbActionCorrectFilenames.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbActionCorrectFilenames.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 115</value>
-  </data>
-  <data name="rbActionCorrectFilenames.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="rbActionCorrectFilenames.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 25</value>
-  </data>
-  <data name="rbActionCorrectFilenames.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="rbActionCorrectFilenames.Text" xml:space="preserve">
-    <value>Correct filenames</value>
-  </data>
-  <data name="rbActionCorrectFilenames.ToolTip" xml:space="preserve">
-    <value>Correct filenames in CUE sheets</value>
-  </data>
-  <data name="&gt;&gt;rbActionCorrectFilenames.Name" xml:space="preserve">
-    <value>rbActionCorrectFilenames</value>
-  </data>
-  <data name="&gt;&gt;rbActionCorrectFilenames.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbActionCorrectFilenames.Parent" xml:space="preserve">
-    <value>grpAction</value>
-  </data>
-  <data name="&gt;&gt;rbActionCorrectFilenames.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="rbActionCreateCUESheet.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbActionCreateCUESheet.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbActionCreateCUESheet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 87</value>
-  </data>
-  <data name="rbActionCreateCUESheet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="rbActionCreateCUESheet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 25</value>
-  </data>
-  <data name="rbActionCreateCUESheet.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="rbActionCreateCUESheet.Text" xml:space="preserve">
-    <value>Create CUE Sheet</value>
-  </data>
-  <data name="rbActionCreateCUESheet.ToolTip" xml:space="preserve">
-    <value>Create a CUE sheet for sets of tracks and extract embedded CUE sheets</value>
-  </data>
-  <data name="&gt;&gt;rbActionCreateCUESheet.Name" xml:space="preserve">
-    <value>rbActionCreateCUESheet</value>
-  </data>
-  <data name="&gt;&gt;rbActionCreateCUESheet.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbActionCreateCUESheet.Parent" xml:space="preserve">
-    <value>grpAction</value>
-  </data>
-  <data name="&gt;&gt;rbActionCreateCUESheet.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="rbActionVerify.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbActionVerify.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbActionVerify.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 60</value>
-  </data>
-  <data name="rbActionVerify.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="rbActionVerify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 25</value>
-  </data>
-  <data name="rbActionVerify.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="rbActionVerify.Text" xml:space="preserve">
-    <value>&amp;Verify</value>
-  </data>
-  <data name="rbActionVerify.ToolTip" xml:space="preserve">
-    <value>Contact the AccurateRip database for validation and compare the image against database</value>
-  </data>
-  <data name="&gt;&gt;rbActionVerify.Name" xml:space="preserve">
-    <value>rbActionVerify</value>
-  </data>
-  <data name="&gt;&gt;rbActionVerify.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbActionVerify.Parent" xml:space="preserve">
-    <value>grpAction</value>
-  </data>
-  <data name="&gt;&gt;rbActionVerify.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="rbActionEncode.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rbActionEncode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="rbActionEncode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 32</value>
-  </data>
-  <data name="rbActionEncode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="rbActionEncode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 25</value>
-  </data>
-  <data name="rbActionEncode.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="rbActionEncode.Text" xml:space="preserve">
-    <value>&amp;Encode</value>
-  </data>
-  <data name="rbActionEncode.ToolTip" xml:space="preserve">
-    <value>Convert to another format. Don't contact the AccurateRip database for validation</value>
-  </data>
-  <data name="&gt;&gt;rbActionEncode.Name" xml:space="preserve">
-    <value>rbActionEncode</value>
-  </data>
-  <data name="&gt;&gt;rbActionEncode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rbActionEncode.Parent" xml:space="preserve">
-    <value>grpAction</value>
-  </data>
-  <data name="&gt;&gt;rbActionEncode.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="tableLayoutPanel4.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.Name" xml:space="preserve">
-    <value>labelPregap</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.Name" xml:space="preserve">
-    <value>lblWriteOffset</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.Name" xml:space="preserve">
-    <value>txtPreGapLength</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MaskedTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.Name" xml:space="preserve">
-    <value>labelDataTrack</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.Name" xml:space="preserve">
-    <value>txtDataTrackLength</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MaskedTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.Name" xml:space="preserve">
-    <value>textBoxOffset</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tableLayoutPanel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tableLayoutPanel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
-  </data>
-  <data name="tableLayoutPanel4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="tableLayoutPanel4.RowCount" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>219, 114</value>
-  </data>
-  <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel4.Name" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel4.Parent" xml:space="preserve">
-    <value>grpExtra</value>
-  </data>
-  <data name="&gt;&gt;tableLayoutPanel4.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tableLayoutPanel4.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="labelPregap" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblWriteOffset" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtPreGapLength" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="labelDataTrack" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtDataTrackLength" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="textBoxOffset" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,56.75676,Percent,43.24324" /&gt;&lt;Rows Styles="Percent,33.33333,Percent,33.33333,Percent,33.33333" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="labelPregap.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelPregap.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelPregap.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelPregap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 0</value>
-  </data>
-  <data name="labelPregap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="labelPregap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 38</value>
-  </data>
-  <data name="labelPregap.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="labelPregap.Text" xml:space="preserve">
-    <value>Pregap</value>
-  </data>
-  <data name="labelPregap.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.Name" xml:space="preserve">
-    <value>labelPregap</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;labelPregap.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="lblWriteOffset.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="lblWriteOffset.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="lblWriteOffset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="lblWriteOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 76</value>
-  </data>
-  <data name="lblWriteOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="lblWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 38</value>
-  </data>
-  <data name="lblWriteOffset.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="lblWriteOffset.Text" xml:space="preserve">
-    <value>Offset</value>
-  </data>
-  <data name="lblWriteOffset.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.Name" xml:space="preserve">
-    <value>lblWriteOffset</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;lblWriteOffset.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="txtPreGapLength.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="txtPreGapLength.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Consolas, 8.25pt</value>
-  </data>
-  <data name="txtPreGapLength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 5</value>
-  </data>
-  <data name="txtPreGapLength.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="txtPreGapLength.Mask" xml:space="preserve">
-    <value>00:00:00</value>
-  </data>
-  <data name="txtPreGapLength.PromptChar" type="System.Char, mscorlib" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtPreGapLength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 27</value>
-  </data>
-  <data name="txtPreGapLength.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="txtPreGapLength.ToolTip" xml:space="preserve">
-    <value>Pregap is a certain amount of silence or hidden audio before track one. Normally it is known from the CUE sheet, but if converting/verifying a set of separate tracks without a CUE sheet you might want to set this.</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.Name" xml:space="preserve">
-    <value>txtPreGapLength</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MaskedTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;txtPreGapLength.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="labelDataTrack.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelDataTrack.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="labelDataTrack.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelDataTrack.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 38</value>
-  </data>
-  <data name="labelDataTrack.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="labelDataTrack.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 38</value>
-  </data>
-  <data name="labelDataTrack.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="labelDataTrack.Text" xml:space="preserve">
-    <value>Data track</value>
-  </data>
-  <data name="labelDataTrack.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.Name" xml:space="preserve">
-    <value>labelDataTrack</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;labelDataTrack.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="txtDataTrackLength.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="txtDataTrackLength.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Consolas, 8.25pt</value>
-  </data>
-  <data name="txtDataTrackLength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 43</value>
-  </data>
-  <data name="txtDataTrackLength.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="txtDataTrackLength.Mask" xml:space="preserve">
-    <value>00:00:00</value>
-  </data>
-  <data name="txtDataTrackLength.PromptChar" type="System.Char, mscorlib" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtDataTrackLength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 27</value>
-  </data>
-  <data name="txtDataTrackLength.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="txtDataTrackLength.ToolTip" xml:space="preserve">
-    <value>Not used for normal music CDs. Enhanced CDs with data tracks cannot be found in database unless you know the length of the data track. You can often find it in EAC log. If EAC log is found next to the CUE sheet, it will be parsed automatically and you won't have to enter anything here.</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.Name" xml:space="preserve">
-    <value>txtDataTrackLength</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MaskedTextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;txtDataTrackLength.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="textBoxOffset.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="textBoxOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>128, 81</value>
-  </data>
-  <data name="textBoxOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="textBoxOffset.MaxLength" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="textBoxOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 27</value>
-  </data>
-  <data name="textBoxOffset.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="textBoxOffset.Text" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="textBoxOffset.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Right</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.Name" xml:space="preserve">
-    <value>textBoxOffset</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.Parent" xml:space="preserve">
-    <value>tableLayoutPanel4</value>
-  </data>
-  <data name="&gt;&gt;textBoxOffset.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="btnConvert.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="btnConvert.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnConvert.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="btnConvert.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="btnConvert.Size" type="System.Drawing.Size, System.Drawing">
-    <value>194, 41</value>
-  </data>
-  <data name="btnConvert.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="btnConvert.Text" xml:space="preserve">
-    <value>&amp;Go</value>
-  </data>
-  <data name="&gt;&gt;btnConvert.Name" xml:space="preserve">
-    <value>btnConvert</value>
-  </data>
-  <data name="&gt;&gt;btnConvert.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnConvert.Parent" xml:space="preserve">
-    <value>panelGo</value>
-  </data>
-  <data name="&gt;&gt;btnConvert.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="btnStop.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnStop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="btnStop.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="btnStop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 40</value>
-  </data>
-  <data name="btnStop.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="btnStop.Text" xml:space="preserve">
-    <value>&amp;Stop</value>
-  </data>
-  <data name="btnStop.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;btnStop.Name" xml:space="preserve">
-    <value>btnStop</value>
-  </data>
-  <data name="&gt;&gt;btnStop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnStop.Parent" xml:space="preserve">
-    <value>panelGo</value>
-  </data>
-  <data name="&gt;&gt;btnStop.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="btnResume.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnResume.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnResume.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 0</value>
-  </data>
-  <data name="btnResume.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="btnResume.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 40</value>
-  </data>
-  <data name="btnResume.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="btnResume.Text" xml:space="preserve">
-    <value>&amp;Resume</value>
-  </data>
-  <data name="btnResume.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;btnResume.Name" xml:space="preserve">
-    <value>btnResume</value>
-  </data>
-  <data name="&gt;&gt;btnResume.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnResume.Parent" xml:space="preserve">
-    <value>panelGo</value>
-  </data>
-  <data name="&gt;&gt;btnResume.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="btnPause.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="btnPause.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnPause.Location" type="System.Drawing.Point, System.Drawing">
-    <value>97, 0</value>
-  </data>
-  <data name="btnPause.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="btnPause.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 40</value>
-  </data>
-  <data name="btnPause.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="btnPause.Text" xml:space="preserve">
-    <value>&amp;Pause</value>
-  </data>
-  <data name="btnPause.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;btnPause.Name" xml:space="preserve">
-    <value>btnPause</value>
-  </data>
-  <data name="&gt;&gt;btnPause.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnPause.Parent" xml:space="preserve">
-    <value>panelGo</value>
-  </data>
-  <data name="&gt;&gt;btnPause.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="toolStripDropDownButtonProfile.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripDropDownButtonProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 29</value>
-  </data>
-  <data name="toolStripDropDownButtonProfile.Text" xml:space="preserve">
-    <value>default</value>
-  </data>
-  <data name="toolStripDropDownButtonProfile.ToolTipText" xml:space="preserve">
-    <value>Profile</value>
-  </data>
-  <data name="toolStripTextBoxAddProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 31</value>
-  </data>
-  <data name="toolStripTextBoxAddProfile.ToolTipText" xml:space="preserve">
-    <value>Create a new profile</value>
-  </data>
-  <data name="toolStripMenuItemDeleteProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>172, 30</value>
-  </data>
-  <data name="toolStripMenuItemDeleteProfile.Text" xml:space="preserve">
-    <value>delete</value>
-  </data>
-  <data name="toolStripMenuItemDeleteProfile.ToolTipText" xml:space="preserve">
-    <value>Delete current profile</value>
-  </data>
-  <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>169, 6</value>
-  </data>
-  <data name="defaultToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>172, 30</value>
-  </data>
-  <data name="defaultToolStripMenuItem.Text" xml:space="preserve">
-    <value>default</value>
-  </data>
-  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>6, 32</value>
-  </data>
-  <data name="toolStripButtonAbout.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripButtonAbout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 29</value>
-  </data>
-  <data name="toolStripButtonAbout.Text" xml:space="preserve">
-    <value>About</value>
-  </data>
-  <data name="toolStripButtonHelp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripButtonHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 29</value>
-  </data>
-  <data name="toolStripButtonHelp.Text" xml:space="preserve">
-    <value>CUETools website</value>
-  </data>
-  <data name="toolStripButtonSettings.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripButtonSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>28, 29</value>
-  </data>
-  <data name="toolStripButtonSettings.Text" xml:space="preserve">
-    <value>Settings</value>
-  </data>
-  <data name="toolStripButtonShowLog.ImageScaling" type="System.Windows.Forms.ToolStripItemImageScaling, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="toolStripButtonShowLog.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
-    <value>Magenta</value>
-  </data>
-  <data name="toolStripButtonShowLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 29</value>
-  </data>
-  <data name="toolStripButtonShowLog.Text" xml:space="preserve">
-    <value>Batch log</value>
-  </data>
   <metadata name="contextMenuStripFileTree.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>424, 8</value>
   </metadata>
+  <data name="SelectedNodeName.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="SelectedNodeName.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="SelectedNodeName.Text" xml:space="preserve">
+    <value>Selected file</value>
+  </data>
+  <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>221, 6</value>
+  </data>
+  <data name="setAsMyMusicFolderToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="setAsMyMusicFolderToolStripMenuItem.Text" xml:space="preserve">
+    <value>Set as My Music folder</value>
+  </data>
+  <data name="resetToOriginalLocationToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="resetToOriginalLocationToolStripMenuItem.Text" xml:space="preserve">
+    <value>Reset to original location</value>
+  </data>
+  <data name="editMetadataToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="editMetadataToolStripMenuItem.Text" xml:space="preserve">
+    <value>Edit metadata</value>
+  </data>
+  <data name="addFolderToLocalDatabaseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="addFolderToLocalDatabaseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Add folder to local database</value>
+  </data>
+  <data name="removeItemFromDatabaseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="removeItemFromDatabaseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Remove from local database</value>
+  </data>
+  <data name="updateLocalDatabaseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="updateLocalDatabaseToolStripMenuItem.Text" xml:space="preserve">
+    <value>Update local database</value>
+  </data>
+  <data name="locateInExplorerToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>224, 22</value>
+  </data>
+  <data name="locateInExplorerToolStripMenuItem.Text" xml:space="preserve">
+    <value>Locate in explorer</value>
+  </data>
   <data name="contextMenuStripFileTree.Size" type="System.Drawing.Size, System.Drawing">
-    <value>311, 250</value>
+    <value>225, 186</value>
   </data>
   <data name="&gt;&gt;contextMenuStripFileTree.Name" xml:space="preserve">
     <value>contextMenuStripFileTree</value>
   </data>
   <data name="&gt;&gt;contextMenuStripFileTree.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="SelectedNodeName.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="SelectedNodeName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="SelectedNodeName.Text" xml:space="preserve">
-    <value>Selected file</value>
-  </data>
-  <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 6</value>
-  </data>
-  <data name="setAsMyMusicFolderToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="setAsMyMusicFolderToolStripMenuItem.Text" xml:space="preserve">
-    <value>Set as My Music folder</value>
-  </data>
-  <data name="resetToOriginalLocationToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="resetToOriginalLocationToolStripMenuItem.Text" xml:space="preserve">
-    <value>Reset to original location</value>
-  </data>
-  <data name="editMetadataToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="editMetadataToolStripMenuItem.Text" xml:space="preserve">
-    <value>Edit metadata</value>
-  </data>
-  <data name="addFolderToLocalDatabaseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="addFolderToLocalDatabaseToolStripMenuItem.Text" xml:space="preserve">
-    <value>Add folder to local database</value>
-  </data>
-  <data name="removeItemFromDatabaseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="removeItemFromDatabaseToolStripMenuItem.Text" xml:space="preserve">
-    <value>Remove from local database</value>
-  </data>
-  <data name="updateLocalDatabaseToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="updateLocalDatabaseToolStripMenuItem.Text" xml:space="preserve">
-    <value>Update local database</value>
-  </data>
-  <data name="locateInExplorerToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 30</value>
-  </data>
-  <data name="locateInExplorerToolStripMenuItem.Text" xml:space="preserve">
-    <value>Locate in explorer</value>
   </data>
   <metadata name="backgroundWorkerAddToLocalDB.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>845, 8</value>
@@ -3118,10 +2506,10 @@
     <value>30</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 21</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>1026, 811</value>
+    <value>684, 502</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8.25pt</value>
@@ -3523,11 +2911,8 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAACAAQAAwAMAAPAPAAA=
 </value>
   </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>1038, 833</value>
+    <value>699, 537</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>CUETools 2.1.7</value>


### PR DESCRIPTION
Restore the `ImageScalingSize` to default settings, which is (16, 16).
As a side effect of commit 16fccfe, the `ImageScalingSize` was set to
(24, 24), which led to over-sized images. In case of `toolStripInput`
and `toolStripOutput` the images were scaled non-proportionally and
looked squashed.
- CUETools:
  - Reset the `ImageScalingSize` of:
    `statusStrip1`
    `toolStripCorrectorFormat`
    `toolStripInput`
    `toolStripOutput`
    `toolStripMenu`
    `contextMenuStripFileTree`
  - Restore `toolStripProgressBar2.Size` to `120, 23`
  - Restore $this.MinimumSize to `699, 537`
- CUERipper:
  - Reset the `ImageScalingSize` of: `statusStrip1`
  - Restore `$this.MinimumSize` to `680, 487`
- The above mentioned modifications were applied and the rest of the
  changes result from saving the forms with Visual Studio.
- The CUETools and CUERipper forms are restored like they
  looked in 2.1.7
