### PR TITLE
[CUERipper] Save metadata before Exit

### DIFF
--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -1079,6 +1079,9 @@ namespace CUERipper
             }
 
 			sw.Close();
+			// Save current metadata
+			if (data.selectedRelease != null)
+				data.selectedRelease.metadata.Save();
 		}
 
 		private void listTracks_BeforeLabelEdit(object sender, LabelEditEventArgs e)


### PR DESCRIPTION
Up to now, entered metadata was lost when closing CUERipper, if it
had not been saved before by another event (e.g. Go, Eject).

- Save the metadata anyway, when closing CUERipper.
