### PR TITLE
[CUETools.Codecs.FLACCL] Fix constructor

### DIFF
--- a/CUETools.Codecs.FLACCL/FLACCLWriter.cs
+++ b/CUETools.Codecs.FLACCL/FLACCLWriter.cs
@@ -372,7 +372,7 @@ namespace CUETools.Codecs.FLACCL
 
         public const int MAX_BLOCKSIZE = 65536;
 
-        public AudioEncoder(string path, Stream IO, EncoderSettings settings)
+        public AudioEncoder(EncoderSettings settings, string path, Stream IO)
         {
             m_settings = settings.Clone() as EncoderSettings;
             m_settings.Validate();
@@ -394,11 +394,6 @@ namespace CUETools.Codecs.FLACCL
             eparams.flake_set_defaults(m_settings);
 
             crc8 = new Crc8();
-        }
-
-        public AudioEncoder(string path, EncoderSettings settings)
-            : this(path, null, settings)
-        {
         }
 
         public int TotalSize

--- a/CUETools.FLACCL.cmd/Program.cs
+++ b/CUETools.FLACCL.cmd/Program.cs
@@ -276,10 +276,9 @@ namespace CUETools.FLACCL.cmd
 			{
                 if (device_type != null)
                     settings.DeviceType = (OpenCLDeviceType)(Enum.Parse(typeof(OpenCLDeviceType), device_type, true));
-                encoder = new Codecs.FLACCL.AudioEncoder((output_file == "-" || output_file == "nul") ? "" : output_file,
+                encoder = new Codecs.FLACCL.AudioEncoder(settings, (output_file == "-" || output_file == "nul") ? "" : output_file,
                     output_file == "-" ? Console.OpenStandardOutput() :
-                    output_file == "nul" ? new NullStream() : null,
-                    settings);
+                    output_file == "nul" ? new NullStream() : null);
                 settings = encoder.Settings as Codecs.FLACCL.EncoderSettings;
                 encoder.FinalSampleCount = audioSource.Length;
 				if (stereo_method != null)


### PR DESCRIPTION
The constructor parameters of `Activator.CreateInstance()` were updated
in **`CUETools.Processor\AudioReadWrite.cs`** as of commits 16fccfe and
e1f8906. The parameter `"settings"` was added in front of `path` and `IO`,
which required an update to the order of constructor parameters in
several codecs.

- Fixes the following error message, when using FLACCL codec:
  `Exception: Constructor on type`
  `'CUETools.Codecs.FLACCL.AudioEncoder' not found.`
- This is a follow-up commit to 18c6c1a
- Resolves #82
