### PR TITLE
Fix index error when 1st track is data track

### DIFF
--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -1057,7 +1057,7 @@ namespace CUERipper
 		{
 			if (data.selectedRelease == null) return;
 			if (e.Label != null && selectedDriveInfo.drive.TOC[e.Item + 1].IsAudio)
-				data.selectedRelease.metadata.Tracks[e.Item].Title = e.Label;
+				data.selectedRelease.metadata.Tracks[e.Item + 1 - selectedDriveInfo.drive.TOC.FirstAudio].Title = e.Label;
 			else
 				e.CancelEdit = true;
 		}


### PR DESCRIPTION
The issue occurred in case of CDs, where the first track is a data
track. After editing the title of the last audio track, the index was
out of range.

- `listTracks_AfterLabelEdit()`:
  Correct the index of `data.selectedRelease.metadata.Tracks[]` by adding
  "`1`" and subtracting "`selectedDriveInfo.drive.TOC.FirstAudio`", which
  is `1` if the first track is audio, and `2` if the first track is data.
- Fixes the following error:
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
   at System.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument, ExceptionResource resource)
   at CUERipper.frmCUERipper.listTracks_AfterLabelEdit(Object sender, LabelEditEventArgs e)
```
- Resolves #126