### PR TITLE
[CUERipper] Add setting for C2ErrorMode

### DIFF
--- a/CUERipper/CUERipperConfig.cs
+++ b/CUERipper/CUERipperConfig.cs
@@ -83,6 +83,7 @@ namespace CUERipper
             }
 
             this.DriveOffsets = new SerializableDictionary<string, int>();
+            this.DriveC2ErrorModes = new SerializableDictionary<string, int>();
         }
 
         internal static XmlSerializer serializer = new XmlSerializer(typeof(CUERipperConfig));
@@ -99,5 +100,8 @@ namespace CUERipper
         public string DefaultDrive { get; set; }
 
         public SerializableDictionary<string, int> DriveOffsets { get; set; }
+
+        // 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto)
+        public SerializableDictionary<string, int> DriveC2ErrorModes { get; set; }
     }
 }

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -344,6 +344,21 @@ namespace CUERipper
 						reader.DriveOffset = driveOffset;
 					else
 						reader.DriveOffset = 0;
+
+					if (cueRipperConfig.DriveC2ErrorModes.ContainsKey(reader.ARName))
+					{
+						reader.DriveC2ErrorMode = cueRipperConfig.DriveC2ErrorModes[reader.ARName];
+						if (reader.DriveC2ErrorMode < 0 || reader.DriveC2ErrorMode > 3)
+						{
+							// Invalid setting, use 3 (Auto)
+							reader.DriveC2ErrorMode = 3;
+						}
+					}
+					else
+					{
+						reader.DriveC2ErrorMode = 3; // 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto)
+					}
+					cueRipperConfig.DriveC2ErrorModes[reader.ARName] = reader.DriveC2ErrorMode; // Remove this line, when setting is available in GUI. See numericWriteOffset_ValueChanged
 				}
 				data.Drives.Add(new DriveInfo(m_icon_mgr, drive + ":\\", reader));
 			}

--- a/CUETools.Ripper.Console/Program.cs
+++ b/CUETools.Ripper.Console/Program.cs
@@ -81,6 +81,7 @@ namespace CUETools.ConsoleRipper
 			Console.WriteLine("-P, --paranoid           maximum level of error correction;");
 			Console.WriteLine("-D, --drive <letter>     use a specific CD drive, e.g. {0};", drives);
 			Console.WriteLine("-O, --offset <samples>   use specific drive read offset;");
+			Console.WriteLine("-C, --c2mode <int>       use specific C2ErrorMode, 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto);");
 			Console.WriteLine("-T, --test               detect read command;");
 			Console.WriteLine("--d8                     force D8h read command;");
 			Console.WriteLine("--be                     force BEh read command;");
@@ -96,6 +97,7 @@ namespace CUETools.ConsoleRipper
 			int correctionQuality = 1;
 			string driveLetter = null;
 			int driveOffset = 0;
+			int driveC2ErrorMode = 3;
 			bool test = false;
 			bool forceD8 = false, forceBE = false, quiet = false;
 			for (int arg = 0; arg < args.Length; arg++)
@@ -119,6 +121,8 @@ namespace CUETools.ConsoleRipper
 					driveLetter = args[arg];
 				else if ((args[arg] == "-O" || args[arg] == "--offset") && ++arg < args.Length)
 					ok = int.TryParse(args[arg], out driveOffset);
+				else if ((args[arg] == "-C" || args[arg] == "--c2mode") && ++arg < args.Length)
+					ok = int.TryParse(args[arg], out driveC2ErrorMode) && (driveC2ErrorMode >= 0 && driveC2ErrorMode <=3);
 				else
 					ok = false;
 				if (!ok)
@@ -163,6 +167,7 @@ namespace CUETools.ConsoleRipper
 						//throw new Exception("Failed to find drive read offset for drive" + audioSource.ARName);
 
 				audioSource.DriveOffset = driveOffset;
+				audioSource.DriveC2ErrorMode = driveC2ErrorMode;
 				audioSource.CorrectionQuality = correctionQuality;
 				audioSource.DebugMessages = !quiet;
 				if (forceD8) audioSource.ForceD8 = true;
@@ -205,6 +210,7 @@ namespace CUETools.ConsoleRipper
 
 				Console.WriteLine("Drive       : {0}", audioSource.Path);
 				Console.WriteLine("Read offset : {0}", audioSource.DriveOffset);
+				Console.WriteLine("C2ErrorMode : {0} ({1})", audioSource.DriveC2ErrorMode, (DriveC2ErrorModeSetting)audioSource.DriveC2ErrorMode);
 				Console.WriteLine("Read cmd    : {0}", audioSource.CurrentReadCommand);
 				Console.WriteLine("Secure mode : {0}", audioSource.CorrectionQuality);
 				Console.WriteLine("Filename    : {0}", destFile);
@@ -274,7 +280,8 @@ namespace CUETools.ConsoleRipper
 				logWriter.WriteLine("{0}", audioSource.RipperVersion);
 				logWriter.WriteLine("Extraction logfile from {0}", DateTime.Now);
 				logWriter.WriteLine("Used drive  : {0}", audioSource.Path);
-				logWriter.WriteLine("Read offset correction                      : {0}", audioSource.DriveOffset);
+				logWriter.WriteLine("Read offset correction : {0}", audioSource.DriveOffset);
+				logWriter.WriteLine("C2 error mode          : {0} ({1})", audioSource.DriveC2ErrorMode, (DriveC2ErrorModeSetting)audioSource.DriveC2ErrorMode);
 				bool wereErrors = false;
 				for (int iTrack = 1; iTrack <= audioSource.TOC.AudioTracks; iTrack++)
 					for (uint iSector = audioSource.TOC[iTrack].Start; iSector <= audioSource.TOC[iTrack].End; iSector ++)

--- a/CUETools.Ripper/DriveC2ErrorModeSetting.cs
+++ b/CUETools.Ripper/DriveC2ErrorModeSetting.cs
@@ -1,0 +1,11 @@
+﻿namespace CUETools.Ripper
+{
+    // enum includes Auto in addition to Bwg.Scsi\Device.cs C2ErrorMode
+    public enum DriveC2ErrorModeSetting
+    {
+        None,
+        Mode294,
+        Mode296,
+        Auto
+    }
+}

--- a/CUETools.Ripper/Ripper.cs
+++ b/CUETools.Ripper/Ripper.cs
@@ -19,6 +19,7 @@ namespace CUETools.Ripper
 		string ARName { get; }
 		string EACName { get; }
 		int DriveOffset { get; set; }
+		int DriveC2ErrorMode { get; set; }
 		string RipperVersion { get; }
 		string CurrentReadCommand { get; }
 		int CorrectionQuality { get; set; }


### PR DESCRIPTION
There are some drives, where automatic detection of the `C2ErrorMode`
does not work. CUETools already contains a fix for specific drives,
where `Mode294` does not work properly. However, there are still drives,
where setting the `C2ErrorMode` to a specific value helps.

- Add a setting for the `C2ErrorMode`
- Values for the drive specific setting "`DriveC2ErrorModes`" are:
  `0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto)`
- `CUETools.Ripper.Console.exe`, add option:
  `-C, --c2mode <int>       use specific C2ErrorMode, 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto);`
