### PR TITLE
Update WavPack to 5.4.0

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -29,9 +29,11 @@ jobs:
           submodules: recursive
       # nasm is required for building Release|Win32
       - uses: ilammy/setup-nasm@v1
-      - name: Apply patch
+      - name: Apply patches
         # yamllint disable-line rule:line-length
-        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
+        run: |
+          git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
+          git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools_VS2017.patch --verbose
       - name: Build Release|Any CPU
         run: |
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Any CPU"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -30,9 +30,11 @@ jobs:
           submodules: recursive
       # nasm is required for building Release|Win32
       - uses: ilammy/setup-nasm@v1
-      - name: Apply patch
+      - name: Apply patches
         # yamllint disable-line rule:line-length
-        run: git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
+        run: |
+          git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
+          git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools_VS2017.patch --verbose
       - name: Build Release|Any CPU
         run: |
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Any CPU"

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/gchudov/openclnet.git
 [submodule "ThirdParty/WavPack"]
 	path = ThirdParty/WavPack
-	url = https://github.com/gchudov/WavPack.git
+	url = https://github.com/dbry/WavPack.git
 [submodule "ThirdParty/WindowsMediaLib"]
 	path = ThirdParty/WindowsMediaLib
 	url = https://github.com/gchudov/WindowsMediaLib.git

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Prebuilt binaries can be downloaded from [CUETools Download](http://cue.tools/wi
 `git clone https://github.com/gchudov/cuetools.net.git`
 * Get the required submodules using:  
 `git submodule update --init --recursive`
-* Apply patch to submodule flac:  
-`git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch`
+* Apply patches to submodules:  
+`git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch`  
+`git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools_VS2017.patch`
 * The solution can be built using Microsoft Visual Studio 2017 or newer (Community Edition will work)
   * Install the required .NET development tools (currently .NET Framework 4.7 and .NET Core 2.0)
   * Install an appropriate Windows SDK version (currently 10.0.16299.0)

--- a/ThirdParty/submodule_WavPack_CUETools_VS2017.patch
+++ b/ThirdParty/submodule_WavPack_CUETools_VS2017.patch
@@ -1,0 +1,673 @@
+diff --git a/audition/audition.vcxproj b/audition/audition.vcxproj
+index fd59f60..a1ff47f 100644
+--- a/audition/audition.vcxproj
++++ b/audition/audition.vcxproj
+@@ -26,19 +26,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -57,7 +57,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+diff --git a/src/libwavpack.vcxproj b/src/libwavpack.vcxproj
+index 3d586d6..121a4f1 100644
+--- a/src/libwavpack.vcxproj
++++ b/src/libwavpack.vcxproj
+@@ -26,19 +26,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -58,32 +58,32 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <ClCompile>
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+@@ -96,10 +96,10 @@
+     <ClCompile>
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+@@ -113,10 +113,10 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <StringPooling>true</StringPooling>
+       <ExceptionHandling />
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <BufferSecurityCheck>false</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <DisableLanguageExtensions>false</DisableLanguageExtensions>
+@@ -142,10 +142,10 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <StringPooling>true</StringPooling>
+       <ExceptionHandling />
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <BufferSecurityCheck>false</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <DisableLanguageExtensions>false</DisableLanguageExtensions>
+@@ -172,13 +172,33 @@
+     <ClCompile Include="entropy_utils.c" />
+     <ClCompile Include="extra1.c" />
+     <ClCompile Include="extra2.c" />
+-    <ClCompile Include="open_filename.c" />
+-    <ClCompile Include="open_legacy.c" />
+-    <ClCompile Include="open_raw.c" />
++    <ClCompile Include="open_filename.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
++    <ClCompile Include="open_legacy.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
++    <ClCompile Include="open_raw.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
+     <ClCompile Include="open_utils.c" />
+     <ClCompile Include="pack.c" />
+     <ClCompile Include="pack_dns.c" />
+-    <ClCompile Include="pack_dsd.c" />
++    <ClCompile Include="pack_dsd.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
+     <ClCompile Include="pack_floats.c" />
+     <ClCompile Include="pack_utils.c" />
+     <ClCompile Include="read_words.c" />
+diff --git a/wavpack.sln b/wavpack.sln
+index a979740..0b9a66d 100644
+--- a/wavpack.sln
++++ b/wavpack.sln
+@@ -1,7 +1,7 @@
+ ﻿
+ Microsoft Visual Studio Solution File, Format Version 12.00
+-# Visual Studio Version 16
+-VisualStudioVersion = 16.0.30804.86
++# Visual Studio 15
++VisualStudioVersion = 15.9.28307.1500
+ MinimumVisualStudioVersion = 10.0.40219.1
+ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libwavpack", "src\libwavpack.vcxproj", "{5CCCB9CF-0384-458F-BA08-72B73866840F}"
+ EndProject
+diff --git a/wavpackdll/wavpackdll.rc b/wavpackdll/wavpackdll.rc
+index 782c69f..4ea10a3 100644
+--- a/wavpackdll/wavpackdll.rc
++++ b/wavpackdll/wavpackdll.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "afxres.h"
++#include "winres.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS
+@@ -34,7 +34,7 @@ END
+ 
+ 2 TEXTINCLUDE 
+ BEGIN
+-    "#include ""afxres.h""\r\n"
++    "#include ""winres.h""\r\n"
+     "\0"
+ END
+ 
+diff --git a/wavpackdll/wavpackdll.vcxproj b/wavpackdll/wavpackdll.vcxproj
+index eabba53..2925c90 100644
+--- a/wavpackdll/wavpackdll.vcxproj
++++ b/wavpackdll/wavpackdll.vcxproj
+@@ -26,19 +26,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -58,25 +58,25 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>true</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>true</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>false</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>false</LinkIncremental>
+   </PropertyGroup>
+@@ -93,18 +93,18 @@
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetEncodedNoise
+ 
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -116,11 +116,11 @@
+ /export:WavpackLittleEndianToNative /export:WavpackNativeToLittleEndian
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+@@ -150,16 +150,16 @@
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -171,11 +171,11 @@
+ /export:WavpackLittleEndianToNative /export:WavpackNativeToLittleEndian
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+@@ -198,23 +198,23 @@
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+       <WholeProgramOptimization>false</WholeProgramOptimization>
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -227,11 +227,11 @@
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ /export:WavpackGetEncodedNoise
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+@@ -259,25 +259,25 @@
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+       <WholeProgramOptimization>false</WholeProgramOptimization>
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetEncodedNoise
+ 
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -289,11 +289,11 @@
+ /export:WavpackLittleEndianToNative /export:WavpackNativeToLittleEndian
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+diff --git a/wavpackexe/wavpack.vcxproj b/wavpackexe/wavpack.vcxproj
+index 89d7b8f..b6939f4 100644
+--- a/wavpackexe/wavpack.vcxproj
++++ b/wavpackexe/wavpack.vcxproj
+@@ -25,19 +25,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -56,7 +56,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+diff --git a/winamp/winamp.vcxproj b/winamp/winamp.vcxproj
+index 0761d2e..0ecc44a 100644
+--- a/winamp/winamp.vcxproj
++++ b/winamp/winamp.vcxproj
+@@ -26,19 +26,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -57,7 +57,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+diff --git a/winamp/winamp_lng/winamp_lng.vcxproj b/winamp/winamp_lng/winamp_lng.vcxproj
+index e7b87ad..aba4c94 100644
+--- a/winamp/winamp_lng/winamp_lng.vcxproj
++++ b/winamp/winamp_lng/winamp_lng.vcxproj
+@@ -26,25 +26,25 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+     <CharacterSet>Unicode</CharacterSet>
+     <WholeProgramOptimization>false</WholeProgramOptimization>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+     <CharacterSet>Unicode</CharacterSet>
+     <WholeProgramOptimization>false</WholeProgramOptimization>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+     <CharacterSet>Unicode</CharacterSet>
+     <WholeProgramOptimization>false</WholeProgramOptimization>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>DynamicLibrary</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+     <CharacterSet>Unicode</CharacterSet>
+     <WholeProgramOptimization>false</WholeProgramOptimization>
+   </PropertyGroup>
+@@ -65,7 +65,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+diff --git a/wvgainexe/wvgain.vcxproj b/wvgainexe/wvgain.vcxproj
+index b7331b9..a463dad 100644
+--- a/wvgainexe/wvgain.vcxproj
++++ b/wvgainexe/wvgain.vcxproj
+@@ -25,19 +25,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -56,7 +56,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+diff --git a/wvtagexe/wvtag.vcxproj b/wvtagexe/wvtag.vcxproj
+index b593ab8..20a85aa 100644
+--- a/wvtagexe/wvtag.vcxproj
++++ b/wvtagexe/wvtag.vcxproj
+@@ -26,19 +26,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -57,7 +57,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+diff --git a/wvunpackexe/wvunpack.vcxproj b/wvunpackexe/wvunpack.vcxproj
+index 599b888..794e92a 100644
+--- a/wvunpackexe/wvunpack.vcxproj
++++ b/wvunpackexe/wvunpack.vcxproj
+@@ -25,19 +25,19 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+     <ConfigurationType>Application</ConfigurationType>
+-    <PlatformToolset>v142</PlatformToolset>
++    <PlatformToolset>v141</PlatformToolset>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+@@ -56,7 +56,7 @@
+   </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+-    <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
++    <_ProjectFileVersion>15.9.28307.1500</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>

--- a/ThirdParty/submodule_WavPack_CUETools_VS2019.patch
+++ b/ThirdParty/submodule_WavPack_CUETools_VS2019.patch
@@ -1,0 +1,338 @@
+diff --git a/src/libwavpack.vcxproj b/src/libwavpack.vcxproj
+index 3d586d6..e3299c5 100644
+--- a/src/libwavpack.vcxproj
++++ b/src/libwavpack.vcxproj
+@@ -61,29 +61,29 @@
+     <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+   </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+     <ClCompile>
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+@@ -96,10 +96,10 @@
+     <ClCompile>
+       <Optimization>Disabled</Optimization>
+       <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <MinimalRebuild>true</MinimalRebuild>
+       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+@@ -113,10 +113,10 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <StringPooling>true</StringPooling>
+       <ExceptionHandling />
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <BufferSecurityCheck>false</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <DisableLanguageExtensions>false</DisableLanguageExtensions>
+@@ -142,10 +142,10 @@
+       <IntrinsicFunctions>true</IntrinsicFunctions>
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <StringPooling>true</StringPooling>
+       <ExceptionHandling />
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <BufferSecurityCheck>false</BufferSecurityCheck>
+       <FunctionLevelLinking>true</FunctionLevelLinking>
+       <DisableLanguageExtensions>false</DisableLanguageExtensions>
+@@ -172,13 +172,33 @@
+     <ClCompile Include="entropy_utils.c" />
+     <ClCompile Include="extra1.c" />
+     <ClCompile Include="extra2.c" />
+-    <ClCompile Include="open_filename.c" />
+-    <ClCompile Include="open_legacy.c" />
+-    <ClCompile Include="open_raw.c" />
++    <ClCompile Include="open_filename.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
++    <ClCompile Include="open_legacy.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
++    <ClCompile Include="open_raw.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
+     <ClCompile Include="open_utils.c" />
+     <ClCompile Include="pack.c" />
+     <ClCompile Include="pack_dns.c" />
+-    <ClCompile Include="pack_dsd.c" />
++    <ClCompile Include="pack_dsd.c">
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++    </ClCompile>
+     <ClCompile Include="pack_floats.c" />
+     <ClCompile Include="pack_utils.c" />
+     <ClCompile Include="read_words.c" />
+diff --git a/wavpackdll/wavpackdll.rc b/wavpackdll/wavpackdll.rc
+index 782c69f..4ea10a3 100644
+--- a/wavpackdll/wavpackdll.rc
++++ b/wavpackdll/wavpackdll.rc
+@@ -7,7 +7,7 @@
+ //
+ // Generated from the TEXTINCLUDE 2 resource.
+ //
+-#include "afxres.h"
++#include "winres.h"
+ 
+ /////////////////////////////////////////////////////////////////////////////
+ #undef APSTUDIO_READONLY_SYMBOLS
+@@ -34,7 +34,7 @@ END
+ 
+ 2 TEXTINCLUDE 
+ BEGIN
+-    "#include ""afxres.h""\r\n"
++    "#include ""winres.h""\r\n"
+     "\0"
+ END
+ 
+diff --git a/wavpackdll/wavpackdll.vcxproj b/wavpackdll/wavpackdll.vcxproj
+index eabba53..5a77dea 100644
+--- a/wavpackdll/wavpackdll.vcxproj
++++ b/wavpackdll/wavpackdll.vcxproj
+@@ -61,22 +61,22 @@
+     <_ProjectFileVersion>16.0.30804.86</_ProjectFileVersion>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>true</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>true</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+-    <IntDir>$(Configuration)\</IntDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>false</LinkIncremental>
+   </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
++    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
+     <IntDir>$(Platform)\$(Configuration)\</IntDir>
+     <LinkIncremental>false</LinkIncremental>
+   </PropertyGroup>
+@@ -93,18 +93,18 @@
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetEncodedNoise
+ 
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -116,11 +116,11 @@
+ /export:WavpackLittleEndianToNative /export:WavpackNativeToLittleEndian
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+@@ -150,16 +150,16 @@
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -171,11 +171,11 @@
+ /export:WavpackLittleEndianToNative /export:WavpackNativeToLittleEndian
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+@@ -198,23 +198,23 @@
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+       <WholeProgramOptimization>false</WholeProgramOptimization>
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -227,11 +227,11 @@
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ /export:WavpackGetEncodedNoise
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
+@@ -259,25 +259,25 @@
+       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+       <OmitFramePointers>true</OmitFramePointers>
+       <WholeProgramOptimization>false</WholeProgramOptimization>
+-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+       <PrecompiledHeader />
+       <WarningLevel>Level3</WarningLevel>
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <CompileAs>Default</CompileAs>
+     </ClCompile>
+     <Link>
+-      <AdditionalOptions>/export:WavpackOpenFileInput /export:WavpackOpenFileInputEx /export:WavpackGetMode
++      <AdditionalOptions>/export:WavpackGetMode
+ /export:WavpackGetVersion /export:WavpackGetErrorMessage /export:WavpackUnpackSamples
+-/export:WavpackSeekSample /export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
++/export:WavpackGetNumTagItems /export:WavpackGetNumBinaryTagItems /export:WavpackGetTagItem /export:WavpackGetBinaryTagItem
+ /export:WavpackGetEncodedNoise
+ 
+ /export:WavpackGetTagItemIndexed /export:WavpackGetBinaryTagItemIndexed /export:WavpackOpenFileOutput
+-/export:WavpackSetConfiguration /export:WavpackPackInit /export:WavpackPackSamples
++/export:WavpackPackInit /export:WavpackPackSamples
+ /export:WavpackFlushSamples /export:WavpackAddWrapper /export:WavpackStoreMD5Sum
+ /export:WavpackUpdateNumSamples /export:WavpackGetWrapperLocation
+ /export:WavpackAppendTagItem /export:WavpackAppendBinaryTagItem /export:WavpackDeleteTagItem /export:WavpackWriteTag
+-/export:WavpackGetNumSamples /export:WavpackGetSampleIndex /export:WavpackGetNumErrors
+-/export:WavpackLossyBlocks /export:WavpackGetProgress /export:WavpackGetFileSize
++/export:WavpackGetNumErrors
++/export:WavpackLossyBlocks /export:WavpackGetProgress
+ /export:WavpackGetRatio /export:WavpackGetAverageBitrate /export:WavpackGetInstantBitrate
+ /export:WavpackCloseFile /export:WavpackGetSampleRate /export:WavpackGetNumChannels
+ /export:WavpackGetChannelMask /export:WavpackGetFloatNormExp
+@@ -289,11 +289,11 @@
+ /export:WavpackLittleEndianToNative /export:WavpackNativeToLittleEndian
+ /export:WavpackGetLibraryVersion /export:WavpackGetLibraryVersionString
+ 
+-/export:WavpackOpenRawDecoder /export:WavpackOpenFileInputEx64
++/export:WavpackOpenFileInputEx64
+ /export:WavpackGetNumSamples64 /export:WavpackGetSampleIndex64
+ /export:WavpackSeekSample64 /export:WavpackGetFileSize64
+ /export:WavpackGetQualifyMode /export:WavpackGetFileExtension
+-/export:WavpackGetFileFormat /export:WavpackGetNumSamplesInFrame
++/export:WavpackGetFileFormat
+ /export:WavpackGetNativeSampleRate /export:WavpackGetChannelIdentities
+ /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
+ /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout


### PR DESCRIPTION
- Used the following commands, to switch the WavPack submodule to
  upstream [dbry/WavPack](https://github.com/dbry/WavPack) repo and checkout commit dbry/WavPack@2ce3c06 (5.4.0):
```sh
    git submodule set-url ThirdParty/WavPack \
    https://github.com/dbry/WavPack.git
    git submodule update --init --recursive --remote ThirdParty/WavPack
    pushd ThirdParty/WavPack/
    git checkout 2ce3c069be548e82ea9c05741ace6583e549c6de
    popd
```
- Add patch based on commits of GitHub repo [gchudov/WavPack](https://github.com/gchudov/WavPack)
  "Converted projects to work with VS2017 and configured wavpackdll for
  use with CUETools."
  (commits c2d60b1, 9b59bcd), which is applied using:
  `git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools_VS2017.patch`
- A patch for compiling with VS2019 is provided too:
  `ThirdParty/submodule_WavPack_CUETools_VS2019.patch`
- Add info on how to apply the patch to `README.md`
- Update GitHub actions accordingly for applying the patch to the
  checked out dbry/WavPack submodule