### PR TITLE
[CUETools] Fix CTDB.FetchFile Exception

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1798,24 +1798,30 @@ namespace CUETools.Processor
                     // TODO: load secondary album art?
                     // TODO: load uri150 version first, load full version in background of choice form?
                     var ms = new MemoryStream();
-                    if (CTDB.FetchFile(imageMeta.uri, ms))
+                    try
                     {
-                        TagLib.Picture pic = new TagLib.Picture(new TagLib.ByteVector(ms.ToArray()));
-                        pic.Description = imageMeta.uri;
-                        using (MemoryStream imageStream = new MemoryStream(pic.Data.Data, 0, pic.Data.Count))
-                            try
-                            {
+                        if (CTDB.FetchFile(imageMeta.uri, ms))
+                        {
+                            TagLib.Picture pic = new TagLib.Picture(new TagLib.ByteVector(ms.ToArray()));
+                            pic.Description = imageMeta.uri;
+                            using (MemoryStream imageStream = new MemoryStream(pic.Data.Data, 0, pic.Data.Count))
+                                try
+                                {
 #if NET47 || NET20
-                                var image = Image.FromStream(ms);
-                                pic.Description += $" ({image.Width}x{image.Height})";
-                                //if (image.Height > 0 && image.Width > 0 && (image.Height * 1.0 / image.Width) > 0.9 && (image.Width * 1.0 / image.Height) > 0.9)
-                                //    isSquare = true;
-                                // pic.MimeType = f(image.RawFormat);
+                                    var image = Image.FromStream(ms);
+                                    pic.Description += $" ({image.Width}x{image.Height})";
+                                    //if (image.Height > 0 && image.Width > 0 && (image.Height * 1.0 / image.Width) > 0.9 && (image.Width * 1.0 / image.Height) > 0.9)
+                                    //    isSquare = true;
+                                    // pic.MimeType = f(image.RawFormat);
 #endif
-                            }
-                            catch { }
+                                }
+                                catch { }
 
-                        _albumArt.Add(pic);
+                            _albumArt.Add(pic);
+                        }
+                    }
+                    catch (Exception)
+                    {
                     }
                 }
                 CheckStop();


### PR DESCRIPTION
If "Verify using CTDB" is disabled, an exception can occur in
`LoadAndResizeAlbumArt()`. `CTDB` is `null` in this case and
`CTDB.FetchFile(imageMeta.uri, ms)` will throw the exception.
The exception occurs after selecting specific entries in the
"Select best match" window for albums, when there are different album
arts available from coverartarchive.org. In this case, the window for
selecting the album art is not shown anymore and the exception appears.

- Use "`try`" and `catch` the exception
- Fixes the following error:
  `Exception Object reference not set to an instance of an object.`
- This commit is an addition to 3f121a8
- Resolves #148
