### PR TITLE
Make sure output template contains extension .cue

### DIFF
--- a/CUERipper/frmCUERipper.Designer.cs
+++ b/CUERipper/frmCUERipper.Designer.cs
@@ -614,6 +614,7 @@ namespace CUERipper
             this.bnComboBoxOutputFormat.TextChanged += new System.EventHandler(this.bnComboBoxOutputFormat_TextChanged);
             this.bnComboBoxOutputFormat.Leave += new System.EventHandler(this.bnComboBoxOutputFormat_Leave);
             this.bnComboBoxOutputFormat.MouseLeave += new System.EventHandler(this.bnComboBoxOutputFormat_MouseLeave);
+            this.bnComboBoxOutputFormat.Validating += new System.ComponentModel.CancelEventHandler(this.bnComboBoxOutputFormat_Validating);
             // 
             // listMetadata
             // 

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -179,6 +179,10 @@ namespace CUERipper
 				bnComboBoxOutputFormat.Items.Add(sr.Load(string.Format("OutputPathUseTemplate{0}", iFormat)) ?? "");
 
 			bnComboBoxOutputFormat.Text = sr.Load("PathFormat") ?? "%music%\\%artist%\\[%year% - ]%album%\\%artist% - %album%.cue";
+			if (!bnComboBoxOutputFormat.Text.EndsWith(".cue", StringComparison.InvariantCultureIgnoreCase))
+			{
+				bnComboBoxOutputFormat.Text = bnComboBoxOutputFormat.Text + ".cue";
+			}
 			SelectedOutputAudioType = (AudioEncoderType?)sr.LoadInt32("OutputAudioType", null, null) ?? AudioEncoderType.Lossless;
 			bnComboBoxImage.SelectedIndex = sr.LoadInt32("ComboImage", 0, bnComboBoxImage.Items.Count - 1) ?? 0;
 			trackBarSecureMode.Value = sr.LoadInt32("SecureMode", 0, trackBarSecureMode.Maximum - 1) ?? 1;
@@ -1327,6 +1331,15 @@ namespace CUERipper
 
 		private void bnComboBoxOutputFormat_TextChanged(object sender, EventArgs e)
 		{
+			UpdateOutputPath();
+		}
+
+		private void bnComboBoxOutputFormat_Validating(object sender, CancelEventArgs e)
+		{
+			if (!bnComboBoxOutputFormat.Text.EndsWith(".cue", StringComparison.InvariantCultureIgnoreCase))
+			{
+				bnComboBoxOutputFormat.Text = bnComboBoxOutputFormat.Text + ".cue";
+			}
 			UpdateOutputPath();
 		}
 

--- a/CUETools/frmCUETools.Designer.cs
+++ b/CUETools/frmCUETools.Designer.cs
@@ -603,6 +603,7 @@ namespace JDP {
             this.toolTip1.SetToolTip(this.comboBoxOutputFormat, resources.GetString("comboBoxOutputFormat.ToolTip"));
             this.comboBoxOutputFormat.SelectedIndexChanged += new System.EventHandler(this.comboBoxOutputFormat_SelectedIndexChanged);
             this.comboBoxOutputFormat.TextUpdate += new System.EventHandler(this.comboBoxOutputFormat_TextUpdate);
+            this.comboBoxOutputFormat.Validating += new System.ComponentModel.CancelEventHandler(this.comboBoxOutputFormat_Validating);
             // 
             // txtInputPath
             // 

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -319,6 +319,15 @@ namespace JDP
             UpdateOutputPath();
         }
 
+        private void comboBoxOutputFormat_Validating(object sender, CancelEventArgs e)
+        {
+            if (!comboBoxOutputFormat.Text.EndsWith(".cue", StringComparison.InvariantCultureIgnoreCase))
+            {
+                comboBoxOutputFormat.Text = comboBoxOutputFormat.Text + ".cue";
+            }
+            UpdateOutputPath();
+        }
+
         private void frmCUETools_Load(object sender, EventArgs e)
         {
             _batchPaths = new List<string>();
@@ -1357,6 +1366,10 @@ namespace JDP
             SelectedCUEStyle = _profile._CUEStyle;
             textBoxOffset.Text = _profile._writeOffset.ToString();
             comboBoxOutputFormat.Text = _profile._outputTemplate ?? comboBoxOutputFormat.Items[0].ToString();
+            if (!comboBoxOutputFormat.Text.EndsWith(".cue", StringComparison.InvariantCultureIgnoreCase))
+            {
+                comboBoxOutputFormat.Text = comboBoxOutputFormat.Text + ".cue";
+            }
             toolStripDropDownButtonProfile.Text = _profile._name;
             SelectedScript = _profile._script;
             checkBoxEditTags.Checked = _profile._editTags;


### PR DESCRIPTION
The output template needs to contain an extension, which is
typically ".cue". This is relevant in cases, where e.g. the album or
artist contains a dot. If the default extension ".cue" has been
removed, then the text after the dot will be treated as the extension,
which can lead to undesired behavior.

- Check, if the output template contains ".cue" at the end and add it
  if missing.
- The check for ".cue" is done after editing the output template in
  CUERipper or CUETools and also when loading the settings file for the
  case that it has been edited.
- Resolves:
  Weird results when there are dots in filenames
    https://hydrogenaud.io/index.php?topic=122028.0
  Fallback when user doesn't add extension to template
    https://hydrogenaud.io/index.php?topic=118915.msg980706#msg980706