### PR TITLE
Update #124

### DIFF
--- a/Bwg.Scsi/Device.cs
+++ b/Bwg.Scsi/Device.cs
@@ -3703,7 +3703,7 @@ namespace Bwg.Scsi
         /// </summary>
         /// <param name="bDisable">If true, CD eject is disabled. If false, CD eject is enabled</param>
         /// <returns></returns>
-        public bool DisableEjectDrive(bool bDisable)
+        public bool DisableEjectDisc(bool bDisable)
         {
             PREVENT_MEDIA_REMOVAL pmr = new PREVENT_MEDIA_REMOVAL();
             pmr.PreventMediaRemoval = bDisable ? 1u : 0u;

--- a/CUERipper/Options.cs
+++ b/CUERipper/Options.cs
@@ -70,11 +70,11 @@ namespace CUERipper
         [DefaultValue(true), Category("Extraction"), DisplayName("Embed album art")]
         public bool embedAlbumArt { get { return config.embedAlbumArt; } set { config.embedAlbumArt = value; } }
 
-        [DefaultValue(true), Category("Extraction"), DisplayName("Eject after rip")]
+        [DefaultValue(false), Category("Extraction"), DisplayName("Eject after rip")]
         public bool ejectAfterRip { get { return config.ejectAfterRip; } set { config.ejectAfterRip = value; } }
 
-        [DefaultValue(false), Category("Extraction"), DisplayName("Disable eject drive")]
-        public bool disableDriveEject { get { return config.disableEjectDrive; } set { config.disableEjectDrive = value; } }
+        [DefaultValue(false), Category("Extraction"), DisplayName("Disable eject disc")]
+        public bool disableEjectDisc { get { return config.disableEjectDisc; } set { config.disableEjectDisc = value; } }
 
         [DefaultValue("%tracknumber%. %title%"), Category("Extraction"), DisplayName("Track filename")]
         public string trackFilenameFormat { get { return config.trackFilenameFormat; } set { config.trackFilenameFormat = value; } }

--- a/CUERipper/Options.cs
+++ b/CUERipper/Options.cs
@@ -70,6 +70,12 @@ namespace CUERipper
         [DefaultValue(true), Category("Extraction"), DisplayName("Embed album art")]
         public bool embedAlbumArt { get { return config.embedAlbumArt; } set { config.embedAlbumArt = value; } }
 
+        [DefaultValue(true), Category("Extraction"), DisplayName("Eject after rip")]
+        public bool ejectAfterRip { get { return config.ejectAfterRip; } set { config.ejectAfterRip = value; } }
+
+        [DefaultValue(false), Category("Extraction"), DisplayName("Disable eject drive")]
+        public bool disableDriveEject { get { return config.disableEjectDrive; } set { config.disableEjectDrive = value; } }
+
         [DefaultValue("%tracknumber%. %title%"), Category("Extraction"), DisplayName("Track filename")]
         public string trackFilenameFormat { get { return config.trackFilenameFormat; } set { config.trackFilenameFormat = value; } }
 

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 using CUEControls;
 using CUETools.AccurateRip;
 using CUETools.CTDB;
@@ -201,6 +202,80 @@ namespace CUERipper
 		const ushort DBT_DEVNODES_CHANGED = 0x0007;
 		#endregion
 
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal class DEV_BROADCAST_HDR
+		{
+			internal Int32 dbch_size;
+			internal Int32 dbch_devicetype;
+			internal Int32 dbch_reserved;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct DEV_BROADCAST_VOLUME
+		{
+			public DEV_BROADCAST_HDR Header;
+			public int UnitMask;
+			public short Flags;
+		}
+
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+		internal class DEV_BROADCAST_PORT
+		{
+			public int dbcp_size;
+			public int dbcp_devicetype;
+			public int dbcp_reserved; // MSDN say "do not use"
+			[MarshalAs(UnmanagedType.ByValArray, SizeConst = 255)]
+			public byte[] dbcp_name;
+		}
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+		internal class DEV_BROADCAST_DEVICEINTERFACE
+		{
+			public Int32 dbcc_size;
+			public Int32 dbcc_devicetype;
+			public Int32 dbcc_reserved;
+			[MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)]
+			internal Byte[] dbcc_classguid;
+			[MarshalAs(UnmanagedType.ByValArray, SizeConst = 255)]
+			internal Byte[] dbcc_name;
+		}
+
+		private int firstBitSet(int iIn)
+		{
+			for (int i = 0; i < 32; i++)
+			{
+				if ((iIn & 1) != 0)
+					return i;
+				iIn >>= 1;
+			};
+			return -1;
+		}
+
+#if DEBUG
+		private const int DBT_DEVTYPE_VOLUME = 2;
+		private void logDeviceChangeEvent(ref Message rMessageIn)
+		{
+			int iVal = rMessageIn.WParam.ToInt32();
+			DEV_BROADCAST_HDR hdr = (DEV_BROADCAST_HDR)Marshal.PtrToStructure(rMessageIn.LParam, typeof(DEV_BROADCAST_HDR));
+			if (hdr.dbch_devicetype == DBT_DEVTYPE_VOLUME)
+			{
+				DEV_BROADCAST_VOLUME vol = (DEV_BROADCAST_VOLUME)Marshal.PtrToStructure(rMessageIn.LParam, typeof(DEV_BROADCAST_VOLUME));
+				char cDriveLetter = (char)(firstBitSet(vol.UnitMask) + ((int)'A'));
+				// here we get drive mount point from bitmask
+				string sMessage = cDriveLetter + ":";
+				if (iVal == DBT_DEVICEARRIVAL)
+					sMessage = "DBT_DEVICEARRIVAL " + sMessage;
+				else if (iVal == DBT_DEVICEREMOVECOMPLETE)
+					sMessage = "DBT_DEVICEREMOVECOMPLETE " + sMessage;
+				else if (iVal == DBT_DEVICEREMOVECOMPLETE)
+					sMessage = "DBT_DEVICEREMOVECOMPLETE " + sMessage;
+				System.Diagnostics.Trace.WriteLine(sMessage);
+			}
+		}
+#endif
+
 		/// <summary>
 		/// This method is called when a window message is processed by the dotnet application
 		/// framework.  We override this method and look for the WM_DEVICECHANGE message. All
@@ -211,19 +286,22 @@ namespace CUERipper
 		/// <param name="m">the windows message being processed</param>
 		protected override void WndProc(ref Message m)
 		{
-			if (m.Msg == WM_DEVICECHANGE && _workThread == null)
+			if (m.Msg == WM_DEVICECHANGE)
 			{
-				int val = m.WParam.ToInt32();
-				if (val == DBT_DEVICEARRIVAL || val == DBT_DEVICEREMOVECOMPLETE)
+				if (_workThread == null)
 				{
-					// Save current metadata before clearing
-					if (data.selectedRelease != null)
-						data.selectedRelease.metadata.Save();
-					UpdateDrive();
-				}
-				else if (val == DBT_DEVNODES_CHANGED)
-				{
-					if (_workThread == null)
+					int val = m.WParam.ToInt32();
+					if (val == DBT_DEVICEARRIVAL || val == DBT_DEVICEREMOVECOMPLETE)
+					{
+#if DEBUG
+						logDeviceChangeEvent(ref m);
+#endif
+						// Save current metadata before clearing
+						if (data.selectedRelease != null)
+							data.selectedRelease.metadata.Save();
+						UpdateDrive();
+					}
+					else if (val == DBT_DEVNODES_CHANGED)
 					{
 						// Save current metadata before clearing
 						if (data.selectedRelease != null)
@@ -408,9 +486,14 @@ namespace CUERipper
 
 			audioSource.ReadProgress += new EventHandler<ReadProgressArgs>(CDReadProgress);
 			audioSource.DriveOffset = (int)numericWriteOffset.Value;
-
+			bool bDisableEjectDrive = _config.disableEjectDrive;
 			try
 			{
+				if (bDisableEjectDrive)
+				this.Invoke((MethodInvoker)delegate ()
+				{
+					audioSource.DisableEjectDrive(true);
+				});
                 if (this.testAndCopy)
                     cueSheet.TestBeforeCopy();
                 else
@@ -433,15 +516,23 @@ namespace CUERipper
 				}
 				this.Invoke((MethodInvoker)delegate()
 				{
+					if (bDisableEjectDrive)
+					{
+						audioSource.DisableEjectDrive(false);
+						bDisableEjectDrive = false;
+					}
+					if (_config.ejectAfterRip)
+						audioSource.EjectDisk();
+
                     DialogResult dlgRes = audioSource.FailedSectors.PopulationCount() != 0 ? 
 						MessageBox.Show(this, cueSheet.GenerateVerifyStatus() + (canFix ? "\n" + Properties.Resources.DoneRippingRepair : "") + ".", Properties.Resources.DoneRippingErrors, MessageBoxButtons.OK, MessageBoxIcon.Error) :
 						MessageBox.Show(this, cueSheet.GenerateVerifyStatus() + ".", Properties.Resources.DoneRipping, MessageBoxButtons.OK, MessageBoxIcon.Information);
-				});
+                });
 			}
 			catch (StopException)
 			{
 			}
-#if !DEBUG
+//#if !DEBUG
 			catch (Exception ex)
 			{
 				this.Invoke((MethodInvoker)delegate()
@@ -452,7 +543,15 @@ namespace CUERipper
 					DialogResult dlgRes = MessageBox.Show(this, message, Properties.Resources.ExceptionMessage, MessageBoxButtons.OK, MessageBoxIcon.Error);
 				});
 			}
-#endif
+//#endif
+			finally
+			{
+				if (bDisableEjectDrive)
+					this.Invoke((MethodInvoker)delegate ()
+					{
+					audioSource.DisableEjectDrive(false);
+					});
+			}
 
 			audioSource.ReadProgress -= new EventHandler<ReadProgressArgs>(CDReadProgress);
 			try
@@ -474,7 +573,9 @@ namespace CUERipper
 			this.BeginInvoke((MethodInvoker)delegate()
 			{
 				SetupControls();
-				UpdateOutputPath();
+//				if (_config.ejectAfterRip)
+					UpdateDrive();
+//				UpdateOutputPath();
 			});
 		}
 
@@ -1681,9 +1782,13 @@ namespace CUERipper
 
         private void buttonEjectDisk_Click(object sender, EventArgs e)
         {
-            if (selectedDriveInfo != null)
-                selectedDriveInfo.drive.EjectDisk();
-        }
+			if (selectedDriveInfo != null)
+			{
+				selectedDriveInfo.drive.DisableEjectDrive(false);
+				selectedDriveInfo.drive.EjectDisk();
+			}
+			UpdateDrive();
+		}
 	}
 
     internal class BackgroundWorkerArtworkArgs

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -486,13 +486,13 @@ namespace CUERipper
 
 			audioSource.ReadProgress += new EventHandler<ReadProgressArgs>(CDReadProgress);
 			audioSource.DriveOffset = (int)numericWriteOffset.Value;
-			bool bDisableEjectDrive = _config.disableEjectDrive;
+			bool bDisableEjectDisc = _config.disableEjectDisc;
 			try
 			{
-				if (bDisableEjectDrive)
+				if (bDisableEjectDisc)
 				this.Invoke((MethodInvoker)delegate ()
 				{
-					audioSource.DisableEjectDrive(true);
+					audioSource.DisableEjectDisc(true);
 				});
                 if (this.testAndCopy)
                     cueSheet.TestBeforeCopy();
@@ -516,10 +516,10 @@ namespace CUERipper
 				}
 				this.Invoke((MethodInvoker)delegate()
 				{
-					if (bDisableEjectDrive)
+					if (bDisableEjectDisc)
 					{
-						audioSource.DisableEjectDrive(false);
-						bDisableEjectDrive = false;
+						audioSource.DisableEjectDisc(false);
+						bDisableEjectDisc = false;
 					}
 					if (_config.ejectAfterRip)
 						audioSource.EjectDisk();
@@ -546,10 +546,10 @@ namespace CUERipper
 //#endif
 			finally
 			{
-				if (bDisableEjectDrive)
+				if (bDisableEjectDisc)
 					this.Invoke((MethodInvoker)delegate ()
 					{
-					audioSource.DisableEjectDrive(false);
+					audioSource.DisableEjectDisc(false);
 					});
 			}
 
@@ -1784,7 +1784,7 @@ namespace CUERipper
         {
 			if (selectedDriveInfo != null)
 			{
-				selectedDriveInfo.drive.DisableEjectDrive(false);
+				selectedDriveInfo.drive.DisableEjectDisc(false);
 				selectedDriveInfo.drive.EjectDisk();
 			}
 			UpdateDrive();

--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -29,7 +29,7 @@ namespace CUETools.Processor
         public bool detectGaps;
         public bool preserveHTOA;
         public bool ejectAfterRip;
-        public bool disableEjectDrive;
+        public bool disableEjectDisc;
         public bool keepOriginalFilenames;
         public string trackFilenameFormat;
         public string singleFilenameFormat;
@@ -94,8 +94,8 @@ namespace CUETools.Processor
 
             autoCorrectFilenames = true;
             preserveHTOA = true;
-            ejectAfterRip = true;
-            disableEjectDrive = false;
+            ejectAfterRip = false;
+            disableEjectDisc = false;
             detectGaps = true;
             keepOriginalFilenames = false;
             trackFilenameFormat = "%tracknumber%. %title%";
@@ -177,7 +177,7 @@ namespace CUETools.Processor
             autoCorrectFilenames = src.autoCorrectFilenames;
             preserveHTOA = src.preserveHTOA;
             ejectAfterRip = src.ejectAfterRip;
-            disableEjectDrive = src.disableEjectDrive;
+            disableEjectDisc = src.disableEjectDisc;
             detectGaps = src.detectGaps;
             keepOriginalFilenames = src.keepOriginalFilenames;
             trackFilenameFormat = src.trackFilenameFormat;
@@ -259,7 +259,7 @@ namespace CUETools.Processor
 
             sw.Save("PreserveHTOA", preserveHTOA);
             sw.Save("EjectAfterRip", ejectAfterRip);
-            sw.Save("DisableEjectButtonDrive", disableEjectDrive);
+            sw.Save("DisableEjectDisc", disableEjectDisc);
             sw.Save("DetectGaps", detectGaps);            
             sw.Save("AutoCorrectFilenames", autoCorrectFilenames);
             sw.Save("KeepOriginalFilenames", keepOriginalFilenames);
@@ -361,8 +361,8 @@ namespace CUETools.Processor
             writeArLogOnVerify = sr.LoadBoolean("ArWriteLogOnVerify") ?? false;
 
             preserveHTOA = sr.LoadBoolean("PreserveHTOA") ?? true;
-            ejectAfterRip = sr.LoadBoolean("EjectAfterRip") ?? true;
-            disableEjectDrive = sr.LoadBoolean("DisableEjectButtonDrive") ?? false;
+            ejectAfterRip = sr.LoadBoolean("EjectAfterRip") ?? false;
+            disableEjectDisc = sr.LoadBoolean("DisableEjectDisc") ?? false;
             detectGaps = sr.LoadBoolean("DetectGaps") ?? true;
             autoCorrectFilenames = sr.LoadBoolean("AutoCorrectFilenames") ?? true;
             keepOriginalFilenames = sr.LoadBoolean("KeepOriginalFilenames") ?? false;

--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -28,6 +28,8 @@ namespace CUETools.Processor
         public bool autoCorrectFilenames;
         public bool detectGaps;
         public bool preserveHTOA;
+        public bool ejectAfterRip;
+        public bool disableEjectDrive;
         public bool keepOriginalFilenames;
         public string trackFilenameFormat;
         public string singleFilenameFormat;
@@ -92,6 +94,8 @@ namespace CUETools.Processor
 
             autoCorrectFilenames = true;
             preserveHTOA = true;
+            ejectAfterRip = true;
+            disableEjectDrive = false;
             detectGaps = true;
             keepOriginalFilenames = false;
             trackFilenameFormat = "%tracknumber%. %title%";
@@ -172,6 +176,8 @@ namespace CUETools.Processor
 
             autoCorrectFilenames = src.autoCorrectFilenames;
             preserveHTOA = src.preserveHTOA;
+            ejectAfterRip = src.ejectAfterRip;
+            disableEjectDrive = src.disableEjectDrive;
             detectGaps = src.detectGaps;
             keepOriginalFilenames = src.keepOriginalFilenames;
             trackFilenameFormat = src.trackFilenameFormat;
@@ -252,6 +258,8 @@ namespace CUETools.Processor
             sw.Save("ArWriteLogOnVerify", writeArLogOnVerify);
 
             sw.Save("PreserveHTOA", preserveHTOA);
+            sw.Save("EjectAfterRip", ejectAfterRip);
+            sw.Save("DisableEjectButtonDrive", disableEjectDrive);
             sw.Save("DetectGaps", detectGaps);            
             sw.Save("AutoCorrectFilenames", autoCorrectFilenames);
             sw.Save("KeepOriginalFilenames", keepOriginalFilenames);
@@ -353,6 +361,8 @@ namespace CUETools.Processor
             writeArLogOnVerify = sr.LoadBoolean("ArWriteLogOnVerify") ?? false;
 
             preserveHTOA = sr.LoadBoolean("PreserveHTOA") ?? true;
+            ejectAfterRip = sr.LoadBoolean("EjectAfterRip") ?? true;
+            disableEjectDrive = sr.LoadBoolean("DisableEjectButtonDrive") ?? false;
             detectGaps = sr.LoadBoolean("DetectGaps") ?? true;
             autoCorrectFilenames = sr.LoadBoolean("AutoCorrectFilenames") ?? true;
             keepOriginalFilenames = sr.LoadBoolean("KeepOriginalFilenames") ?? false;

--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -635,10 +635,10 @@ namespace CUETools.Ripper.SCSI
             }
         }
 
-        public void DisableEjectDrive(bool bDisable)
+        public void DisableEjectDisc(bool bDisable)
         {
             if (m_device != null)
-                m_device.DisableEjectDrive(bDisable);
+                m_device.DisableEjectDisc(bDisable);
             else
             {
                 try
@@ -648,7 +648,7 @@ namespace CUETools.Ripper.SCSI
                     {
                         try
                         {
-                            m_device.DisableEjectDrive(bDisable);
+                            m_device.DisableEjectDisc(bDisable);
                         }
                         finally
                         {
@@ -663,7 +663,7 @@ namespace CUETools.Ripper.SCSI
             }
         }
 
-        bool gapsDetected = false;
+		bool gapsDetected = false;
 
 		public unsafe bool DetectGaps()
 		{

--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -635,7 +635,35 @@ namespace CUETools.Ripper.SCSI
             }
         }
 
-		bool gapsDetected = false;
+        public void DisableEjectDrive(bool bDisable)
+        {
+            if (m_device != null)
+                m_device.DisableEjectDrive(bDisable);
+            else
+            {
+                try
+                {
+                    m_device = new Device(m_logger);
+                    if (m_device.Open(m_device_letter))
+                    {
+                        try
+                        {
+                            m_device.DisableEjectDrive(bDisable);
+                        }
+                        finally
+                        {
+                            m_device.Close();
+                        }
+                    }
+                }
+                finally
+                {
+                    m_device = null;
+                }
+            }
+        }
+
+        bool gapsDetected = false;
 
 		public unsafe bool DetectGaps()
 		{

--- a/CUETools.Ripper/Ripper.cs
+++ b/CUETools.Ripper/Ripper.cs
@@ -12,7 +12,8 @@ namespace CUETools.Ripper
 	{
 		bool Open(char Drive);
         void EjectDisk();
-		bool DetectGaps();
+        void DisableEjectDrive(bool bDisable);
+        bool DetectGaps();
 		bool GapsDetected { get; }
 		CDImageLayout TOC { get; }
 		string ARName { get; }

--- a/CUETools.Ripper/Ripper.cs
+++ b/CUETools.Ripper/Ripper.cs
@@ -12,8 +12,8 @@ namespace CUETools.Ripper
 	{
 		bool Open(char Drive);
         void EjectDisk();
-        void DisableEjectDrive(bool bDisable);
-        bool DetectGaps();
+        void DisableEjectDisc(bool bDisable);
+		bool DetectGaps();
 		bool GapsDetected { get; }
 		CDImageLayout TOC { get; }
 		string ARName { get; }


### PR DESCRIPTION
This PR includes updates to #124.

- Set the default of "Eject after rip" to false, in order to preserve
  the default behavior of CUERipper.
- Rename `disableEjectDrive` to `disableEjectDisc` etc.
  It is rather the disc, which is ejected, and not the drive.
