### PR TITLE
Add AfterBuild target to CUETools.Compression.Rar

### DIFF
--- a/CUETools.Compression.Rar/CUETools.Compression.Rar.csproj
+++ b/CUETools.Compression.Rar/CUETools.Compression.Rar.csproj
@@ -31,4 +31,11 @@
     <ProjectReference Include="..\CUETools.Compression\CUETools.Compression.csproj" />
   </ItemGroup>
 
+  <Target Name="CopyFiles" AfterTargets="Build">
+    <CreateItem Include="$(OutputPath)\CUETools.Compression.Rar.*">
+      <Output TaskParameter="Include" ItemName="FilesToCopy" />
+    </CreateItem>
+    <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(OutputPath)\..\x64\" ContinueOnError="true" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
The `OutputPath` of `CUETools.Compression.Rar.csproj` points to the
`plugins\win32` directory by default. Add AfterBuild target for copying
`CUETools.Compression.Rar.*` to the `plugins\x64` directory.
Background: `CUETools.Compression.Rar.dll` needs to be in the same
directory as `win32\unrar.dll` or `x64\Unrar.dll` and is therefore copied.