### PR TITLE
[CUETools] Use first album art in batch mode

### DIFF
--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -554,7 +554,11 @@ namespace JDP
         private void MakeSelection(object sender, CUEToolsSelectionEventArgs e)
         {
             if (_batchPaths.Count > 1 || _batchProcessed > 0)
+            {
+                // Select the first album art (or log file) in case of batch mode.
+                e.selection = 0;
                 return;
+            }
             this.Invoke((MethodInvoker)delegate()
             {
                 frmChoice dlg = new frmChoice();


### PR DESCRIPTION
Since 3f121a8 no album art is used in case of multiple album art files,
if no album art is selected in the dialog and also in batch mode [1].
The batch mode behavior before was to use the first one from the list
of found album art files.

- Return index 0 instead of -1 from the album art selection dialog in
  case of batch mode.
- Resolves:
  https://hydrogenaud.io/index.php?topic=122155.0

[1] https://github.com/gchudov/cuetools.net/blob/ddec34a1ff613fe63522e9a0a48f84f3e3356395/CUETools.Processor/CUESheet.cs#L1847