### PR TITLE
Simplify version entries in resx and datasource

### DIFF
--- a/CUEPlayer/Properties/DataSources/Output.datasource
+++ b/CUEPlayer/Properties/DataSources/Output.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="Output" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUEPlayer.Output, CUEPlayer, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUEPlayer.Output, CUEPlayer, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUEPlayer/Properties/DataSources/frmCUEPlayer.datasource
+++ b/CUEPlayer/Properties/DataSources/frmCUEPlayer.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="frmCUEPlayer" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUEPlayer.frmCUEPlayer, CUEPlayer, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUEPlayer.frmCUEPlayer, CUEPlayer, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUERipper/Properties/DataSources/frmCUERipper.datasource
+++ b/CUERipper/Properties/DataSources/frmCUERipper.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="frmCUERipper" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUERipper.frmCUERipper, CUERipper, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUERipper.frmCUERipper, CUERipper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUERipper/frmCUERipper.resx
+++ b/CUERipper/frmCUERipper.resx
@@ -494,7 +494,7 @@
     <value>bnComboBoxLosslessOrNot</value>
   </data>
   <data name="&gt;&gt;bnComboBoxLosslessOrNot.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxLosslessOrNot.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -524,7 +524,7 @@
     <value>bnComboBoxEncoder</value>
   </data>
   <data name="&gt;&gt;bnComboBoxEncoder.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxEncoder.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -578,7 +578,7 @@
     <value>bnComboBoxFormat</value>
   </data>
   <data name="&gt;&gt;bnComboBoxFormat.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxFormat.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -647,7 +647,7 @@
     <value>bnComboBoxImage</value>
   </data>
   <data name="&gt;&gt;bnComboBoxImage.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxImage.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
@@ -1178,7 +1178,7 @@
     <value>bnComboBoxRelease</value>
   </data>
   <data name="&gt;&gt;bnComboBoxRelease.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxRelease.Parent" xml:space="preserve">
     <value>panel3</value>
@@ -1208,7 +1208,7 @@
     <value>bnComboBoxDrives</value>
   </data>
   <data name="&gt;&gt;bnComboBoxDrives.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxDrives.Parent" xml:space="preserve">
     <value>panel3</value>
@@ -1238,7 +1238,7 @@
     <value>bnComboBoxOutputFormat</value>
   </data>
   <data name="&gt;&gt;bnComboBoxOutputFormat.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;bnComboBoxOutputFormat.Parent" xml:space="preserve">
     <value>panel5</value>

--- a/CUERipper/frmFreedbSubmit.resx
+++ b/CUERipper/frmFreedbSubmit.resx
@@ -138,7 +138,7 @@
     <value>imgComboBoxCategory</value>
   </data>
   <data name="&gt;&gt;imgComboBoxCategory.Type" xml:space="preserve">
-    <value>CUEControls.ImgComboBox, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;imgComboBoxCategory.Parent" xml:space="preserve">
     <value>groupBox1</value>

--- a/CUETools/Properties/DataSources/CUETools.Processor.CUEConfig.datasource
+++ b/CUETools/Properties/DataSources/CUETools.Processor.CUEConfig.datasource
@@ -6,5 +6,5 @@
     cause the file to be unrecognizable by the program.
 -->
 <GenericObjectDataSource DisplayName="CUEConfig" Version="1.0" xmlns="urn:schemas-microsoft-com:xml-msdatasource">
-   <TypeInfo>CUETools.Processor.CUEConfig, CUETools.Processor, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
+   <TypeInfo>CUETools.Processor.CUEConfig, CUETools.Processor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</TypeInfo>
 </GenericObjectDataSource>

--- a/CUETools/frmCUETools.resx
+++ b/CUETools/frmCUETools.resx
@@ -487,7 +487,7 @@
     <value>fileSystemTreeView1</value>
   </data>
   <data name="&gt;&gt;fileSystemTreeView1.Type" xml:space="preserve">
-    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;fileSystemTreeView1.Parent" xml:space="preserve">
     <value>grpInput</value>
@@ -544,7 +544,7 @@
     <value>fileSystemTreeView1</value>
   </data>
   <data name="&gt;&gt;fileSystemTreeView1.Type" xml:space="preserve">
-    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.2.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>CUEControls.FileSystemTreeView, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;fileSystemTreeView1.Parent" xml:space="preserve">
     <value>grpInput</value>


### PR DESCRIPTION
Several `.resx` and `.datasource` files contained the exact version
information of CUETools, which is not necessary. Simplify these
entries, so that they are not updated upon each release of CUETools.

- Replacements:
  `CUEControls, Version=2.2.1.0` -> `CUEControls, Version=2.0.0.0`
  `CUEPlayer, Version=2.2.1.0` -> `CUEPlayer, Version=2.0.0.0`
  `CUETools.Processor, Version=2.2.1.0` -> `CUETools.Processor, Version=2.0.0.0`
