### PR TITLE
Add info about stdin

### DIFF
--- a/CUETools.ALACEnc/Program.cs
+++ b/CUETools.ALACEnc/Program.cs
@@ -11,7 +11,7 @@ namespace CUETools.ALACEnc
 	{
 		static void Usage()
 		{
-			Console.WriteLine("Usage    : CUETools.ALACEnc.exe [options] <input.wav>");
+			Console.WriteLine("Usage    : CUETools.ALACEnc.exe [options] <input.wav> (or \"-\" for stdin)");
 			Console.WriteLine();
 			Console.WriteLine("Options:");
 			Console.WriteLine();

--- a/CUETools.FLACCL.cmd/Program.cs
+++ b/CUETools.FLACCL.cmd/Program.cs
@@ -31,7 +31,7 @@ namespace CUETools.FLACCL.cmd
 	{
 		static void Usage()
 		{
-			Console.WriteLine("Usage    : CUETools.FLACCL.exe [options] <input.wav>");
+			Console.WriteLine("Usage    : CUETools.FLACCL.exe [options] <input.wav> (or \"-\" for stdin)");
 			Console.WriteLine();
 			Console.WriteLine("Options:");
 			Console.WriteLine();

--- a/CUETools.FlaCudaExe/Program.cs
+++ b/CUETools.FlaCudaExe/Program.cs
@@ -31,7 +31,7 @@ namespace CUETools.FlaCudaExe
 	{
 		static void Usage()
 		{
-			Console.WriteLine("Usage    : CUETools.FlaCuda.exe [options] <input.wav>");
+			Console.WriteLine("Usage    : CUETools.FlaCuda.exe [options] <input.wav> (or \"-\" for stdin)");
 			Console.WriteLine();
 			Console.WriteLine("Options:");
 			Console.WriteLine();

--- a/CUETools.Flake/Program.cs
+++ b/CUETools.Flake/Program.cs
@@ -88,7 +88,7 @@ namespace CUETools.FlakeExe
     {
         static void Usage()
         {
-            Console.WriteLine("Usage    : CUETools.Flake.exe [options] <input.wav>");
+            Console.WriteLine("Usage    : CUETools.Flake.exe [options] <input.wav> (or \"-\" for stdin)");
             Console.WriteLine();
             Console.WriteLine("Options:");
             Console.WriteLine();


### PR DESCRIPTION
The command line tools `CUETools.ALACEnc.exe`, `CUETools.FLACCL.cmd.exe`
and `CUETools.Flake.exe` allow usage of "-" (without quotes) for `stdin`.
Add this info to the command line help output.

- Resolves #141
