### PR TITLE
Fix CUEConfigAdvanced copy constructor

### DIFF
--- a/CUETools.Processor/CUEConfigAdvanced.cs
+++ b/CUETools.Processor/CUEConfigAdvanced.cs
@@ -37,6 +37,7 @@ namespace CUETools.Processor
         }
 
         public CUEConfigAdvanced(CUEConfigAdvanced src)
+            : base(src)
         {
             // Iterate through each property and call SetValue()
             foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(this))


### PR DESCRIPTION
This PR contains the fix as suggested by @RDamman in https://github.com/gchudov/cuetools.net/issues/113#issuecomment-904517997:

Call to the right (copy) constructor of the base class in
CUEConfigAdvanced.cs

- Resolves #113