### PR TITLE
Support UTF-8 encoding when reading cuesheets

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1093,7 +1093,7 @@ namespace CUETools.Processor
                 if (_config.autoCorrectFilenames)
                     sr = new StringReader(CorrectAudioFilenames(_config, pathIn, false));
                 else
-                    sr = new StreamReader(pathIn, CUESheet.Encoding);
+                    sr = StreamReader_UTF_ANSI(pathIn);
 
                 _logFiles = new List<CUEToolsSourceFile>();
                 _defaultLog = Path.GetFileNameWithoutExtension(pathIn);
@@ -3872,7 +3872,7 @@ namespace CUETools.Processor
 
         public static string CorrectAudioFilenames(CUEConfig _config, string path, bool always)
         {
-            StreamReader sr = new StreamReader(path, CUESheet.Encoding);
+            StreamReader sr = StreamReader_UTF_ANSI(path);
             string cue = sr.ReadToEnd();
             sr.Close();
             string extension;


### PR DESCRIPTION
CUETools currently supports reading of cuesheets in `ANSI` or `UTF-8-BOM`
format. In case of `UTF-8` files without BOM, issues with special
characters in filenames and cuesheets can occur.

- Use method `StreamReader_UTF_ANSI()` in `CorrectAudioFilenames()`.
  Detect, if file is `UTF-8-BOM` or `UTF-8` without BOM. Otherwise
  fall back to default encoding, which is typically `ANSI`.
