### PR TITLE
Fix C2 error mode for two Pioneer drives

### DIFF
--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -812,8 +812,8 @@ namespace CUETools.Ripper.SCSI
 
 			ReadCDCommand[] readmode = { ReadCDCommand.ReadCdBEh, ReadCDCommand.ReadCdD8h };
 			Device.C2ErrorMode[] c2mode = { Device.C2ErrorMode.Mode294, Device.C2ErrorMode.Mode296, Device.C2ErrorMode.None };
-			// Mode294 does not work for these drives: LG GH24NSD1, ASUS DRW-24D5MT. Try Mode296 first
-			if (Path.Contains("GH24NSD1") || Path.Contains("DRW-24D5MT"))
+			// Mode294 does not work for these drives: LG GH24NSD1, ASUS DRW-24D5MT, PIONEER DVR-S21, PIONEER BDR-XD07U. Try Mode296 first
+			if (Path.Contains("GH24NSD1") || Path.Contains("DRW-24D5MT") || Path.Contains("DVR-S21") || Path.Contains("BDR-XD07U"))
 			{
 				c2mode.SetValue(Device.C2ErrorMode.Mode296, 0);
 				c2mode.SetValue(Device.C2ErrorMode.Mode294, 1);


### PR DESCRIPTION
- `C2ErrorMode.Mode294` does not work for these drives:
  PIONEER DVR-S21, BDR-XD07U. Try `Mode296` first.
- Fixes the following exceptions:
  - DVR-S21:
    `CUETools.Ripper.SCSI.SCSIException:`
    `'Error reading CD: medium error: UNRECOVERED READ ERROR'`
    - Resolves #133
  - BDR-XD07U:
    `Exception: Error reading CD: IoctlFailed`
    - Resolves #155
