### PR TITLE
Fix C2 mode for HL-DT-ST BD-RE BU40N

### DIFF
--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -812,8 +812,8 @@ namespace CUETools.Ripper.SCSI
 
 			ReadCDCommand[] readmode = { ReadCDCommand.ReadCdBEh, ReadCDCommand.ReadCdD8h };
 			Device.C2ErrorMode[] c2mode = { Device.C2ErrorMode.Mode294, Device.C2ErrorMode.Mode296, Device.C2ErrorMode.None };
-			// Mode294 does not work for these drives: LG GH24NSD1, ASUS DRW-24D5MT, PIONEER DVR-S21, PIONEER BDR-XD07U. Try Mode296 first
-			if (Path.Contains("GH24NSD1") || Path.Contains("DRW-24D5MT") || Path.Contains("DVR-S21") || Path.Contains("BDR-XD07U"))
+			// Mode294 does not work for these drives: LG GH24NSD1, ASUS DRW-24D5MT, PIONEER DVR-S21, PIONEER BDR-XD07U, HL-DT-ST BD-RE BU40N. Try Mode296 first
+			if (Path.Contains("GH24NSD1") || Path.Contains("DRW-24D5MT") || Path.Contains("DVR-S21") || Path.Contains("BDR-XD07U") || Path.Contains("BU40N"))
 			{
 				c2mode.SetValue(Device.C2ErrorMode.Mode296, 0);
 				c2mode.SetValue(Device.C2ErrorMode.Mode294, 1);


### PR DESCRIPTION
- `C2ErrorMode.Mode294` does not work for this drive:
  **`HL-DT-ST BD-RE BU40N`**. Try `Mode296` first.
- Resolves #164