### PR TITLE
Update libFLAC to 1.3.3 git 27c6157

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ilammy/setup-nasm@v1
       - name: Apply patch
         # yamllint disable-line rule:line-length
-        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch
+        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
       - name: Build Release|Any CPU
         run: |
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Any CPU"

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -29,6 +29,9 @@ jobs:
           submodules: recursive
       # nasm is required for building Release|Win32
       - uses: ilammy/setup-nasm@v1
+      - name: Apply patch
+        # yamllint disable-line rule:line-length
+        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch
       - name: Build Release|Any CPU
         run: |
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Any CPU"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: ilammy/setup-nasm@v1
       - name: Apply patch
         # yamllint disable-line rule:line-length
-        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch
+        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
       - name: Build Release|Any CPU
         run: |
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Any CPU"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -30,6 +30,9 @@ jobs:
           submodules: recursive
       # nasm is required for building Release|Win32
       - uses: ilammy/setup-nasm@v1
+      - name: Apply patch
+        # yamllint disable-line rule:line-length
+        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch
       - name: Build Release|Any CPU
         run: |
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Any CPU"

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/gchudov/taglib-sharp.git
 [submodule "ThirdParty/flac"]
 	path = ThirdParty/flac
-	url = https://github.com/gchudov/flac.git
+	url = https://github.com/xiph/flac.git
 [submodule "ThirdParty/MAC_SDK"]
 	path = ThirdParty/MAC_SDK
 	url = https://github.com/gchudov/MAC_SDK.git

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Prebuilt binaries can be downloaded from [CUETools Download](http://cue.tools/wi
 `git clone https://github.com/gchudov/cuetools.net.git`
 * Get the required submodules using:  
 `git submodule update --init --recursive`
+* Apply patch to submodule flac:  
+`git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch`
 * The solution can be built using Microsoft Visual Studio 2017 or newer (Community Edition will work)
   * Install the required .NET development tools (currently .NET Framework 4.7 and .NET Core 2.0)
   * Install an appropriate Windows SDK version (currently 10.0.16299.0)

--- a/ThirdParty/submodule_flac_CUETools.patch
+++ b/ThirdParty/submodule_flac_CUETools.patch
@@ -1,0 +1,174 @@
+diff --git a/src/libFLAC/libFLAC_dynamic.vcxproj b/src/libFLAC/libFLAC_dynamic.vcxproj
+index 3c0c10e3..1639ada0 100644
+--- a/src/libFLAC/libFLAC_dynamic.vcxproj
++++ b/src/libFLAC/libFLAC_dynamic.vcxproj
+@@ -1,5 +1,5 @@
+ ﻿<?xml version="1.0" encoding="utf-8"?>
+-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
++<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+   <ItemGroup Label="ProjectConfigurations">
+     <ProjectConfiguration Include="Debug|Win32">
+       <Configuration>Debug</Configuration>
+@@ -22,21 +22,26 @@
+     <ProjectGuid>{4cefbc83-c215-11db-8314-0800200c9a66}</ProjectGuid>
+     <RootNamespace>libFLAC_dynamic</RootNamespace>
+     <Keyword>Win32Proj</Keyword>
++    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+     <WholeProgramOptimization>true</WholeProgramOptimization>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+     <WholeProgramOptimization>true</WholeProgramOptimization>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -58,23 +63,23 @@
+     <_ProjectFileVersion>12.0.30501.0</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+-    <OutDir>$(SolutionDir)objs\$(Configuration)\lib\</OutDir>
+-    <IntDir>$(Configuration)_dynamic\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
+     <LinkIncremental>true</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+     <LinkIncremental>true</LinkIncremental>
+-    <OutDir>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+-    <OutDir>$(SolutionDir)objs\$(Configuration)\lib\</OutDir>
+-    <IntDir>$(Configuration)_dynamic\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
+     <LinkIncremental>false</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+     <LinkIncremental>false</LinkIncremental>
+-    <OutDir>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
+   </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+@@ -82,7 +87,7 @@
+       <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+@@ -92,7 +97,6 @@
+       <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+     </ClCompile>
+     <Link>
+-      <AdditionalDependencies>$(SolutionDir)objs\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+       <SubSystem>Windows</SubSystem>
+@@ -104,7 +108,7 @@
+       <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+       <WarningLevel>Level3</WarningLevel>
+@@ -113,7 +117,6 @@
+       <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+     </ClCompile>
+     <Link>
+-      <AdditionalDependencies>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+       <SubSystem>Windows</SubSystem>
+@@ -127,8 +130,8 @@
+       <OmitFramePointers>true</OmitFramePointers>
+       <WholeProgramOptimization>true</WholeProgramOptimization>
+       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <BufferSecurityCheck>false</BufferSecurityCheck>
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+@@ -137,7 +140,6 @@
+       <FloatingPointModel>Fast</FloatingPointModel>
+     </ClCompile>
+     <Link>
+-      <AdditionalDependencies>$(SolutionDir)objs\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+       <SubSystem>Windows</SubSystem>
+@@ -155,8 +157,8 @@
+       <OmitFramePointers>true</OmitFramePointers>
+       <WholeProgramOptimization>true</WholeProgramOptimization>
+       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.3";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <BufferSecurityCheck>false</BufferSecurityCheck>
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+@@ -165,7 +167,6 @@
+       <FloatingPointModel>Fast</FloatingPointModel>
+     </ClCompile>
+     <Link>
+-      <AdditionalDependencies>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+       <GenerateDebugInformation>true</GenerateDebugInformation>
+       <SubSystem>Windows</SubSystem>
+@@ -241,10 +242,6 @@
+     <ClCompile Include="memory.c" />
+     <ClCompile Include="metadata_iterators.c" />
+     <ClCompile Include="metadata_object.c" />
+-    <ClCompile Include="ogg_decoder_aspect.c" />
+-    <ClCompile Include="ogg_encoder_aspect.c" />
+-    <ClCompile Include="ogg_helper.c" />
+-    <ClCompile Include="ogg_mapping.c" />
+     <ClCompile Include="stream_decoder.c" />
+     <ClCompile Include="stream_encoder.c" />
+     <ClCompile Include="stream_encoder_framing.c" />
+diff --git a/src/libFLAC/libFLAC_dynamic.vcxproj.filters b/src/libFLAC/libFLAC_dynamic.vcxproj.filters
+index 875c0216..a92f2a74 100644
+--- a/src/libFLAC/libFLAC_dynamic.vcxproj.filters
++++ b/src/libFLAC/libFLAC_dynamic.vcxproj.filters
+@@ -193,18 +193,6 @@
+     <ClCompile Include="metadata_object.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>
+-    <ClCompile Include="ogg_decoder_aspect.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+-    <ClCompile Include="ogg_encoder_aspect.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+-    <ClCompile Include="ogg_helper.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+-    <ClCompile Include="ogg_mapping.c">
+-      <Filter>Source Files</Filter>
+-    </ClCompile>
+     <ClCompile Include="stream_decoder.c">
+       <Filter>Source Files</Filter>
+     </ClCompile>


### PR DESCRIPTION
An issue with currently used libFLAC version 1.3.2 git 45f7d41 has been
reported [1]. Compression efficiency was affected, depending on CPU
type.
- Used the following commands, to switch the flac submodule to upstream
  [xiph/flac](https://github.com/xiph/flac) repo and checkout commit xiph/flac@27c6157:
```sh
    git submodule set-url ThirdParty/flac https://github.com/xiph/flac.git
    git submodule update --init --recursive --remote ThirdParty/flac
    pushd ThirdParty/flac/
    git checkout 27c615706cedd252a206dd77e3910dfa395dcc49
    popd
```
- Add patch based on commits of [gchudov/flac](https://github.com/gchudov/flac) github repo
  "project file modified to build the .dll for use with CUETools"
  (commits 36fce5b, 6735ddd, 8f4f296, 900bf23), which is applied using:
  `git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch`
- Add info on how to apply `ThirdParty/submodule_flac_CUETools.patch`
  to `README.md`
- Update GitHub actions accordingly for applying the patch to the
  checked out xiph/flac submodule

[1] https://hydrogenaud.io/index.php?topic=120750.0