### PR TITLE
Enable Insert and Delete key for Decoders

### DIFF
--- a/CUETools/frmSettings.Designer.cs
+++ b/CUETools/frmSettings.Designer.cs
@@ -1280,6 +1280,7 @@ namespace JDP
             this.listBoxDecoders.FormattingEnabled = true;
             this.listBoxDecoders.Name = "listBoxDecoders";
             this.tableLayoutPanel5.SetRowSpan(this.listBoxDecoders, 2);
+            this.listBoxDecoders.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listBoxDecoders_KeyDown);
             // 
             // tabPage4
             // 

--- a/CUETools/frmSettings.cs
+++ b/CUETools/frmSettings.cs
@@ -518,7 +518,7 @@ namespace JDP
             }
         }
 
-        private void listViewDecoders_KeyDown(object sender, KeyEventArgs e)
+        private void listBoxDecoders_KeyDown(object sender, KeyEventArgs e)
         {
             switch (e.KeyCode)
             {


### PR DESCRIPTION
In `CUETools - Advanced settings - Decoders`, the keys insert and delete
could not be used yet for adding or removing Decoders. Enable the
possibility to use insert and delete keys like in the `Formats` or
`Encoders` tab.

- Add event `listBoxDecoders.KeyDown`
- The method for the `KeyDown` event has already been available.
  However, rename it according to the name of the `ListBox` control:
    `listViewDecoders_KeyDown` -> `listBoxDecoders_KeyDown`
  Remark: the name is now analogous to `listBoxEncoders_KeyDown`
