### PR TITLE
Fix writing of tags for CD-Singles

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1445,7 +1445,7 @@ namespace CUETools.Processor
             }
 
             // Store the audio filenames, generating generic names if necessary
-            _hasSingleFilename = _sourcePaths.Count == 1;
+            _hasSingleFilename = (_sourcePaths.Count == 1 && TrackCount > 1); // Enable _hasTrackFilenames for CD-Singles with 1 track
             _singleFilename = _hasSingleFilename ? Path.GetFileName(_sourcePaths[0]) :
                 "Range.wav";
 


### PR DESCRIPTION
In case of CD-Singles with one track, the tags `AccurateRip`, `CTDB` and
`CDTOC` were only written upon verify or encode , if the CD-Single
had been ripped in image mode with embedded `CUESheet`.
- Enable writing of these tags also for CD-Singles (with one track),
  which have been ripped in track mode.
- Resolves #121
