### PR TITLE
Switch from freedb.org to gnudb.org

### DIFF
--- a/CUERipper/Properties/Settings.Designer.cs
+++ b/CUERipper/Properties/Settings.Designer.cs
@@ -25,7 +25,7 @@ namespace CUERipper.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("freedb.org")]
+        [global::System.Configuration.DefaultSettingValueAttribute("gnudb.gnudb.org")]
         public string MAIN_FREEDB_SITEADDRESS {
             get {
                 return ((string)(this["MAIN_FREEDB_SITEADDRESS"]));

--- a/CUERipper/Properties/Settings.settings
+++ b/CUERipper/Properties/Settings.settings
@@ -3,7 +3,7 @@
   <Profiles />
   <Settings>
     <Setting Name="MAIN_FREEDB_SITEADDRESS" Type="System.String" Scope="User">
-      <Value Profile="(Default)">freedb.org</Value>
+      <Value Profile="(Default)">gnudb.gnudb.org</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/CUERipper/app.config
+++ b/CUERipper/app.config
@@ -8,7 +8,7 @@
   <userSettings>
     <CUERipper.Properties.Settings>
       <setting name="MAIN_FREEDB_SITEADDRESS" serializeAs="String">
-        <value>freedb.org</value>
+        <value>gnudb.gnudb.org</value>
       </setting>
     </CUERipper.Properties.Settings>
   </userSettings>

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -914,7 +914,7 @@ namespace CUETools.Processor
                 m_freedb.Hostname = _config.advanced.FreedbDomain;
                 m_freedb.ClientName = "CUETools";
                 m_freedb.Version = CUEToolsVersion;
-                m_freedb.SetDefaultSiteAddress("freedb.org");
+                m_freedb.SetDefaultSiteAddress("gnudb.gnudb.org");
 
                 QueryResult queryResult;
                 QueryResultCollection coll;

--- a/Freedb/FreedbHelper.cs
+++ b/Freedb/FreedbHelper.cs
@@ -30,7 +30,7 @@ namespace Freedb
 	/// </summary>
 	public class FreedbHelper
 	{
-		public const string MAIN_FREEDB_ADDRESS = "freedb.freedb.org";
+		public const string MAIN_FREEDB_ADDRESS = "gnudb.gnudb.org";
 		public const string DEFAULT_ADDITIONAL_URL_INFO = "/~cddb/cddb.cgi";
 		public const string SUBMIT_ADDITIONAL_URL_INFO = "/~cddb/submit.cgi";
 		private Site m_mainSite = new Site(MAIN_FREEDB_ADDRESS,"http",DEFAULT_ADDITIONAL_URL_INFO);


### PR DESCRIPTION
[gnudb.org](https://gnudb.org) has continued to provide the Freedb.org database after
Freedb.org was shutdown.
