### PR TITLE
Fix removing of Encoders or Decoders

### DIFF
--- a/CUETools.Codecs/ViewModel/DecoderListViewModel.cs
+++ b/CUETools.Codecs/ViewModel/DecoderListViewModel.cs
@@ -14,6 +14,7 @@ namespace CUETools.Codecs
             this.model = model;
             model.ForEach(item => Add(new AudioDecoderSettingsViewModel(item)));
             AddingNew += OnAddingNew;
+            ListChanged += OnListChanged;
         }
 
         private void OnAddingNew(object sender, AddingNewEventArgs e)
@@ -21,6 +22,14 @@ namespace CUETools.Codecs
             var item = new CommandLine.DecoderSettings("new", "wav", "", "");
             model.Add(item);
             e.NewObject = new AudioDecoderSettingsViewModel(item);
+        }
+
+        private void OnListChanged(object sender, ListChangedEventArgs e)
+        {
+            if (e.ListChangedType == ListChangedType.ItemDeleted)
+            {
+                model.RemoveAt(e.NewIndex);
+            }
         }
 
         public bool TryGetValue(string extension, string name, out AudioDecoderSettingsViewModel result)

--- a/CUETools.Codecs/ViewModel/EncoderListViewModel.cs
+++ b/CUETools.Codecs/ViewModel/EncoderListViewModel.cs
@@ -14,6 +14,7 @@ namespace CUETools.Codecs
             this.model = model;
             model.ForEach(item => Add(new AudioEncoderSettingsViewModel(item)));
             AddingNew += OnAddingNew;
+            ListChanged += OnListChanged;
         }
 
         private void OnAddingNew(object sender, AddingNewEventArgs e)
@@ -21,6 +22,14 @@ namespace CUETools.Codecs
             var item = new CommandLine.EncoderSettings("new", "wav", true, "", "", "", "");
             model.Add(item);
             e.NewObject = new AudioEncoderSettingsViewModel(item);
+        }
+
+        private void OnListChanged(object sender, ListChangedEventArgs e)
+        {
+            if (e.ListChangedType == ListChangedType.ItemDeleted)
+            {
+                model.RemoveAt(e.NewIndex);
+            }
         }
 
         public bool TryGetValue(string extension, bool lossless, string name, out AudioEncoderSettingsViewModel result)


### PR DESCRIPTION
Removing of manually added Encoders or Decoders has not yet been
implemented since the code cleanup in commits ca8bb2f, e1f8906 and
320e75d. The removal appeared only in the CUETools Advanced Settings
form, but was not saved. This was working in CUETools 2.1.7 and earlier.

- Add `ListChanged` event to `DecoderListViewModel` and
  `EncoderListViewModel`. Remove the item also from the underlying list
  using `RemoveAt()` method.
- Removing of manually added Encoders or Decoders is saved now in the
  CUETools settings file
