### PR TITLE
[CUERipper, CUETools] Various minor corrections

### DIFF
--- a/CUERipper/CUERipper.csproj
+++ b/CUERipper/CUERipper.csproj
@@ -43,8 +43,8 @@
     <PublisherName>Gregory S. Chudov</PublisherName>
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>index.html</WebPage>
-    <ApplicationRevision>2</ApplicationRevision>
-    <ApplicationVersion>2.1.4.0</ApplicationVersion>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/CUERipper/Properties/AssemblyInfo.cs
+++ b/CUERipper/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.9.0.0")]
-[assembly: AssemblyFileVersion("1.9.0.0")]
+[assembly: AssemblyVersion("2.1.7.0")]
+[assembly: AssemblyFileVersion("2.1.7.0")]

--- a/CUETools/CUETools.csproj
+++ b/CUETools/CUETools.csproj
@@ -40,8 +40,8 @@
     <PublisherName>CUETools</PublisherName>
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>publish.htm</WebPage>
-    <ApplicationRevision>7</ApplicationRevision>
-    <ApplicationVersion>2.0.3.%2a</ApplicationVersion>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/CUETools/Properties/AssemblyInfo.cs
+++ b/CUETools/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("CUE Tools")]
+[assembly: AssemblyTitle("CUETools")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("")]
+[assembly: AssemblyProduct("CUETools")]
 [assembly: AssemblyCopyright("Copyright 2006-2007 Moitah, 2008-2021 Greg Chudov")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/CUETools/frmCUETools.de-DE.resx
+++ b/CUETools/frmCUETools.de-DE.resx
@@ -130,9 +130,6 @@
   <data name="labelInput.Size" type="System.Drawing.Size, System.Drawing">
     <value>49, 13</value>
   </data>
-  <data name="checkBoxDontGenerate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 17</value>
-  </data>
   <data name="grpInput.Text" xml:space="preserve">
     <value>Eingabe</value>
   </data>
@@ -142,17 +139,11 @@
   <data name="txtOutputPath.ToolTip" xml:space="preserve">
     <value>Ausgabedatei</value>
   </data>
-  <data name="radioButtonAudioNone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 17</value>
-  </data>
   <data name="radioButtonAudioNone.Text" xml:space="preserve">
     <value>Keine</value>
   </data>
   <data name="radioButtonAudioNone.ToolTip" xml:space="preserve">
     <value>Keine Audioausgabe</value>
-  </data>
-  <data name="radioButtonAudioLossy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 17</value>
   </data>
   <data name="radioButtonAudioLossy.Text" xml:space="preserve">
     <value>Verlustbehaftet</value>
@@ -165,9 +156,6 @@
   </data>
   <data name="radioButtonAudioHybrid.ToolTip" xml:space="preserve">
     <value>Hybride Codecs</value>
-  </data>
-  <data name="radioButtonAudioLossless.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 17</value>
   </data>
   <data name="radioButtonAudioLossless.Text" xml:space="preserve">
     <value>Verlustfrei</value>
@@ -184,20 +172,8 @@
   <data name="comboBoxAudioFormat.ToolTip" xml:space="preserve">
     <value>Audiodateiformat</value>
   </data>
-  <data name="rbCorrectorLocateFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
-  </data>
-  <data name="rbCorrectorChangeExtension.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 17</value>
-  </data>
-  <data name="checkBoxCorrectorOverwrite.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
-  </data>
   <data name="grpAction.Text" xml:space="preserve">
     <value>Aktion</value>
-  </data>
-  <data name="rbActionCorrectFilenames.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
   </data>
   <data name="rbActionCorrectFilenames.Text" xml:space="preserve">
     <value>Dateinamen korrigieren</value>
@@ -205,29 +181,17 @@
   <data name="rbActionCorrectFilenames.ToolTip" xml:space="preserve">
     <value>Dateinamen in CUE-Sheets korrigieren</value>
   </data>
-  <data name="rbActionCreateCUESheet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 17</value>
-  </data>
   <data name="rbActionCreateCUESheet.Text" xml:space="preserve">
-    <value>Leeres CUE-Sheet erzeugen</value>
+    <value>CUE-Sheet erzeugen</value>
   </data>
   <data name="rbActionCreateCUESheet.ToolTip" xml:space="preserve">
     <value>Ein CUE-Sheet für Tracks erzeugen und eingebettete CUE-Sheets extrahieren</value>
-  </data>
-  <data name="rbActionVerifyAndEncode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 17</value>
-  </data>
-  <data name="rbActionVerify.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
   </data>
   <data name="rbActionVerify.Text" xml:space="preserve">
     <value>&amp;Verifizieren</value>
   </data>
   <data name="rbActionVerify.ToolTip" xml:space="preserve">
     <value>Kontaktiert die AccurateRip-Datenbank und verifiziert das Image anhand dieser.</value>
-  </data>
-  <data name="rbActionEncode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>126, 17</value>
   </data>
   <data name="rbActionEncode.Text" xml:space="preserve">
     <value>&amp;Kodieren</value>
@@ -261,15 +225,6 @@
   </data>
   <data name="grpExtra.Text" xml:space="preserve">
     <value>Extra</value>
-  </data>
-  <data name="rbFreedbAlways.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
-  </data>
-  <data name="rbFreedbIf.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
-  </data>
-  <data name="rbFreedbNever.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 17</value>
   </data>
   <data name="btnResume.Text" xml:space="preserve">
     <value>&amp;Weiter</value>


### PR DESCRIPTION
- CUERipper\CUERipper.csproj
  Fix incorrect `ApplicationVersion 2.1.4.0` and set it to `1.0.0.%2a`
  like in the other .csproj files. Set `ApplicationRevision` to `0`
- CUERipper\Properties\AssemblyInfo.cs
  Correct version in `AssemblyVersion` and `AssemblyFileVersion`
  1.9.0.0 -> 2.1.7.0
- CUETools\CUETools.csproj
  Fix incorrect `ApplicationVersion 2.0.3.%2a` and set it to `1.0.0.%2a`
  like in the other .csproj files. Set `ApplicationRevision` to `0`
- CUETools\Properties\AssemblyInfo.cs
  Update `AssemblyTitle` and `AssemblyProduct` to `"CUETools"`
- CUETools\frmCUETools.de-DE.resx
  - Correct the translation of "Create CUE sheet", which also reduces
    the length of the translation, so that it fits better.
  - Remove the following leftovers:
      checkBoxCorrectorOverwrite.Size
      checkBoxDontGenerate.Size
      radioButtonAudioLossless.Size
      radioButtonAudioLossy.Size
      radioButtonAudioNone.Size
      rbActionCorrectFilenames.Size
      rbActionCreateCUESheet.Size
      rbActionEncode.Size
      rbActionVerify.Size
      rbActionVerifyAndEncode.Size
      rbCorrectorChangeExtension.Size
      rbCorrectorLocateFiles.Size
      rbFreedbAlways.Size
      rbFreedbIf.Size
      rbFreedbNever.Size
