### PR TITLE
Prepare for CUETools 2.1.8

### DIFF
--- a/CUEControls/CUEControls.csproj
+++ b/CUEControls/CUEControls.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUEControls</AssemblyName>
     <RootNamespace>CUEControls</RootNamespace>
     <Product>CUETools</Product>

--- a/CUEPlayer/Properties/AssemblyInfo.cs
+++ b/CUEPlayer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUEPlayer/Properties/DataSources/Output.datasource
+++ b/CUEPlayer/Properties/DataSources/Output.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="Output" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUEPlayer.Output, CUEPlayer, Version=2.0.7.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUEPlayer.Output, CUEPlayer, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUEPlayer/Properties/DataSources/frmCUEPlayer.datasource
+++ b/CUEPlayer/Properties/DataSources/frmCUEPlayer.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="frmCUEPlayer" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUEPlayer.frmCUEPlayer, CUEPlayer, Version=2.0.7.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUEPlayer.frmCUEPlayer, CUEPlayer, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUEPlayer/frmCUEPlayer.Designer.cs
+++ b/CUEPlayer/frmCUEPlayer.Designer.cs
@@ -68,7 +68,7 @@
 			this.IsMdiContainer = true;
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "frmCUEPlayer";
-			this.Text = "CUEPlayer 2.1.7";
+			this.Text = "CUEPlayer 2.1.8";
 			this.Load += new System.EventHandler(this.frmCUEPlayer_Load);
 			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmCUEPlayer_FormClosing);
 			this.menuStrip1.ResumeLayout(false);

--- a/CUERipper/Properties/AssemblyInfo.cs
+++ b/CUERipper/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUERipper/Properties/DataSources/frmCUERipper.datasource
+++ b/CUERipper/Properties/DataSources/frmCUERipper.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="frmCUERipper" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUERipper.frmCUERipper, CUERipper, Version=1.9.0.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUERipper.frmCUERipper, CUERipper, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUERipper/frmCUERipper.de-DE.resx
+++ b/CUERipper/frmCUERipper.de-DE.resx
@@ -208,7 +208,7 @@
     <value>Optionen</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>CUERipper 2.1.7</value>
+    <value>CUERipper 2.1.8</value>
   </data>
   <data name="bnComboBoxDrives.Text" xml:space="preserve">
     <value>Laufwerke</value>

--- a/CUERipper/frmCUERipper.resx
+++ b/CUERipper/frmCUERipper.resx
@@ -494,7 +494,7 @@
     <value>bnComboBoxLosslessOrNot</value>
   </data>
   <data name="&gt;&gt;bnComboBoxLosslessOrNot.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxLosslessOrNot.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -524,7 +524,7 @@
     <value>bnComboBoxEncoder</value>
   </data>
   <data name="&gt;&gt;bnComboBoxEncoder.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxEncoder.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -578,7 +578,7 @@
     <value>bnComboBoxFormat</value>
   </data>
   <data name="&gt;&gt;bnComboBoxFormat.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxFormat.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -647,7 +647,7 @@
     <value>bnComboBoxImage</value>
   </data>
   <data name="&gt;&gt;bnComboBoxImage.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxImage.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -1171,7 +1171,7 @@
     <value>bnComboBoxRelease</value>
   </data>
   <data name="&gt;&gt;bnComboBoxRelease.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxRelease.Parent" xml:space="preserve">
     <value>panel3</value>
@@ -1201,7 +1201,7 @@
     <value>bnComboBoxDrives</value>
   </data>
   <data name="&gt;&gt;bnComboBoxDrives.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxDrives.Parent" xml:space="preserve">
     <value>panel3</value>
@@ -1231,7 +1231,7 @@
     <value>bnComboBoxOutputFormat</value>
   </data>
   <data name="&gt;&gt;bnComboBoxOutputFormat.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxOutputFormat.Parent" xml:space="preserve">
     <value>panel5</value>
@@ -2156,7 +2156,7 @@
     <value>CenterScreen</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>CUERipper 2.1.7</value>
+    <value>CUERipper 2.1.8</value>
   </data>
   <data name="&gt;&gt;toolStripStatusLabel1.Name" xml:space="preserve">
     <value>toolStripStatusLabel1</value>

--- a/CUERipper/frmFreedbSubmit.resx
+++ b/CUERipper/frmFreedbSubmit.resx
@@ -138,7 +138,7 @@
     <value>imgComboBoxCategory</value>
   </data>
   <data name="&gt;&gt;imgComboBoxCategory.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;imgComboBoxCategory.Parent" xml:space="preserve">
     <value>groupBox1</value>

--- a/CUETools.ALACEnc/CUETools.ALACEnc.csproj
+++ b/CUETools.ALACEnc/CUETools.ALACEnc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.ALACEnc</AssemblyName>
     <RootNamespace>CUETools.ALACEnc</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.ARCUE/CUETools.ARCUE.csproj
+++ b/CUETools.ARCUE/CUETools.ARCUE.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.ARCUE</AssemblyName>
     <RootNamespace>CUETools.ARCUE</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.AccurateRip/CUETools.AccurateRip.csproj
+++ b/CUETools.AccurateRip/CUETools.AccurateRip.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.AccurateRip</AssemblyName>
     <RootNamespace>CUETools.AccurateRip</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.CDImage/CUETools.CDImage.csproj
+++ b/CUETools.CDImage/CUETools.CDImage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.CDImage</AssemblyName>
     <RootNamespace>CUETools.CDImage</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.CLParity/CLParity.cs
+++ b/CUETools.CLParity/CLParity.cs
@@ -383,7 +383,7 @@ namespace CUETools.CLParity
 
         public string Path { get { return null; } }
 
-        public static readonly string vendor_string = "CLParity#2.1.7";
+        public static readonly string vendor_string = "CLParity#2.1.8";
     }
 
 	internal class CLParityTask

--- a/CUETools.CLParity/Properties/AssemblyInfo.cs
+++ b/CUETools.CLParity/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
+++ b/CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.CTDB.Converter</AssemblyName>
     <RootNamespace>CUETools.CTDB.Converter</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.CTDB.EACPlugin.Installer/CUETools.CTDB.EACPlugin.Installer.vdproj
+++ b/CUETools.CTDB.EACPlugin.Installer/CUETools.CTDB.EACPlugin.Installer.vdproj
@@ -248,7 +248,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CUETools.CDImage, Version=2.1.4.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:CUETools.CDImage, Version=2.1.8.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_23A6BB18C5C16459B31F4387E1637805"
@@ -310,7 +310,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CUETools.AccurateRip, Version=2.1.4.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:CUETools.AccurateRip, Version=2.1.8.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_7A5E0041DC75098C30D459114A6DEE81"
@@ -392,7 +392,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:CUETools.Codecs, Version=2.1.4.0, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:CUETools.Codecs, Version=2.1.8.0, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_EA17591A9F261678B36DFC7E72DFC398"
@@ -515,7 +515,7 @@
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:2.1.4"
+        "ProductVersion" = "8:2.1.8"
         "Manufacturer" = "8:Grigory Chudov"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:http://www.cuetools.net"

--- a/CUETools.CTDB.EACPlugin/Metadata.cs
+++ b/CUETools.CTDB.EACPlugin/Metadata.cs
@@ -46,7 +46,7 @@ namespace MetadataPlugIn
             TOC[1][0].Start = 0U;
 
             var ctdb = new CUEToolsDB(TOC, null);
-            var form = new CUETools.CTDB.EACPlugin.FormMetadata(ctdb, "EAC" + data.HostVersion + " CTDB 2.1.7", cdinfo, cover);
+            var form = new CUETools.CTDB.EACPlugin.FormMetadata(ctdb, "EAC" + data.HostVersion + " CTDB 2.1.8", cdinfo, cover);
             form.ShowDialog();
             var meta = form.Meta;
             if (meta == null)
@@ -186,7 +186,7 @@ namespace MetadataPlugIn
 
         public string GetPluginName()
         {
-            return "CUETools DB Metadata Plugin V2.1.7";
+            return "CUETools DB Metadata Plugin V2.1.8";
         }
 
         public void ShowOptions()

--- a/CUETools.CTDB.EACPlugin/Options.Designer.cs
+++ b/CUETools.CTDB.EACPlugin/Options.Designer.cs
@@ -60,7 +60,7 @@ namespace AudioDataPlugIn
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(205, 20);
             this.label1.TabIndex = 0;
-            this.label1.Text = "CUETools DB Plugin V2.1.7";
+            this.label1.Text = "CUETools DB Plugin V2.1.8";
             // 
             // label2
             // 

--- a/CUETools.CTDB.EACPlugin/Plugin.cs
+++ b/CUETools.CTDB.EACPlugin/Plugin.cs
@@ -61,7 +61,7 @@ namespace AudioDataPlugIn
         // the plugin and for display in the log file
         public string GetAudioTransferPluginName()
         {
-            return "CUETools DB Plugin V2.1.7";
+            return "CUETools DB Plugin V2.1.8";
         }
 
         // Each plugin should have its own options page.
@@ -278,7 +278,7 @@ namespace AudioDataPlugIn
 #endif
                 var form = new FormSubmitParity(
                     ctdb,
-                    "EAC" + m_data.HostVersion + " CTDB 2.1.7",
+                    "EAC" + m_data.HostVersion + " CTDB 2.1.8",
                     m_drivename,
                     conf,
                     (arTest.Position != 0 && arTest.CRC32(0) == ar.CRC32(0)) ? 100 : 

--- a/CUETools.CTDB.Types/CUETools.CTDB.Types.csproj
+++ b/CUETools.CTDB.Types/CUETools.CTDB.Types.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.CTDB.Types</AssemblyName>
     <RootNamespace>CUETools.CTDB</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.CTDB/CUETools.CTDB.csproj
+++ b/CUETools.CTDB/CUETools.CTDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.CTDB</AssemblyName>
     <RootNamespace>CUETools.CTDB</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.ChaptersToCue/Program.cs
+++ b/CUETools.ChaptersToCue/Program.cs
@@ -49,7 +49,7 @@ namespace CUETools.ChaptersToCue
         {
             TextWriter stdout = Console.Out;
             Console.SetOut(Console.Error);
-            Console.WriteLine("CUETools.ChaptersToCue v2.1.7 Copyright (C) 2017-2021 Grigory Chudov");
+            Console.WriteLine("CUETools.ChaptersToCue v2.1.8 Copyright (C) 2017-2021 Grigory Chudov");
             Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
             Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
 
@@ -166,7 +166,7 @@ namespace CUETools.ChaptersToCue
             if (queryMeta)
             {
                 var ctdb = new CUEToolsDB(toc, null);
-                ctdb.ContactDB(null, "CUETools.ChaptersToCue 2.1.7", "", false, true, CTDBMetadataSearch.Extensive);
+                ctdb.ContactDB(null, "CUETools.ChaptersToCue 2.1.8", "", false, true, CTDBMetadataSearch.Extensive);
                 foreach (var imeta in ctdb.Metadata)
                 {
                     meta = imeta;

--- a/CUETools.ChaptersToCue/Properties/AssemblyInfo.cs
+++ b/CUETools.ChaptersToCue/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools.Codecs.ALAC/CUETools.Codecs.ALAC.csproj
+++ b/CUETools.Codecs.ALAC/CUETools.Codecs.ALAC.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.ALAC</AssemblyName>
     <RootNamespace>CUETools.Codecs</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.CoreAudio/CUETools.Codecs.CoreAudio.csproj
+++ b/CUETools.Codecs.CoreAudio/CUETools.Codecs.CoreAudio.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.CoreAudio</AssemblyName>
     <RootNamespace>CUETools.Codecs.CoreAudio</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.FLACCL/Properties/AssemblyInfo.cs
+++ b/CUETools.Codecs.FLACCL/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools.Codecs.FlaCuda/Properties/AssemblyInfo.cs
+++ b/CUETools.Codecs.FlaCuda/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools.Codecs.Flake/CUETools.Codecs.Flake.csproj
+++ b/CUETools.Codecs.Flake/CUETools.Codecs.Flake.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.Flake</AssemblyName>
     <RootNamespace>CUETools.Codecs.Flake</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.HDCD/CUETools.Codecs.HDCD.csproj
+++ b/CUETools.Codecs.HDCD/CUETools.Codecs.HDCD.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.HDCD</AssemblyName>
     <RootNamespace>CUETools.Codecs.HDCD</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.Icecast/CUETools.Codecs.Icecast.csproj
+++ b/CUETools.Codecs.Icecast/CUETools.Codecs.Icecast.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.Icecast</AssemblyName>
     <RootNamespace>CUETools.Codecs.Icecast</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.LossyWAV/CUETools.Codecs.LossyWAV.csproj
+++ b/CUETools.Codecs.LossyWAV/CUETools.Codecs.LossyWAV.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.LossyWAV</AssemblyName>
     <RootNamespace>CUETools.Codecs.LossyWAV</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.MACLib/CUETools.Codecs.MACLib.csproj
+++ b/CUETools.Codecs.MACLib/CUETools.Codecs.MACLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.MACLib</AssemblyName>
     <RootNamespace>CUETools.Codecs.MACLib</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.MPEG/CUETools.Codecs.MPEG.csproj
+++ b/CUETools.Codecs.MPEG/CUETools.Codecs.MPEG.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.MPEG</AssemblyName>
     <RootNamespace>CUETools.Codecs.MPEG</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.TTA/AssemblyInfo.cpp
+++ b/CUETools.Codecs.TTA/AssemblyInfo.cpp
@@ -29,7 +29,7 @@ using namespace System::Security::Permissions;
 // You can specify all the value or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly:AssemblyVersionAttribute("2.1.7.0")];
+[assembly:AssemblyVersionAttribute("2.1.8.0")];
 
 [assembly:ComVisible(false)];
 

--- a/CUETools.Codecs.WMA/CUETools.Codecs.WMA.csproj
+++ b/CUETools.Codecs.WMA/CUETools.Codecs.WMA.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.WMA</AssemblyName>
     <RootNamespace>CUETools.Codecs.WMA</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.ffmpeg/CUETools.Codecs.ffmpeg.csproj
+++ b/CUETools.Codecs.ffmpeg/CUETools.Codecs.ffmpeg.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.ffmpegdll</AssemblyName>
     <RootNamespace>CUETools.Codecs.ffmpegdll</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.lame_enc/CUETools.Codecs.LAME.csproj
+++ b/CUETools.Codecs.lame_enc/CUETools.Codecs.LAME.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.lame_enc</AssemblyName>
     <RootNamespace>CUETools.Codecs.lame_enc</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.libFLAC/CUETools.Codecs.libFLAC.csproj
+++ b/CUETools.Codecs.libFLAC/CUETools.Codecs.libFLAC.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.libFLAC</AssemblyName>
     <RootNamespace>CUETools.Codecs.libFLAC</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.libmp3lame/CUETools.Codecs.libmp3lame.csproj
+++ b/CUETools.Codecs.libmp3lame/CUETools.Codecs.libmp3lame.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.libmp3lame</AssemblyName>
     <RootNamespace>CUETools.Codecs.libmp3lame</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs.libwavpack/CUETools.Codecs.libwavpack.csproj
+++ b/CUETools.Codecs.libwavpack/CUETools.Codecs.libwavpack.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs.libwavpack</AssemblyName>
     <RootNamespace>CUETools.Codecs.libwavpack</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Codecs/CUETools.Codecs.csproj
+++ b/CUETools.Codecs/CUETools.Codecs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Codecs</AssemblyName>
     <RootNamespace>CUETools.Codecs</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Compression.Rar/CUETools.Compression.Rar.csproj
+++ b/CUETools.Compression.Rar/CUETools.Compression.Rar.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Compression.Rar</AssemblyName>
     <RootNamespace>CUETools.Compression.Rar</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Compression.Zip/CUETools.Compression.Zip.csproj
+++ b/CUETools.Compression.Zip/CUETools.Compression.Zip.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Compression.Zip</AssemblyName>
     <RootNamespace>CUETools.Compression.Zip</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Compression/CUETools.Compression.csproj
+++ b/CUETools.Compression/CUETools.Compression.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Compression</AssemblyName>
     <RootNamespace>CUETools.Compression</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Converter/CUETools.Converter.csproj
+++ b/CUETools.Converter/CUETools.Converter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Converter</AssemblyName>
     <RootNamespace>CUETools.Converter</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.DSP.Mixer/CUETools.DSP.Mixer.csproj
+++ b/CUETools.DSP.Mixer/CUETools.DSP.Mixer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.DSP.Mixer</AssemblyName>
     <RootNamespace>CUETools.DSP.Mixer</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.DSP.Resampler/CUETools.DSP.Resampler.csproj
+++ b/CUETools.DSP.Resampler/CUETools.DSP.Resampler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.DSP.Resampler</AssemblyName>
     <RootNamespace>CUETools.DSP.Resampler</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.FLACCL.cmd/Properties/AssemblyInfo.cs
+++ b/CUETools.FLACCL.cmd/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools.FlaCudaExe/Properties/AssemblyInfo.cs
+++ b/CUETools.FlaCudaExe/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools.Flake/CUETools.Flake.csproj
+++ b/CUETools.Flake/CUETools.Flake.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Flake</AssemblyName>
     <RootNamespace>CUETools.Flake</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.LossyWAV/CUETools.LossyWAV.csproj
+++ b/CUETools.LossyWAV/CUETools.LossyWAV.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.LossyWAV</AssemblyName>
     <RootNamespace>CUETools.LossyWAV</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Parity/CUETools.Parity.csproj
+++ b/CUETools.Parity/CUETools.Parity.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Parity</AssemblyName>
     <RootNamespace>CUETools.Parity</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -24,7 +24,7 @@ namespace CUETools.Processor
     {
         #region Fields
 
-        public readonly static string CUEToolsVersion = "2.1.7";
+        public readonly static string CUEToolsVersion = "2.1.8";
 
         private bool _stop, _pause;
         private List<CUELine> _attributes;

--- a/CUETools.Processor/CUETools.Processor.csproj
+++ b/CUETools.Processor/CUETools.Processor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Processor</AssemblyName>
     <RootNamespace>CUETools.Processor</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Ripper.Console/CUETools.ConsoleRipper.csproj
+++ b/CUETools.Ripper.Console/CUETools.ConsoleRipper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Ripper.Console</AssemblyName>
     <RootNamespace>CUETools.Ripper.Console</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Ripper.Console/Program.cs
+++ b/CUETools.Ripper.Console/Program.cs
@@ -89,7 +89,7 @@ namespace CUETools.ConsoleRipper
 		static void Main(string[] args)
 		{
 			Console.SetOut(Console.Error);
-			Console.WriteLine("CUERipper v2.1.7 Copyright (C) 2008-2021 Grigory Chudov");
+			Console.WriteLine("CUERipper v2.1.8 Copyright (C) 2008-2021 Grigory Chudov");
 			Console.WriteLine("This is free software under the GNU GPLv3+ license; There is NO WARRANTY, to");
 			Console.WriteLine("the extent permitted by law. <http://www.gnu.org/licenses/> for details.");
 
@@ -180,7 +180,7 @@ namespace CUETools.ConsoleRipper
 				string ArId = AccurateRipVerify.CalculateAccurateRipId(audioSource.TOC);
 				var ctdb = new CUEToolsDB(audioSource.TOC, null);
 				ctdb.Init(arVerify);
-				ctdb.ContactDB(null, "CUETools.ConsoleRipper 2.1.7", audioSource.ARName, true, false, CTDBMetadataSearch.Fast);
+				ctdb.ContactDB(null, "CUETools.ConsoleRipper 2.1.8", audioSource.ARName, true, false, CTDBMetadataSearch.Fast);
 				arVerify.ContactAccurateRip(ArId);
 				CTDBResponseMeta meta = null;
 				foreach (var imeta in ctdb.Metadata)

--- a/CUETools.Ripper.SCSI/CUETools.Ripper.SCSI.csproj
+++ b/CUETools.Ripper.SCSI/CUETools.Ripper.SCSI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Ripper.SCSI</AssemblyName>
     <RootNamespace>CUETools.Ripper.SCSI</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -1261,7 +1261,7 @@ namespace CUETools.Ripper.SCSI
 		{
 			get
 			{
-				return "CUERipper v2.1.7 Copyright (C) 2008-2021 Grigory Chudov";
+				return "CUERipper v2.1.8 Copyright (C) 2008-2021 Grigory Chudov";
 				// ripper.GetName().Name + " " + ripper.GetName().Version;
 			}
 		}

--- a/CUETools.Ripper/CUETools.Ripper.csproj
+++ b/CUETools.Ripper/CUETools.Ripper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netstandard2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.Ripper</AssemblyName>
     <RootNamespace>CUETools.Ripper</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.eac3to/CUETools.eac3to.csproj
+++ b/CUETools.eac3to/CUETools.eac3to.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
-    <Version>2.1.7.0</Version>
+    <Version>2.1.8.0</Version>
     <AssemblyName>CUETools.eac3to</AssemblyName>
     <RootNamespace>CUETools.eac3to</RootNamespace>
     <Product>CUETools</Product>

--- a/CUETools.eac3to/Program.cs
+++ b/CUETools.eac3to/Program.cs
@@ -225,7 +225,7 @@ namespace CUETools.eac3to
                     {
                         var ctdb = new CUEToolsDB(toc, null);
                         Console.Error.WriteLine("Contacting CTDB...");
-                        ctdb.ContactDB(null, "CUETools.eac3to 2.1.7", "", false, true, CTDBMetadataSearch.Extensive);
+                        ctdb.ContactDB(null, "CUETools.eac3to 2.1.8", "", false, true, CTDBMetadataSearch.Extensive);
                         foreach (var imeta in ctdb.Metadata)
                         {
                             meta = imeta;

--- a/CUETools.eac3ui/MainWindow.xaml.cs
+++ b/CUETools.eac3ui/MainWindow.xaml.cs
@@ -147,7 +147,7 @@ namespace BluTools
                 pbStatus.IsIndeterminate = true;
             }));
             //ctdb.UploadHelper.onProgress += worker_ctdbProgress;
-            ctdb.ContactDB(null, "CUETools.eac3to 2.1.7", "", false, true, CTDBMetadataSearch.Extensive);
+            ctdb.ContactDB(null, "CUETools.eac3to 2.1.8", "", false, true, CTDBMetadataSearch.Extensive);
             this.Dispatcher.Invoke((Action)(() =>
             {
                 //metaresults.RaiseListChangedEvents = false; 

--- a/CUETools/CUETools.TestCodecs/AccurateRipVerifyTest.cs
+++ b/CUETools/CUETools.TestCodecs/AccurateRipVerifyTest.cs
@@ -334,7 +334,7 @@ namespace CUETools.TestCodecs
         public void asdaTest()
         {
             //var tempPath = @"C:\Users\user\Downloads\CUETools_2.1.2a\CUE Tools\LocalDB.xml";
-            var tempPath = @"C:\Users\user\Downloads\CUETools_2.1.7\CUE Tools\LocalDB.xml";
+            var tempPath = @"C:\Users\user\Downloads\CUETools_2.1.8\CUE Tools\LocalDB.xml";
             var path = tempPath + @".z";
             //using (var fileStream = new System.IO.FileStream(tempPath, System.IO.FileMode.CreateNew))
             //using (var deflateStream = new System.IO.Compression.DeflateStream(fileStream, System.IO.Compression.CompressionMode.Compress))

--- a/CUETools/Properties/AssemblyInfo.cs
+++ b/CUETools/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.1.7.0")]
-[assembly: AssemblyFileVersion("2.1.7.0")]
+[assembly: AssemblyVersion("2.1.8.0")]
+[assembly: AssemblyFileVersion("2.1.8.0")]

--- a/CUETools/Properties/DataSources/CUETools.Processor.CUEConfig.datasource
+++ b/CUETools/Properties/DataSources/CUETools.Processor.CUEConfig.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="CUEConfig" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUETools.Processor.CUEConfig, CUETools.Processor, Version=1.9.4.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUETools.Processor.CUEConfig, CUETools.Processor, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -609,7 +609,7 @@ namespace JDP
         {
             get
             {
-                return "CUETools 2.1.7";
+                return "CUETools 2.1.8";
             }
         }
 

--- a/CUETools/frmCUETools.resx
+++ b/CUETools/frmCUETools.resx
@@ -265,7 +265,7 @@
     <value>fileSystemTreeView1</value>
   </data>
   <data name="&gt;&gt;fileSystemTreeView1.Type" xml:space="preserve">
-    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.1.7.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.1.8.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;fileSystemTreeView1.Parent" xml:space="preserve">
     <value>grpInput</value>
@@ -2915,7 +2915,7 @@
     <value>699, 537</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>CUETools 2.1.7</value>
+    <value>CUETools 2.1.8</value>
   </data>
   <data name="&gt;&gt;toolStripStatusLabel1.Name" xml:space="preserve">
     <value>toolStripStatusLabel1</value>


### PR DESCRIPTION
- Substitute occurrences of "2.1.7" with "2.1.8" using:
  `git grep -I -l -e '2\.1\.7' -- ':(exclude)*.bat' | xargs \`
  `sed -b -i -e 's/2\.1\.7/2\.1\.8/g'`
- Update some outdated version entries:
  2.1.4 in **`CUETools.CTDB.EACPlugin.Installer.vdproj`**
    `git grep -I -l -e '2\.1\.4' | xargs \`
    `sed -b -i -e 's/2\.1\.4/2\.1\.8/g'`
  2.0.7 in
    **`CUEPlayer/Properties/DataSources/Output.datasource`**
    **`CUEPlayer/Properties/DataSources/frmCUEPlayer.datasource`**
    `git grep -I -l -e '2\.0\.7' | xargs \`
    `sed -b -i -e 's/2\.0\.7/2\.1\.8/g'`
  1.9.4 in **`CUETools.Processor.CUEConfig.datasource`**
    `git grep -I -l -e '1\.9\.4' | xargs \`
    `sed -b -i -e 's/1\.9\.4/2\.1\.8/g'`
  1.9.0 in **`frmCUERipper.datasource`**
    `git grep -I -l -e '1\.9\.0' | xargs \`
    `sed -b -i -e 's/1\.9\.0/2\.1\.8/g'`
