### PR TITLE
Allow three dots at the end of album titles

### DIFF
--- a/CUETools.Processor/General.cs
+++ b/CUETools.Processor/General.cs
@@ -354,6 +354,10 @@ namespace CUETools.Processor
             string result = ReplaceMultiple(fmt, tags, maxLen);
             if (result == String.Empty || result == null)
                 return result;
+            // Album titles can contain three periods at the end.
+            // Remove "...\" from the DirectoryName to retain the behavior as in CUETools 2.1.7
+            if (result.Contains("...\\"))
+                result = result.Replace("...\\", "\\");
             int unique = 1;
             try
             {
@@ -362,6 +366,8 @@ namespace CUETools.Processor
                     var oldkey = tags[unique_key];
                     tags[unique_key] = unique.ToString();
                     string new_result = ReplaceMultiple(fmt, tags, maxLen);
+                    if (new_result.Contains("...\\"))
+                        new_result = new_result.Replace("...\\", "\\");
                     if ((new_result == result && oldkey != tags[unique_key]) || new_result == String.Empty || new_result == null)
                         break;
                     result = new_result;


### PR DESCRIPTION
An issue in CUETools 2.1.8 has been reported [1], if an album title
contains "..." at the end. Three dots at the end of a directory name
are supposed to cause issues. In CUETools 2.1.7, "..." was
automatically removed from the directory name.

- Add a check to remove "...\" from the `DirectoryName` to retain the
  behavior as in CUETools 2.1.7
- Fixes the following `Exception: Could not find a part of the path`

[1] https://hydrogenaud.io/index.php?topic=120854.0