### PR TITLE
EACPlugin: Use TLS 1.2 for coverart download

### DIFF
--- a/CUETools.CTDB.EACPlugin/FormMetadata.cs
+++ b/CUETools.CTDB.EACPlugin/FormMetadata.cs
@@ -57,6 +57,7 @@ namespace CUETools.CTDB.EACPlugin
 
         private void backgroundWorker1_DoWork(object sender, DoWorkEventArgs e)
         {
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)Enum.ToObject(typeof(SecurityProtocolType), 3072); // Use TLS 1.2
 #if DEBUG
             string server = "db.cuetools.net";
 #else


### PR DESCRIPTION
The coverartarchive.org site stopped supporting TLS 1.1.
EAC plugin is built for .NET 2.0, which doesn't use TLS 1.2 by default.
- Switch to TLS 1.2
- Resolves #150
