### PR TITLE
[CUERipper] Save metadata before Eject

### DIFF
--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -1787,6 +1787,9 @@ namespace CUERipper
 				selectedDriveInfo.drive.DisableEjectDisc(false);
 				selectedDriveInfo.drive.EjectDisk();
 			}
+			// Save current metadata before clearing
+			if (data.selectedRelease != null)
+				data.selectedRelease.metadata.Save();
 			UpdateDrive();
 		}
 	}


### PR DESCRIPTION
Part of commit 9d2886e, `UpdateDrive()` has been added to
`buttonEjectDisk_Click()`, in order to fix #115.
However, `UpdateDrive()` clears modified metadata.

- Save the metadata before `UpdateDrive()`, similar to
  a2b12d1