### PR TITLE
[CUERipper] Add GUI setting for C2ErrorMode

### DIFF
--- a/CUERipper/frmCUERipper.Designer.cs
+++ b/CUERipper/frmCUERipper.Designer.cs
@@ -37,6 +37,7 @@ namespace CUERipper
             CUEControls.RectRadius rectRadius5 = new CUEControls.RectRadius();
             CUEControls.RectRadius rectRadius6 = new CUEControls.RectRadius();
             CUEControls.RectRadius rectRadius7 = new CUEControls.RectRadius();
+            CUEControls.RectRadius rectRadius8 = new CUEControls.RectRadius();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabelMusicBrainz = new System.Windows.Forms.ToolStripStatusLabel();
@@ -54,8 +55,8 @@ namespace CUERipper
             this.buttonAbort = new System.Windows.Forms.Button();
             this.buttonPause = new System.Windows.Forms.Button();
             this.numericWriteOffset = new System.Windows.Forms.NumericUpDown();
-            this.lblWriteOffset = new System.Windows.Forms.Label();
             this.groupBoxSettings = new System.Windows.Forms.GroupBox();
+            this.bnComboBoxC2ErrorModeSetting = new CUEControls.ImgComboBox();
             this.buttonEncoderSettings = new System.Windows.Forms.Button();
             this.checkBoxTestAndCopy = new System.Windows.Forms.CheckBox();
             this.bnComboBoxLosslessOrNot = new CUEControls.ImgComboBox();
@@ -276,15 +277,12 @@ namespace CUERipper
             0,
             -2147483648});
             this.numericWriteOffset.Name = "numericWriteOffset";
+            this.toolTip1.SetToolTip(this.numericWriteOffset, resources.GetString("numericWriteOffset.ToolTip"));
             this.numericWriteOffset.ValueChanged += new System.EventHandler(this.numericWriteOffset_ValueChanged);
-            // 
-            // lblWriteOffset
-            // 
-            resources.ApplyResources(this.lblWriteOffset, "lblWriteOffset");
-            this.lblWriteOffset.Name = "lblWriteOffset";
             // 
             // groupBoxSettings
             // 
+            this.groupBoxSettings.Controls.Add(this.bnComboBoxC2ErrorModeSetting);
             this.groupBoxSettings.Controls.Add(this.buttonEncoderSettings);
             this.groupBoxSettings.Controls.Add(this.checkBoxTestAndCopy);
             this.groupBoxSettings.Controls.Add(this.bnComboBoxLosslessOrNot);
@@ -297,11 +295,27 @@ namespace CUERipper
             this.groupBoxSettings.Controls.Add(this.labelEncoderMode);
             this.groupBoxSettings.Controls.Add(this.trackBarEncoderMode);
             this.groupBoxSettings.Controls.Add(this.trackBarSecureMode);
-            this.groupBoxSettings.Controls.Add(this.lblWriteOffset);
             this.groupBoxSettings.Controls.Add(this.numericWriteOffset);
             resources.ApplyResources(this.groupBoxSettings, "groupBoxSettings");
             this.groupBoxSettings.Name = "groupBoxSettings";
             this.groupBoxSettings.TabStop = false;
+            // 
+            // bnComboBoxC2ErrorModeSetting
+            // 
+            this.bnComboBoxC2ErrorModeSetting.BackColor = System.Drawing.Color.Transparent;
+            this.bnComboBoxC2ErrorModeSetting.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.bnComboBoxC2ErrorModeSetting.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.bnComboBoxC2ErrorModeSetting.ImageKeyMember = "ImageKey";
+            this.bnComboBoxC2ErrorModeSetting.ImageList = null;
+            resources.ApplyResources(this.bnComboBoxC2ErrorModeSetting, "bnComboBoxC2ErrorModeSetting");
+            this.bnComboBoxC2ErrorModeSetting.Name = "bnComboBoxC2ErrorModeSetting";
+            rectRadius1.BottomLeft = 2;
+            rectRadius1.BottomRight = 2;
+            rectRadius1.TopLeft = 2;
+            rectRadius1.TopRight = 6;
+            this.bnComboBoxC2ErrorModeSetting.Radius = rectRadius1;
+            this.toolTip1.SetToolTip(this.bnComboBoxC2ErrorModeSetting, resources.GetString("bnComboBoxC2ErrorModeSetting.ToolTip"));
+            this.bnComboBoxC2ErrorModeSetting.SelectedValueChanged += new System.EventHandler(this.bnComboBoxC2ErrorModeSetting_SelectedValueChanged);
             // 
             // buttonEncoderSettings
             // 
@@ -329,11 +343,11 @@ namespace CUERipper
             this.bnComboBoxLosslessOrNot.ImageList = null;
             resources.ApplyResources(this.bnComboBoxLosslessOrNot, "bnComboBoxLosslessOrNot");
             this.bnComboBoxLosslessOrNot.Name = "bnComboBoxLosslessOrNot";
-            rectRadius1.BottomLeft = 2;
-            rectRadius1.BottomRight = 2;
-            rectRadius1.TopLeft = 2;
-            rectRadius1.TopRight = 6;
-            this.bnComboBoxLosslessOrNot.Radius = rectRadius1;
+            rectRadius2.BottomLeft = 2;
+            rectRadius2.BottomRight = 2;
+            rectRadius2.TopLeft = 2;
+            rectRadius2.TopRight = 6;
+            this.bnComboBoxLosslessOrNot.Radius = rectRadius2;
             this.bnComboBoxLosslessOrNot.SelectedValueChanged += new System.EventHandler(this.bnComboBoxLosslessOrNot_SelectedValueChanged);
             // 
             // losslessOrNotBindingSource
@@ -354,11 +368,11 @@ namespace CUERipper
             this.bnComboBoxEncoder.ImageList = null;
             resources.ApplyResources(this.bnComboBoxEncoder, "bnComboBoxEncoder");
             this.bnComboBoxEncoder.Name = "bnComboBoxEncoder";
-            rectRadius2.BottomLeft = 2;
-            rectRadius2.BottomRight = 2;
-            rectRadius2.TopLeft = 2;
-            rectRadius2.TopRight = 6;
-            this.bnComboBoxEncoder.Radius = rectRadius2;
+            rectRadius3.BottomLeft = 2;
+            rectRadius3.BottomRight = 2;
+            rectRadius3.TopLeft = 2;
+            rectRadius3.TopRight = 6;
+            this.bnComboBoxEncoder.Radius = rectRadius3;
             this.bnComboBoxEncoder.SelectedValueChanged += new System.EventHandler(this.bnComboBoxEncoder_SelectedValueChanged);
             // 
             // encodersBindingSource
@@ -381,11 +395,11 @@ namespace CUERipper
             this.bnComboBoxFormat.ImageList = null;
             resources.ApplyResources(this.bnComboBoxFormat, "bnComboBoxFormat");
             this.bnComboBoxFormat.Name = "bnComboBoxFormat";
-            rectRadius3.BottomLeft = 2;
-            rectRadius3.BottomRight = 2;
-            rectRadius3.TopLeft = 2;
-            rectRadius3.TopRight = 6;
-            this.bnComboBoxFormat.Radius = rectRadius3;
+            rectRadius4.BottomLeft = 2;
+            rectRadius4.BottomRight = 2;
+            rectRadius4.TopLeft = 2;
+            rectRadius4.TopRight = 6;
+            this.bnComboBoxFormat.Radius = rectRadius4;
             this.bnComboBoxFormat.SelectedValueChanged += new System.EventHandler(this.bnComboBoxFormat_SelectedValueChanged);
             // 
             // formatsBindingSource
@@ -407,11 +421,11 @@ namespace CUERipper
             this.bnComboBoxImage.ImageList = null;
             resources.ApplyResources(this.bnComboBoxImage, "bnComboBoxImage");
             this.bnComboBoxImage.Name = "bnComboBoxImage";
-            rectRadius4.BottomLeft = 2;
-            rectRadius4.BottomRight = 2;
-            rectRadius4.TopLeft = 2;
-            rectRadius4.TopRight = 6;
-            this.bnComboBoxImage.Radius = rectRadius4;
+            rectRadius5.BottomLeft = 2;
+            rectRadius5.BottomRight = 2;
+            rectRadius5.TopLeft = 2;
+            rectRadius5.TopRight = 6;
+            this.bnComboBoxImage.Radius = rectRadius5;
             this.bnComboBoxImage.SelectedValueChanged += new System.EventHandler(this.bnComboBoxImage_SelectedValueChanged);
             // 
             // cUEStylesBindingSource
@@ -551,11 +565,11 @@ namespace CUERipper
             this.bnComboBoxRelease.ImageKeyMember = "ImageKey";
             this.bnComboBoxRelease.ImageList = this.imageListMetadataSource;
             this.bnComboBoxRelease.Name = "bnComboBoxRelease";
-            rectRadius5.BottomLeft = 2;
-            rectRadius5.BottomRight = 2;
-            rectRadius5.TopLeft = 2;
-            rectRadius5.TopRight = 6;
-            this.bnComboBoxRelease.Radius = rectRadius5;
+            rectRadius6.BottomLeft = 2;
+            rectRadius6.BottomRight = 2;
+            rectRadius6.TopLeft = 2;
+            rectRadius6.TopRight = 6;
+            this.bnComboBoxRelease.Radius = rectRadius6;
             this.bnComboBoxRelease.SelectedValueChanged += new System.EventHandler(this.bnComboBoxRelease_SelectedValueChanged);
             // 
             // releasesBindingSource
@@ -589,11 +603,11 @@ namespace CUERipper
             this.bnComboBoxDrives.ImageKeyMember = "ImageKey";
             this.bnComboBoxDrives.ImageList = this.imageListMetadataSource;
             this.bnComboBoxDrives.Name = "bnComboBoxDrives";
-            rectRadius6.BottomLeft = 2;
-            rectRadius6.BottomRight = 2;
-            rectRadius6.TopLeft = 2;
-            rectRadius6.TopRight = 6;
-            this.bnComboBoxDrives.Radius = rectRadius6;
+            rectRadius7.BottomLeft = 2;
+            rectRadius7.BottomRight = 2;
+            rectRadius7.TopLeft = 2;
+            rectRadius7.TopRight = 6;
+            this.bnComboBoxDrives.Radius = rectRadius7;
             this.bnComboBoxDrives.SelectedIndexChanged += new System.EventHandler(this.bnComboBoxDrives_SelectedIndexChanged);
             // 
             // bnComboBoxOutputFormat
@@ -604,11 +618,11 @@ namespace CUERipper
             resources.ApplyResources(this.bnComboBoxOutputFormat, "bnComboBoxOutputFormat");
             this.bnComboBoxOutputFormat.ImageList = null;
             this.bnComboBoxOutputFormat.Name = "bnComboBoxOutputFormat";
-            rectRadius7.BottomLeft = 2;
-            rectRadius7.BottomRight = 2;
-            rectRadius7.TopLeft = 2;
-            rectRadius7.TopRight = 6;
-            this.bnComboBoxOutputFormat.Radius = rectRadius7;
+            rectRadius8.BottomLeft = 2;
+            rectRadius8.BottomRight = 2;
+            rectRadius8.TopLeft = 2;
+            rectRadius8.TopRight = 6;
+            this.bnComboBoxOutputFormat.Radius = rectRadius8;
             this.bnComboBoxOutputFormat.TabStop = false;
             this.bnComboBoxOutputFormat.DropDown += new System.EventHandler(this.bnComboBoxOutputFormat_DroppedDown);
             this.bnComboBoxOutputFormat.TextChanged += new System.EventHandler(this.bnComboBoxOutputFormat_TextChanged);
@@ -845,7 +859,6 @@ namespace CUERipper
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel2;
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusAr;
 		private System.Windows.Forms.NumericUpDown numericWriteOffset;
-        private System.Windows.Forms.Label lblWriteOffset;
 		private System.Windows.Forms.GroupBox groupBoxSettings;
 		private System.Windows.Forms.ToolStripStatusLabel toolStripStatusCTDB;
 		private System.Windows.Forms.TrackBar trackBarEncoderMode;
@@ -903,6 +916,7 @@ namespace CUERipper
 		private System.Windows.Forms.Panel panel7;
         private System.Windows.Forms.Button buttonEncoderSettings;
         private System.Windows.Forms.Button buttonEjectDisk;
-	}
+        private CUEControls.ImgComboBox bnComboBoxC2ErrorModeSetting;
+    }
 }
 

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -169,6 +169,8 @@ namespace CUERipper
             initDone = true;
             bnComboBoxDrives.ImageList = m_icon_mgr.ImageList;
             bnComboBoxFormat.ImageList = m_icon_mgr.ImageList;
+            bnComboBoxC2ErrorModeSetting.DataSource = Enum.GetValues(typeof(CUETools.Ripper.DriveC2ErrorModeSetting));
+            bnComboBoxC2ErrorModeSetting.SelectedIndex = (int)DriveC2ErrorModeSetting.Auto;
 
             SetupControls();
 
@@ -358,7 +360,7 @@ namespace CUERipper
 					{
 						reader.DriveC2ErrorMode = 3; // 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto)
 					}
-					cueRipperConfig.DriveC2ErrorModes[reader.ARName] = reader.DriveC2ErrorMode; // Remove this line, when setting is available in GUI. See numericWriteOffset_ValueChanged
+					cueRipperConfig.DriveC2ErrorModes[reader.ARName] = reader.DriveC2ErrorMode;
 				}
 				data.Drives.Add(new DriveInfo(m_icon_mgr, drive + ":\\", reader));
 			}
@@ -1030,6 +1032,7 @@ namespace CUERipper
 			}
 
             numericWriteOffset.Value = selectedDriveInfo.drive.DriveOffset;
+            bnComboBoxC2ErrorModeSetting.SelectedItem = (DriveC2ErrorModeSetting)selectedDriveInfo.drive.DriveC2ErrorMode;
 			try
 			{
 				selectedDriveInfo.drive.Open(selectedDriveInfo.drive.Path[0]);
@@ -1844,7 +1847,16 @@ namespace CUERipper
 				data.selectedRelease.metadata.Save();
 			UpdateDrive();
 		}
-	}
+
+        private void bnComboBoxC2ErrorModeSetting_SelectedValueChanged(object sender, EventArgs e)
+        {
+            if (selectedDriveInfo != null && selectedDriveInfo.drive.ARName != null)
+            {
+                cueRipperConfig.DriveC2ErrorModes[selectedDriveInfo.drive.ARName] = (int)bnComboBoxC2ErrorModeSetting.SelectedItem;
+                selectedDriveInfo.drive.DriveC2ErrorMode = (int)bnComboBoxC2ErrorModeSetting.SelectedItem;
+            }
+        }
+    }
 
     internal class BackgroundWorkerArtworkArgs
     {

--- a/CUERipper/frmCUERipper.de-DE.resx
+++ b/CUERipper/frmCUERipper.de-DE.resx
@@ -156,9 +156,6 @@
   <data name="buttonPause.Text" xml:space="preserve">
     <value>&amp;Pause</value>
   </data>
-  <data name="lblWriteOffset.Text" xml:space="preserve">
-    <value>Offset lesen</value>
-  </data>
   <data name="checkBoxTestAndCopy.Text" xml:space="preserve">
     <value>Testen &amp;&amp; Kopieren</value>
   </data>
@@ -230,5 +227,13 @@
   </data>
   <data name="buttonEjectDisk.Text" xml:space="preserve">
     <value>Ausw&amp;erfen</value>
+  </data>
+  <data name="bnComboBoxC2ErrorModeSetting.ToolTip" xml:space="preserve">
+    <value>C2-Fehlermodus
+Die Einstellung "Auto" funktioniert mit den meisten Laufwerken.
+Bei Bedarf kann hier der C2-Fehlermodus eingestellt werden.</value>
+  </data>
+  <data name="numericWriteOffset.ToolTip" xml:space="preserve">
+    <value>Lese-Offset</value>
   </data>
 </root>

--- a/CUERipper/frmCUERipper.resx
+++ b/CUERipper/frmCUERipper.resx
@@ -362,16 +362,19 @@
     <value>1</value>
   </data>
   <data name="numericWriteOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>271, 20</value>
+    <value>278, 20</value>
   </data>
   <data name="numericWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
     <value>54, 20</value>
   </data>
   <data name="numericWriteOffset.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="numericWriteOffset.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
+  </data>
+  <data name="numericWriteOffset.ToolTip" xml:space="preserve">
+    <value>Read offset</value>
   </data>
   <data name="&gt;&gt;numericWriteOffset.Name" xml:space="preserve">
     <value>numericWriteOffset</value>
@@ -385,35 +388,37 @@
   <data name="&gt;&gt;numericWriteOffset.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="lblWriteOffset.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="bnComboBoxC2ErrorModeSetting.Location" type="System.Drawing.Point, System.Drawing">
+    <value>201, 19</value>
   </data>
-  <data name="lblWriteOffset.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="bnComboBoxC2ErrorModeSetting.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>40, 0</value>
   </data>
-  <data name="lblWriteOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>203, 22</value>
+  <data name="bnComboBoxC2ErrorModeSetting.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 21</value>
   </data>
-  <data name="lblWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 13</value>
+  <data name="bnComboBoxC2ErrorModeSetting.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
   </data>
-  <data name="lblWriteOffset.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
+  <data name="bnComboBoxC2ErrorModeSetting.Text" xml:space="preserve">
+    <value>Mode296</value>
   </data>
-  <data name="lblWriteOffset.Text" xml:space="preserve">
-    <value>Read offset</value>
+  <data name="bnComboBoxC2ErrorModeSetting.ToolTip" xml:space="preserve">
+    <value>C2 Error Mode
+The "Auto" setting works with most drives.
+If required, the C2 error mode can be set here.</value>
   </data>
-  <data name="&gt;&gt;lblWriteOffset.Name" xml:space="preserve">
-    <value>lblWriteOffset</value>
+  <data name="&gt;&gt;bnComboBoxC2ErrorModeSetting.Name" xml:space="preserve">
+    <value>bnComboBoxC2ErrorModeSetting</value>
   </data>
-  <data name="&gt;&gt;lblWriteOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;bnComboBoxC2ErrorModeSetting.Type" xml:space="preserve">
+    <value>CUEControls.ImgComboBox, CUEControls, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;lblWriteOffset.Parent" xml:space="preserve">
+  <data name="&gt;&gt;bnComboBoxC2ErrorModeSetting.Parent" xml:space="preserve">
     <value>groupBoxSettings</value>
   </data>
-  <data name="&gt;&gt;lblWriteOffset.ZOrder" xml:space="preserve">
-    <value>12</value>
+  <data name="&gt;&gt;bnComboBoxC2ErrorModeSetting.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="buttonEncoderSettings.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
     <value>Flat</value>
@@ -440,7 +445,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;buttonEncoderSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="checkBoxTestAndCopy.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -452,7 +457,7 @@
     <value>83, 17</value>
   </data>
   <data name="checkBoxTestAndCopy.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="checkBoxTestAndCopy.Text" xml:space="preserve">
     <value>Test &amp;&amp; Copy</value>
@@ -467,7 +472,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;checkBoxTestAndCopy.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <metadata name="losslessOrNotBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 95</value>
@@ -500,7 +505,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;bnComboBoxLosslessOrNot.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <metadata name="encodersBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1217, 56</value>
@@ -530,7 +535,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;bnComboBoxEncoder.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="labelSecureMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -557,7 +562,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;labelSecureMode.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <metadata name="formatsBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>1045, 56</value>
@@ -584,7 +589,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;bnComboBoxFormat.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="labelEncoderMinMode.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -623,7 +628,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;labelEncoderMinMode.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <metadata name="cUEStylesBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>526, 56</value>
@@ -653,7 +658,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;bnComboBoxImage.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="labelEncoderMaxMode.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -692,7 +697,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;labelEncoderMaxMode.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="labelEncoderMode.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8.25pt</value>
@@ -728,7 +733,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;labelEncoderMode.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="trackBarEncoderMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -755,7 +760,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;trackBarEncoderMode.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="trackBarSecureMode.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -767,7 +772,7 @@
     <value>127, 45</value>
   </data>
   <data name="trackBarSecureMode.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="&gt;&gt;trackBarSecureMode.Name" xml:space="preserve">
     <value>trackBarSecureMode</value>
@@ -779,7 +784,7 @@
     <value>groupBoxSettings</value>
   </data>
   <data name="&gt;&gt;trackBarSecureMode.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="groupBoxSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Left</value>
@@ -816,7 +821,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAABy
-        CQAAAk1TRnQBSQFMAgEBBAEAAXwBAwF8AQMBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        CQAAAk1TRnQBSQFMAgEBBAEAAawBAwGsAQMBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABQAMAASADAAEBAQABCAYAAQgYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
         AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
         AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
@@ -965,198 +970,197 @@
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
-        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAACg
-        LAAAAk1TRnQBSQFMAgEBCwEAAWABAAFgAQABEAEAARABAAT/ASEBAAj/AUIBTQE2BwABNgMAASgDAAFA
-        AwABMAMAAQEBAAEgBgABMCoAAWIBagFyAf8BYgFqAXIB/wFiAWoBcgH/AWIBagFyAf8cAAFYAckC/wE1
-        AYMBrAH/ATUBgwGsAf8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJ
-        Av8BWAHJAv8BWAHJAv8BWAHJAv+UAAFiAWoBcgH/AzkB/wM5Af8BIAIwAf8DBwH/AwcB/wMAAf8DBwH/
-        EAABNQGDAawB/wMAAf8BIwEhAR8B/wFAAUMBPgH/AwAB/wEbAQ0BEQH/AVgByQL/AVgByQL/AVgByQL/
-        AVgByQL/AVgByQL/AVgByQL/AVgByQL/AVgByQL/AVgByQL/AVgByQL/BAADFgEfA08BugMlAfkDHgH/
-        Ax4B/wMeAf8DHgH/Ax4B/wMeAf8DHgH/Ax4B/wMlAfkDTwG5AxYBHlAAAzkB/wG9AsYB/wFiAWoBcgH/
-        AzkB/wEYAiAB/wMHAf8DBwH/AwAB/wMAAf8DBwH/DwAB/wHLAdEBygH/AfwD/wH8A/8B/AP/AUABQwE+
-        Af8BGwENAREB/wFYAckC/wFYAckC/wFYAckC/wFYAckC/wFYAckC/wFYAckC/wFYAckC/wFYAckC/wFY
-        AckC/wQAA08BuwNEAXoDBAEGIAADBAEGA0QBewNPAbpMAAEYAiAB/wM5Af8BYgFqAXIB/wG9AsYB/wFi
-        AWoBcgH/ARgCIAH/AwcB/wMHAf8DAAH/AwAB/wMAAf8DBwH/CwAB/wHLAdEBygH/AfwD/wH8A/8B/AP/
-        AfwD/wMAAf8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJAv8BWAHJ
-        Av8EAAMlAfkDBAEGKAADBQEHAykB+EgAARgCIAH/ASACMAH/AzkB/wM5Af8BYgFqAXIB/wFiAWoBcgH/
-        ASACMAH/ARgCIAH/AwcB/wMAAf8DAAH/AwAB/wMAAf8BGAIgAf8EAAE1AYMBrAH/ARsBDQERAf8BbgJl
-        Af8BvAK9Af8BvAK9Af8BywHRAcoB/wMAAf8BIwEhAR8B/wMAAf8DAAH/AwAB/wMAAf8BIwEhAR8B/wFY
-        AckC/wFYAckC/wFYAckC/wQAAx4B/zAAAx4B/0gAAwcB/wEYAiAB/wEYAiAB/wEgAjAB/wEgAjAB/wMH
-        Af8BDwFaAWIB/wEPAVoBYgH/AwAB/wMAAf8DAAH/AwAB/wMAAf8DAAH/BAABWAHJAv8BNQGDAawB/wEb
-        AQ0BEQH/AwAB/wMAAf8B/AP/AwAB/wEbAQ0BEQH/AaQBqQGhAf8B/AP/AfwD/wGTAZ4BnAH/ASMBIQEf
-        Af8BIwEhAR8B/wFYAckC/wFYAckC/wQAAx4B/zAAAx4B/0QAAWIBagFyAf8DAAH/AwcB/wMHAf8DBwH/
-        AwcB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wEAAcYB1gH/AwAB/wMAAf8DAAH/AwAB/wMAAf8BYgFq
-        AXIB/wFYAckC/wFYAckC/wFYAckC/wFYAckC/wMAAf8B/AP/AwAB/wEjASEBHwH/AfwD/wH8A/8B/AP/
-        AfwD/wHLAdEBygH/AwAB/wFYAckC/wFYAckC/wQAAx4B/zAAAx4B/0QAAWIBagFyAf8DAAH/AwAB/wMA
-        Af8DAAH/AQ8BWgFiAf8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wEPAVoBYgH/AwAB/wMA
-        Af8DAAH/AwAB/wFiAWoBcgH/Aa4BYwFqAf8BrgFjAWoB/wGuAWMBagH/Aa4BYwFqAf8DAAH/AfwD/wMA
-        Af8DAAH/AUABQwE+Af8BywHRAcoB/wH8A/8B/AP/AfwD/wMAAf8BrgFjAWoB/wGuAWMBagH/BAADHgH/
-        MAADHgH/RAABYgFqAXIB/wMAAf8DAAH/AwAB/wMAAf8BDwFaAWIB/wEAAcYB1gH/AQABxgHWAf8BAAHG
-        AdYB/wEAAcYB1gH/AQ8BWgFiAf8DBwH/AwcB/wMHAf8DBwH/AWIBagFyAf8BrgFjAWoB/wGuAWMBagH/
-        Aa4BYwFqAf8BrgFjAWoB/wMAAf8B/AP/AwAB/wFbAUEBRAH/ARsBDQERAf8DAAH/AwAB/wMAAf8B/AP/
-        AwAB/wGuAWMBagH/Aa4BYwFqAf8EAAMeAf8wAAMeAf9EAAFiAWoBcgH/AwAB/wMAAf8DAAH/AwAB/wMH
-        Af8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wMHAf8BGAIgAf8BGAIgAf8DBwH/AwcB/wFi
-        AWoBcgH/Aa4BYwFqAf8BrgFjAWoB/wGuAWMBagH/Aa4BYwFqAf8DAAH/AfwD/wEbAQ0BEQH/AwAB/wEj
-        ASEBHwH/AVsBQQFEAf8BWwFBAUQB/wMAAf8B/AP/AwAB/wGuAWMBagH/Aa4BYwFqAf8EAAMeAf8cAANH
-        AYUDJQH5Ax4B/wMeAf8DHgH/AzUB7kgAAwcB/wMAAf8DAAH/AwAB/wMAAf8DBwH/AQ8BWgFiAf8BDwFa
-        AWIB/wMHAf8DOQH/AzkB/wEYAiAB/wEYAiAB/wEYAiAB/wQAAa4BYwFqAf8BrgFjAWoB/wGuAWMBagH/
-        Aa4BYwFqAf8DAAH/AfwD/wH8A/8BkwGeAZwB/wEjASEBHwH/AwAB/wEbAQ0BEQH/AwAB/wH8A/8DAAH/
-        Aa4BYwFqAf8BrgFjAWoB/wQAAx4B/xwAAyUB+QMOARMEAAMEAQUDTwGwA0oBjkgAAzkB/wMAAf8DAAH/
-        AwAB/wMHAf8DBwH/ARgCIAH/AzkB/wFiAWoBcgH/AWICrQH/AzkB/wM5Af8BGAIgAf8DOQH/BAABrgFj
-        AWoB/wGuAWMBagH/Aa4BYwFqAf8BrgFjAWoB/wMAAf8BvAK9Af8B/AP/AfwD/wH8A/8BywHRAcoB/wFQ
-        AVkBWAH/AwAB/wH8A/8DAAH/Aa4BYwFqAf8BrgFjAWoB/wQAAx4B/xwAAx4B/wQAAwQBBQNPAa4DTgG1
-        AwUBB0wAARgCIAH/AwAB/wMAAf8DBwH/AwcB/wEYAiAB/wEgAjAB/wFiAWoBcgH/Ab0CxgH/AWIBagFy
-        Af8BIAIwAf8DOQH/CAABrgFjAWoB/wGuAWMBagH/Aa4BYwFqAf8BrgFjAWoB/wEjASEBHwH/AUABQwE+
-        Af8BvAK9Af8B/AP/AfwD/wH8A/8B/AP/AfwD/wH8A/8DAAH/Aa4BYwFqAf8BrgFjAWoB/wQAAyUB+QME
-        AQYYAAMeAf8DBAEFA04BrwNOAa8DBAEFVAADOQH/AwAB/wMHAf8DBwH/ARgCIAH/ASACMAH/AzkB/wFi
-        AWoBcgH/AWIBagFyAf8BYgFqAXIB/wwAAa4BYwFqAf8BrgFjAWoB/wGuAWMBagH/Aa4BYwFqAf8BrgFj
-        AWoB/wEjASEBHwH/AwAB/wEjASEBHwH/AZMBngGcAf8B/AP/AfwD/wH8A/8B/AP/AwAB/wGuAWMBagH/
-        Aa4BYwFqAf8EAANOAbwDQwF5AwQBBhQAAx4B/wNPAbADTgGvAwQBBVwAASACMAH/ASACMAH/AwcB/wMH
-        Af8DBwH/ARgCIAH/AzkB/wM5Af8QAAGuAWMBagH/Aa4BYwFqAf8BrgFjAWoB/wGuAWMBagH/Aa4BYwFq
-        Af8BrgFjAWoB/wGuAWMBagH/ASMBIQEfAf8DAAH/ARsBDQERAf8BbgJlAf8BywHRAcoB/wH8A/8DAAH/
-        Aa4BYwFqAf8BrgFjAWoB/wQAAxYBHwNOAbwDJQH5Ax4B/wMeAf8DHgH/Ax4B/wMeAf8DNQHuA0oBjgME
-        AQVoAAFiAWoBcgH/AWIBagFyAf8BYgFqAXIB/wFiAWoBcgH/HAABrgFjAWoB/wGuAWMBagH/Aa4BYwFq
-        Af8BrgFjAWoB/wGuAWMBagH/Aa4BYwFqAf8BrgFjAWoB/wGuAWMBagH/Aa4BYwFqAf8BGwENAREB/wMA
-        Af8BQAFDAT4B/wEjASEBHwH/Aa4BYwFqAf+IAAPAAf8DawH/A2sB/wPAAf8DwAH/A8AB/wPAAf8DwAH/
+        ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAAB6
+        LAAAAk1TRnQBSQFMAgEBCwEAAZABAAGQAQABEAEAARABAAT/ASEBAAj/AUIBTQE2BwABNgMAASgDAAFA
+        AwABMAMAAQEBAAEgBgABMCoAAVwBZAFsAf8BXAFkAWwB/wFcAWQBbAH/AVwBZAFsAf8cAAFSAckC/wEv
+        AYMBrAH/AS8BgwGsAf8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJ
+        Av8BUgHJAv8BUgHJAv8BUgHJAv+UAAFcAWQBbAH/AzMB/wMzAf8BGgIqAf8DAQH/AwEB/wMAAf8DAQH/
+        EAABLwGDAawB/wMAAf8BHQEbARkB/wE6AT0BOAH/AwAB/wEVAQcBCwH/AVIByQL/AVIByQL/AVIByQL/
+        AVIByQL/AVIByQL/AVIByQL/AVIByQL/AVIByQL/AVIByQL/AVIByQL/BAADFgEfA1UBugMrAfkDGAH/
+        AxgB/wMYAf8DGAH/AxgB/wMYAf8DGAH/AxgB/wMrAfkDVgG5AxYBHlAAAzMB/wG9AsYB/wFcAWQBbAH/
+        AzMB/wESAhoB/wMBAf8DAQH/AwAB/wMAAf8DAQH/DwAB/wHLAdEBygH/AfwD/wH8A/8B/AP/AToBPQE4
+        Af8BFQEHAQsB/wFSAckC/wFSAckC/wFSAckC/wFSAckC/wFSAckC/wFSAckC/wFSAckC/wFSAckC/wFS
+        AckC/wQAA1YBuwNEAXoDBAEGIAADBAEGA0QBewNVAbpMAAESAhoB/wMzAf8BXAFkAWwB/wG9AsYB/wFc
+        AWQBbAH/ARICGgH/AwEB/wMBAf8DAAH/AwAB/wMAAf8DAQH/CwAB/wHLAdEBygH/AfwD/wH8A/8B/AP/
+        AfwD/wMAAf8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJAv8BUgHJ
+        Av8EAAMrAfkDBAEGKAADBQEHAzkB+EgAARICGgH/ARoCKgH/AzMB/wMzAf8BXAFkAWwB/wFcAWQBbAH/
+        ARoCKgH/ARICGgH/AwEB/wMAAf8DAAH/AwAB/wMAAf8BEgIaAf8EAAEvAYMBrAH/ARUBBwELAf8BaAJf
+        Af8BvAK9Af8BvAK9Af8BywHRAcoB/wMAAf8BHQEbARkB/wMAAf8DAAH/AwAB/wMAAf8BHQEbARkB/wFS
+        AckC/wFSAckC/wFSAckC/wQAAxgB/zAAAxgB/0gAAwEB/wESAhoB/wESAhoB/wEaAioB/wEaAioB/wMB
+        Af8BCQFUAVwB/wEJAVQBXAH/AwAB/wMAAf8DAAH/AwAB/wMAAf8DAAH/BAABUgHJAv8BLwGDAawB/wEV
+        AQcBCwH/AwAB/wMAAf8B/AP/AwAB/wEVAQcBCwH/AaQBqQGhAf8B/AP/AfwD/wGTAZ4BnAH/AR0BGwEZ
+        Af8BHQEbARkB/wFSAckC/wFSAckC/wQAAxgB/zAAAxgB/0QAAVwBZAFsAf8DAAH/AwEB/wMBAf8DAQH/
+        AwEB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wEAAcYB1gH/AwAB/wMAAf8DAAH/AwAB/wMAAf8BXAFk
+        AWwB/wFSAckC/wFSAckC/wFSAckC/wFSAckC/wMAAf8B/AP/AwAB/wEdARsBGQH/AfwD/wH8A/8B/AP/
+        AfwD/wHLAdEBygH/AwAB/wFSAckC/wFSAckC/wQAAxgB/zAAAxgB/0QAAVwBZAFsAf8DAAH/AwAB/wMA
+        Af8DAAH/AQkBVAFcAf8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wEJAVQBXAH/AwAB/wMA
+        Af8DAAH/AwAB/wFcAWQBbAH/Aa4BXQFkAf8BrgFdAWQB/wGuAV0BZAH/Aa4BXQFkAf8DAAH/AfwD/wMA
+        Af8DAAH/AToBPQE4Af8BywHRAcoB/wH8A/8B/AP/AfwD/wMAAf8BrgFdAWQB/wGuAV0BZAH/BAADGAH/
+        MAADGAH/RAABXAFkAWwB/wMAAf8DAAH/AwAB/wMAAf8BCQFUAVwB/wEAAcYB1gH/AQABxgHWAf8BAAHG
+        AdYB/wEAAcYB1gH/AQkBVAFcAf8DAQH/AwEB/wMBAf8DAQH/AVwBZAFsAf8BrgFdAWQB/wGuAV0BZAH/
+        Aa4BXQFkAf8BrgFdAWQB/wMAAf8B/AP/AwAB/wFVATsBPgH/ARUBBwELAf8DAAH/AwAB/wMAAf8B/AP/
+        AwAB/wGuAV0BZAH/Aa4BXQFkAf8EAAMYAf8wAAMYAf9EAAFcAWQBbAH/AwAB/wMAAf8DAAH/AwAB/wMB
+        Af8BAAHGAdYB/wEAAcYB1gH/AQABxgHWAf8BAAHGAdYB/wMBAf8BEgIaAf8BEgIaAf8DAQH/AwEB/wFc
+        AWQBbAH/Aa4BXQFkAf8BrgFdAWQB/wGuAV0BZAH/Aa4BXQFkAf8DAAH/AfwD/wEVAQcBCwH/AwAB/wEd
+        ARsBGQH/AVUBOwE+Af8BVQE7AT4B/wMAAf8B/AP/AwAB/wGuAV0BZAH/Aa4BXQFkAf8EAAMYAf8cAANI
+        AYUDKwH5AxgB/wMYAf8DGAH/A0oB7kgAAwEB/wMAAf8DAAH/AwAB/wMAAf8DAQH/AQkBVAFcAf8BCQFU
+        AVwB/wMBAf8DMwH/AzMB/wESAhoB/wESAhoB/wESAhoB/wQAAa4BXQFkAf8BrgFdAWQB/wGuAV0BZAH/
+        Aa4BXQFkAf8DAAH/AfwD/wH8A/8BkwGeAZwB/wEdARsBGQH/AwAB/wEVAQcBCwH/AwAB/wH8A/8DAAH/
+        Aa4BXQFkAf8BrgFdAWQB/wQAAxgB/xwAAysB+QMOARMEAAMEAQUDUwGwA0sBjkgAAzMB/wMAAf8DAAH/
+        AwAB/wMBAf8DAQH/ARICGgH/AzMB/wFcAWQBbAH/AVwCrQH/AzMB/wMzAf8BEgIaAf8DMwH/BAABrgFd
+        AWQB/wGuAV0BZAH/Aa4BXQFkAf8BrgFdAWQB/wMAAf8BvAK9Af8B/AP/AfwD/wH8A/8BywHRAcoB/wFK
+        AVMBUgH/AwAB/wH8A/8DAAH/Aa4BXQFkAf8BrgFdAWQB/wQAAxgB/xwAAxgB/wQAAwQBBQNUAa4DVQG1
+        AwUBB0wAARICGgH/AwAB/wMAAf8DAQH/AwEB/wESAhoB/wEaAioB/wFcAWQBbAH/Ab0CxgH/AVwBZAFs
+        Af8BGgIqAf8DMwH/CAABrgFdAWQB/wGuAV0BZAH/Aa4BXQFkAf8BrgFdAWQB/wEdARsBGQH/AToBPQE4
+        Af8BvAK9Af8B/AP/AfwD/wH8A/8B/AP/AfwD/wH8A/8DAAH/Aa4BXQFkAf8BrgFdAWQB/wQAAysB+QME
+        AQYYAAMYAf8DBAEFA1QBrwNUAa8DBAEFVAADMwH/AwAB/wMBAf8DAQH/ARICGgH/ARoCKgH/AzMB/wFc
+        AWQBbAH/AVwBZAFsAf8BXAFkAWwB/wwAAa4BXQFkAf8BrgFdAWQB/wGuAV0BZAH/Aa4BXQFkAf8BrgFd
+        AWQB/wEdARsBGQH/AwAB/wEdARsBGQH/AZMBngGcAf8B/AP/AfwD/wH8A/8B/AP/AwAB/wGuAV0BZAH/
+        Aa4BXQFkAf8EAANWAbwDRAF5AwQBBhQAAxgB/wNTAbADVAGvAwQBBVwAARoCKgH/ARoCKgH/AwEB/wMB
+        Af8DAQH/ARICGgH/AzMB/wMzAf8QAAGuAV0BZAH/Aa4BXQFkAf8BrgFdAWQB/wGuAV0BZAH/Aa4BXQFk
+        Af8BrgFdAWQB/wGuAV0BZAH/AR0BGwEZAf8DAAH/ARUBBwELAf8BaAJfAf8BywHRAcoB/wH8A/8DAAH/
+        Aa4BXQFkAf8BrgFdAWQB/wQAAxYBHwNWAbwDKwH5AxgB/wMYAf8DGAH/AxgB/wMYAf8DSgHuA0sBjgME
+        AQVoAAFcAWQBbAH/AVwBZAFsAf8BXAFkAWwB/wFcAWQBbAH/HAABrgFdAWQB/wGuAV0BZAH/Aa4BXQFk
+        Af8BrgFdAWQB/wGuAV0BZAH/Aa4BXQFkAf8BrgFdAWQB/wGuAV0BZAH/Aa4BXQFkAf8BFQEHAQsB/wMA
+        Af8BOgE9ATgB/wEdARsBGQH/Aa4BXQFkAf+IAAPAAf8DZQH/A2UB/wPAAf8DwAH/A8AB/wPAAf8DwAH/
         A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/BAADCwEPAxQBGwMdASkDIgEyA1IBpgFYAVwBWAHRAVgBXAFY
         AdEDPAFmBAADPAFmAVgBXAFYAdEBWAFcAVgB0QFYAVwBWAHRAVgBXAFYAdEDUgGpAyMBMxAAAycBOwNO
-        AZQCXgFcAc4BeAFqAVkB6wF4AWoBWQHrAl4BXAHOA04BlAIAAeIB/wIAAeIB/wwAAaYCjAH/AUICBwH/
-        ATsCAAH/ATcCAAH/ATcCAAH/ATcCAAH/ATcCAAH/ATcCAAH/ATcCAAH/ATcCAAH/ATcCAAH/ATcCAAH/
-        ATcCAAH/ATUCAAH/ATECAAH/ARECAAH/A2sB/wMAAf8DEAH/AycB/wMAAf8DCgH/A8AB/wPAAf8DwAH/
-        A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wMGAQgDCgEOAxABFQMSARkBWQFcAVkBzAEYAdUBBwH/
-        AUkBdQFGAe8DTgGZBAADTgGZAUkBdQFGAe8BGAHVAQcB/wEYAdUBBwH/ARgB1QEHAf8BWAFcAVgB0QMT
-        ARoIAAMKAQ0DTgGWAZ4BeQFNAfoB4QHNAbkB/wHxAeABzgH/AfkB5wHWAf8B+AHmAdQB/wHwAd0BzAH/
-        AeEBzQG5Af8CAAHiAf8CAAHiAf8DCgENCAABvwGFAYYB/wGDAQsBDQH/AXQBAAEBAf8BcAIAAf8BcAIA
-        Af8D6gH/A+oB/wPqAf8BcAIAAf8D6gH/A+oB/wPqAf8BcAIAAf8BawIAAf8BZgIAAf8BMgIAAf8DAAH/
-        A8AN/wMnAf8DCgH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/EAABWQFcAVkBzAEb
-        Ac0BCgH/AVgBXAFYAdEDIwEzBAADIwEzAVgBXAFYAdEBGAHMAQcB/wEYAcwBBwH/ARgBzAEHAf8BWAFc
-        AVgB0QgAAwoBDQNXAbgB2QG/AaUB/wH+AfIB5AL/AecBzwH/AfwB2wG7Af8B+QHTAbIB/wH2AdABrAH/
-        AfQB0QGuAf8B9gHYAbsB/wIAAeIB/wIAAeIB/wNXAbgDCgENBAABwAGCAYMB/wGJAQwBDgH/AYMBAAEC
-        Af8BdgIAAf8D9gH/AXYCAAH/AXYCAAH/A/YB/wF2AgAB/wP2Af8BdgIAAf8BdgIAAf8D9gH/AXECAAH/
-        AWwCAAH/ATUCAAH/AwAB/wPAEf8DAAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/
-        ASsBLAErAUMBVgFXAVYBuAFWAVcBVgG4ASsBLAErAUMBWQFcAVkBzAEfAcQBDgH/AVgBXAFYAdEDPAFm
-        BAADPAFmAVgBXAFYAdEBGAHBAQcB/wEYAcEBBwH/ARgBwQEHAf8BWAFcAVgB0QgAA04BlgHZAb8BpQL/
-        AfgB6wL/AesB0QL/AeEBwwH/Af4B2wG6Af8B+wHWAbIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIA
-        AeIB/wIAAeIB/wIAAeIB/wIAAeIB/wHCAYIBgwH/AY4BDQEPAf8BiAEBAQMB/wGEAgAF/wGEAgAB/wGE
-        AgAF/wGEAgAF/wGEAgAB/wGEAgAF/wF2AgAB/wFwAgAB/wE3AgAB/wNrAf8DCgH/A1MB/wOyAf8DsgH/
-        A8AB/wMAAf8DEAH/AwAB/wMAAf8DAAH/AwAB/wMQAf8DwAH/A8AB/wPAAf8DVQGyAUUBxgE0Af8BTAGC
-        AUoB8wFZAVwBWQHMAVgBXgFYAdkBGQG3AQgB/wFKAXABRgHvAVoBXQFaAdMDWQHMAVoBXQFaAdMBSQFu
-        AUYB7wEaAbcBCQH/ARkBtgEIAf8BGAG2AQcB/wFYAVwBWAHRBAADJgE4Aa8BhwFOAf0C/gH6Av8B+QHp
-        Av8B7wHYAv8B5wHNAv8B4QHCAf8B/AHcAbsB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIA
-        AeIB/wIAAeIB/wIAAeIB/wHCAYIBgwH/AY4BDQEPAf8BiAEBAQMB/wGEAgAB/wGEAgAN/wGEAgAN/wGE
-        AgAB/wF2AgAB/wFwAgAB/wE3AgAB/wPAAf8DawH/AwoB/wMAAf8DAAX/AwAB/wMKAf8Dlgn/A4YB/wMQ
-        Af8DEAH/A8AB/wPAAf8BWQFcAVkBzAFEAcUBMwH/AToBuwEpAf8BQwHEATIB/wE5Ab0BKAH/ARgBqwEH
-        Af8BGgGsAQkB/wEeAa8BDQH/AR4BrwENAf8BHQGvAQwB/wFKAXABRgHvAVgBXAFYAdEBWAFcAVgB0QFJ
-        AXABRgHvAVgBXAFYAdEEAANOAZYB4gHOAboB/wH3Ad4BxgL/AekB0QL/AfYB4gL/AfIB3QL/AfAB3QH/
-        AfgB6gHZAf8B+AHmAdQB/wH7Ad8BxwH/AfUBzwGrAf8CAAHiAf8CAAHiAf8B+AHdAcMB/wHiAc4BugH/
-        A04BlgHCAYIBgwH/AY4BDQEPAf8BiAEBAQMB/wGEAgAB/wGEAgAB/wGEAgAB/wGEAgAF/wGEAgAF/wGE
-        AgAB/wGEAgAB/wGEAgAB/wF2AgAB/wFwAgAB/wE3AgAB/wPAAf8DwAH/A8AB/wPAAf8DAAX/AwAB/wMQ
-        Ef8DwAH/AwAB/wPAAf8DwAH/A1UBsgFMAc0BOwH/AUwBhAFMAfMBWQFcAVkBzAFZAV4BWAHZASoBsAEZ
-        Af8BGQGiAQgB/wEYAaEBBwH/ARgBoQEHAf8BHwGoAQ4B/wFaAV0BWgHTAzwBZgMjATMDTgGZAzwBZgQA
-        Al4BWwHQAe8B4AHQAf8B5wG+AZYB/wHnAbwBlAH/AfABzAGpAf8B/gHsAdoB/wHdAcQBrAH/AW8BZgFc
-        AecBbwFmAVwB5wHdAcMBqgH/AfgB3QHEAf8CAAHiAf8CAAHiAf8B9QHWAbgB/wHxAd8BzwH/Al4BWwHQ
-        AcIBggGDAf8BjgENAQ8B/wGIAQEBAwH/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAX/AYQCAAX/AYQCAAH/
-        AYQCAAH/AYQCAAH/AXYCAAH/AXACAAH/ATcCAAH/A1MB/wNTAf8DUwH/A1MB/wMABf8DAAH/AwAB/wMn
-        Af8DwA3/AwAB/wNTAf8DUwH/ASsBLAErAUMBVgFXAVYBuAFWAVcBVgG4ASsBLAErAUMBWQFcAVkBzAFG
-        AccBNQH/ATUBtwEkAf8BKwGtARoB/wEhAaQBEAH/ASgBqgEXAf8BWQFcAVkBzBQAAXkBagFZAewB9QHk
-        AdUB/wHpAb4BlwH/AegBvAGWAf8B5wG8AZQB/wHzAd4BygH/AXABaAFZAeYDFAEbAxQBGwFwAWgBWQHm
-        AfYB4wHTAf8CAAHiAf8CAAHiAf8B7QHJAaQB/wH2AeQB0gH/AXkBagFZAewBwgGCAYMB/wGOAQ0BDwH/
-        AYgBAQEDAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIA
-        Af8BhAIAAf8BdgIAAf8BcAIAAf8BNwIAAf8DUwH/A1MB/wNTAf8DUwH/AwAF/wMAAf8DLQH/AwoB/wMA
-        Af8DAAH/AwAF/wMAAf8DUwH/A1MB/xAAAVkBXAFZAcwBSQHKATgB/wE7AbwBKgH/ATsBvAEqAf8BOwG8
-        ASoB/wFDAcQBMgH/AVoBXQFaAdMDPAFmAyMBMwNOAZkDPAFmBAABeQFqAVkB7AH1AeQB1QH/AekBvwGZ
-        Af8B6QHAAZkB/wHpAcEBmgH/AfMB3QHJAf8BcAFoAVkB5gMUARsDFAEbAXABaAFZAeYB+AHoAdkB/wHy
-        AdIBsgH/AfABzAGrAf8B8AHMAasB/wH2AeQB0wH/AXkBagFZAew0/wP2Af8D6gH/A3QB/wNTAf8DUwH/
-        A1MB/wNTAf8DAAX/AwoB/wMAAf8DEAH/Ay0B/wMtAf8DAAX/AwAB/wNTAf8DUwH/EAABWQFcAVkBzAFO
-        Ac8BPQH/AUABwQEvAf8BQAHBAS8B/wFAAcEBLwH/AUIBwwExAf8BUgF2AU0B7wFYAVwBWAHRAVgBXAFY
-        AdEBUgF2AU0B7wFZAVwBWQHMBAACXgFbAdAB8AHhAdEB/wHqAcQBoQH/AekBwQGbAf8B6QHAAZcB/wHx
-        Ac4BsgH/AdwBwwGqAf8BbwFmAVwB5wFvAWYBXAHnAd0BxAGsAv8B/AHzAv8B9AHlAv8B7gHaAf8B/AHl
-        AdEB/wHxAeEB0QH/Al4BWwHQBP8BjgENAQ8J/wGEAgAN/wGEAgAB/wGEAgAN/wF2AgAB/wFwAgAB/wN0
-        Af8DUwH/A1MB/wNTAf8DUwH/AwAJ/wOGAf8DEAH/AwAB/wMKAf8DAAX/AwAB/wNTAf8DUwH/EAABWQFc
-        AVkBzAFbAdwBSgH/AVMB1AFCAf8BUgHTAUEB/wFRAdIBQAH/AUsBzAE6Af8BRQHGATQB/wFNAc4BPAH/
-        AVYB1wFFAf8BVAHVAUMB/wFZAVwBWQHMBAADTgGWAeIBzgG6Af8B8QHSAbYB/wHrAcEBmwH/AesBvwGZ
-        Av8B5AHTAv8B6AHbAf8B8wHaAccB/wH4AfEB5AL/AfgB7QL/AfcB6QL/Af4B8QL/AfwB7wL/AfwB8gH/
-        AeIBzgG6Af8DTgGWBP8BjgENAQ8J/wGEAgAJ/wGEAgAR/wGEAgAB/wP2Af8D6gH/A3QB/wNTAf8DUwH/
-        A1MB/wNTAf8DAAH/A7IN/wPAAf8DQQH/AwAF/wMAAf8DUwH/A1MB/xAAA04BmQFZAVwBWQHMAVkBXAFZ
-        AcwBWQFcAVkBzAFZAVwBWQHMAVkBXwFYAdkBUQHSAUAB/wFZAV8BWAHZAVkBXAFZAcwBWQFcAVkBzANO
-        AZkEAAMmATgBrwGHAU4B/QH6Ae0B4QH/AewBxwGjAv8B7AHaBf8B9wHNAbYB/wHsAb0BlwL/AfQB3AP/
-        AfcC/wH3AegD/wHzA/8B+QH/Av4B+QH/Aa8BhwFOAf0DJgE4BP8BjgENAQ8J/wGEAgAJ/wGEAgAB/wGE
-        AgAB/wGEAgAB/wGEAgAF/wGEAgAB/wF2AgAB/wFwAgAB/wE3AgAB/wNTAf8DUwH/A1MB/wNTAf8DEAH/
-        AycB/wOyGf8DAAH/A1MB/wNTAf8gAAErASwBKwFDAVkBXAFZAcwBXAHdAUsB/wFZAVwBWQHMASsBLAEr
-        AUMQAANOAZYB2QG/AaUC/wH6AfAG/wH9AfMB/wHwAcEBowH/Ae4BxgGgAf8B/QHwAdED/wH+Av8B/QHw
-        Av8B/QHxBf8B2QG/AaUB/wNOAZYEAAT/AY4BDQEPAf8BiAEBAQMF/wGEAgAJ/wGEAgAJ/wGEAgAF/wGE
-        AgAB/wP2Af8D6gH/ATcCAAH/A1MB/wNTAf8DUwH/A1MB/wNTAf8DEAH/AwAB/wMQAf8DhhH/AwAB/wNT
-        Af8DUwH/IAABVgFXAVYBuAFdAYwBTAHzAVcB2AFGAf8BXQGMAUwB8wFWAVcBVgG4EAADCgENA1cBuAHZ
-        Ab8BpQH/Af4B/QH8Av8B8QHkAf8B8gHKAa4B/wHyAdIBrQH/AfkB7QHIA/8B9wP/Af0B/wH+Af0B/AH/
-        AdkBvwGlAf8DVwG4AwoBDQQABP8BkQEUARYJ/wGIAQEBAwH/AYgBAQEDCf8BiAEBAQMB/wGIAQEBAw3/
-        AYMBAAECAf8BdAEAAQEB/wOAAf8DUwH/A1MB/wNTAf8DUwH/A1MB/wNTAf8DUwH/AxAB/wMAAf8DCgH/
-        A1MB/wPABf8DAAH/A1MB/wNTAf8gAAFWAVcBVgG4AWgB6QFXAf8BYwHkAVIB/wFnAegBVgH/AVYBVwFW
-        AbgUAAMKAQ0DTgGWAZ4BeQFNAfoB4QHNAbkB/wHxAeIB1AH/AfkB7AHfAf8B+wHzAeUB/wH0Ae0B5AH/
-        AeIBzgG7Af8BngF5AU0B+gNOAZYDCgENCAAE/wGVAR4BIC3/A/cB/wPsAf8DggH/BAADUwH/A1MB/wNT
-        Af8DUwH/A1MB/wNTAf8DUwH/A1MB/wNTAf8DCgH/AwAB/wMnAf8DEAH/A1MB/yQAASsBLAErAUMDVQGy
-        AVkBXAFZAcwDVQGyASsBLAErAUMcAAMnATsDTgGUAl4BXAHOAXgBagFZAesBewFoAVgB7wFgAV4BWwHZ
-        A08BlwMnATsQAAj/AcMBhQGGKf8D/AH/A/cB/wO/Af//AAUAAZkCzAH/AVoCzAH/AVoCzAH/AVoCzAH/
-        AVoCzAH/AVoCzAH/AVoCzAH/A+oB/yAAAaQCoAH/A1oB/wPMAf+0AAGZAswB/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AVoCzAH/AVoCzAH/A/EB/yAAA9cB/wNaAf8IAAOZAf8DUwH/A0kB/wNJAf8DNgH/Ay0B/wMn
-        Af8DHQH/A4YB/wwAAZkCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/
-        AVoCzAH/A+oB/xgAAZkCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/AVoCzAH/
-        AVoCzAH/A+oB/xQAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BWgLMAf8BmQHMAv8BJwKZAf8BWgLM
-        Af8BWgLMAf8BmQLMAf8QAAPqAf8DWgH/A+oB/wgAA1MB/wNaAf8DSQH/AzYB/wM2Af8DSQH/A1oB/wNr
-        Af8DHQH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AVoCzAH/AVoCzAH/A/EB/xQA
-        AZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wFaAswB/wFaAswB/wPxAf8QAAGZAswB/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AVoCzAH/AVoCzAH/AVoCzAH/AScCzAH/AZkD/wGZAswB/xAAA7IB/wOG
-        Af8DhgH/CAABpAKgAf8DWgH/A1MB/wNTAf8DUwH/A0kB/wNJAf8DNgH/A4YB/wwAAZkCzAH/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wFaAswB/wGZAcwC/wFaAswB/wPxAf8QAAGZAswB/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BWgLMAf8BmQHMAv8BWgLMAf8D8QH/DAABmQLMAf8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEnAswB/wGZA/8BJwKZAf8BWgLMAf8BmQLMAf9MAAGZAswB/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BWgLMAf8BWgLMAf8BWgLMAf8BmQLMAf8QAAGZAswB/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BWgLMAf8BWgLMAf8BWgLMAf8BmQLMAf8MAAGZAswB/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AScCzAH/AZkD/wEnAswB/wGZA/8BmQLMAf8IAANr
-        Af8DawH/A1oB/zgAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        AswB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/wwA
-        AZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BJwLMAf8BmQP/AScCzAH/AZkD/wGZ
-        AswB/wgAA/EB/wOWBf8IAAGkAqAB/wNaAf8DWgH/A1oB/wNaAf8DWgH/A1MB/wNTAf8DmQH/DAABmQLM
-        Af8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/DAABmQLMAf8BzAP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEnAswB/wGZA/8BJwLMAf8BmQP/AZkCzAH/DAAD8QH/A5YB/wgA
-        A1oB/wNaAf8DSQH/A0EB/wM2Af8DSQH/A1oB/wNrAf8DUwH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/DAABxgHWAe8B/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AScCzAH/AZkD/wEnAswB/wGZA/8BmQLMAf8IAAOyAf8DhgH/A7IB/wgAA7IB/wNrAf8DWgH/
-        A1oB/wNaAf8DWgH/A1oB/wNaAf8BpAKgAf8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQLMAf8QAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wKZAVoB/wGZAcwBmQH/DAABxgHWAe8B/wHMA/8BzAP/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AScCzAH/AZkD/wEnAswB/wGZA/8BmQLMAf9MAAGZAswB/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BmQLMAf8QAAGZAswB/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
-        AZkD/wGZAVoBJwH/AZkBWgEnAf8D4wH/CAAB1gLnAf8BxgHWAe8B/wFaAswB/wFaAswB/wFaAswB/wFa
-        AswB/wFaAswB/wFaAswB/wFaAswB/wFaAswB/wGZA/8BJwLMAf8BmQP/AZkCzAH/CAADhgH/A4YB/wOG
-        Af84AAGZAswB/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQLMAf8QAAGZ
-        AswB/wHMA/8BmQP/AZkD/wGZA/8BmQP/ApkBWgH/AcwBmQEnAf8BzAGZAScB/wHMAZkBJwH/AcwBmQEn
-        Av8BzAEnAf8BzAGZAVoB/wPjAf8MAAHGAdYB7wH/AcwD/wHMA/8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZ
-        A/8BJwLMAf8BmQP/AZkCzAH/DAADhgH/DAADsgH/A4YB/wNrAf8DawH/A2sB/wNrAf8DWgH/A1oB/wGk
-        AqAB/wwAAcYB1gHvAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AcYB1gHv
-        Af8QAAHGAdYB7wH/AcwD/wGZA/8BmQP/AZkD/wGZA/8BzAGZAScC/wHMAZkC/wHMAVoC/wHMAVoC/wHM
-        AVoC/wHMAVoC/wHMAVoB/wHMAZkBWgH/DAAB1gLnAf8BxgHWAe8B/wFaAswB/wFaAswB/wFaAswB/wFa
-        AswB/wFaAswB/wFaAswB/wFaAswB/wFaAswB/wGZA/8BxgHWAe8B/wwAA4YB/wwAA4YB/wNaAf8DSQH/
-        A0kB/wNBAf8DQQH/A0kB/wNaAf8DWgH/DAABxgHWAe8B/wHMA/8BzAP/AcwD/wHMA/8BmQP/AZkD/wGZ
-        A/8BmQP/AZkD/wGZA/8BxgHWAe8B/xAAAcYB1gHvAf8BzAP/AcwD/wHMA/8BzAP/AZkD/wLMAZkB/wHM
-        AZkBWgH/AcwBmQFaAf8BzAGZAVoB/wHMAZkBWgL/AcwBmQH/AcwBmQFaAf8D4wH/FAABxgHWAe8B/wHM
-        A/8BzAP/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AcYB1gHvAf8IAAOyAf8DhgH/DAADsgH/A4YB/wOG
-        Af8DhgH/A4YB/wNrAf8DawH/A2sB/wOyAf8MAAHWAucB/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHG
-        AdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AdYC5wH/
-        EAAB1gLnAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHW
-        Ae8B/wHGAdYB7wH/AcYB1gHvAf8BzAGZAVoB/wHMAZkBWgH/A+oB/xgAAdYC5wH/AcYB1gHvAf8BxgHW
-        Ae8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHWAucB/7QA
-        AfABygGmAf8D6gH/CAABQgFNAT4HAAE+AwABKAMAAUADAAEwAwABAQEAAQEFAAGAAQEWAAP/AQAB/AE/
-        AYABAQL/AgAB8AEPAgABgAEBAgAB4AEHAgABjwHxAgABwAEDAgABnwH5AgABgAEBAgABvwH9AgABgAEB
-        AgABvwH9BgABvwH9BgABvwH9BgABvwH9BgABvwGBAgABgAEBAgABvwGRAgABgAEBAgABvwGhAgABwAED
-        AgABnwGDAgAB4AEHAgABjwGHAgAB8AEPAgABgAEPAgAB/AE/AYABAQL/AgABgAEBAQABgAHwAQcFAAGA
-        AcABAwQAAfABgQGAAQEFAAGBAYAGAAEBBwABAQcAAQEHAAEfBgAB8AEBBgAB8AEBBgAB8AEBBgAB8AEB
-        BgAB/wEHAYABAQQAAf8BBwGAAQEEAAH/AQcBwAEDAgABgAEBAf8BBwHwAQ8CAAj/AYABfwGPBf8BgAE/
-        AcwBAQHAAQ8BwAEPAYABBwGMAQEBwAEHAcABBwGAAQcBjAEBAcABAwHAAQMBgAEBAv8BwAEDAcABAwGA
-        AQEBjwH/AcABAwHAAQMBgAEBAYwBAQHAAQMBwAEDAYABAQHMAQEBwAEDAcABAwGAAQEBjAEBAcABAwHA
-        AQMBgAEBAv8BwAEDAcABAQGAAQEBjwH/AcABAwHAAQAB4AEBAdwBAQHAAQMBwAEAAeABAQHcAQEBwAED
-        AcABAAH4AQEBnAEBAcABAwHAAQEB+AEBBf8B8ws=
+        AZQCXgFcAc4BagFjAVkB6wFqAWMBWQHrAl4BXAHOA04BlAIAAeIB/wIAAeIB/wwAAaYCjAH/ATwCAQH/
+        ATUCAAH/ATECAAH/ATECAAH/ATECAAH/ATECAAH/ATECAAH/ATECAAH/ATECAAH/ATECAAH/ATECAAH/
+        ATECAAH/AS8CAAH/ASsCAAH/AQsCAAH/A2UB/wMAAf8DCgH/AyEB/wMAAf8DBAH/A8AB/wPAAf8DwAH/
+        A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wMGAQgDCgEOAxABFQMSARkBWQFcAVkBzAESAdUBAQH/
+        AU8BZgFOAe8DTgGZBAADTgGZAU8BZgFOAe8BEgHVAQEB/wESAdUBAQH/ARIB1QEBAf8BWAFcAVgB0QMT
+        ARoIAAMKAQ0DTgGWAY8BcwFNAfoB4QHNAbkB/wHxAeABzgH/AfkB5wHWAf8B+AHmAdQB/wHwAd0BzAH/
+        AeEBzQG5Af8CAAHiAf8CAAHiAf8DCgENCAABvwGFAYYB/wGDAQUBBwH/AW4CAAH/AWoCAAH/AWoCAAH/
+        A+oB/wPqAf8D6gH/AWoCAAH/A+oB/wPqAf8D6gH/AWoCAAH/AWUCAAH/AWACAAH/ASwCAAH/AwAB/wPA
+        Df8DIQH/AwQB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/xAAAVkBXAFZAcwBFQHN
+        AQQB/wFYAVwBWAHRAyMBMwQAAyMBMwFYAVwBWAHRARIBzAEBAf8BEgHMAQEB/wESAcwBAQH/AVgBXAFY
+        AdEIAAMKAQ0DVwG4AdkBvwGlAf8B/gHyAeQC/wHnAc8B/wH8AdsBuwH/AfkB0wGyAf8B9gHQAawB/wH0
+        AdEBrgH/AfYB2AG7Af8CAAHiAf8CAAHiAf8DVwG4AwoBDQQAAcABggGDAf8BiQEGAQgB/wGDAgAB/wFw
+        AgAB/wP2Af8BcAIAAf8BcAIAAf8D9gH/AXACAAH/A/YB/wFwAgAB/wFwAgAB/wP2Af8BawIAAf8BZgIA
+        Af8BLwIAAf8DAAH/A8AR/wMAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8DwAH/A8AB/wPAAf8BKwEs
+        ASsBQwFWAVcBVgG4AVYBVwFWAbgBKwEsASsBQwFZAVwBWQHMARkBxAEIAf8BWAFcAVgB0QM8AWYEAAM8
+        AWYBWAFcAVgB0QESAcEBAQH/ARIBwQEBAf8BEgHBAQEB/wFYAVwBWAHRCAADTgGWAdkBvwGlAv8B+AHr
+        Av8B6wHRAv8B4QHDAf8B/gHbAboB/wH7AdYBsgH/AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/AgAB4gH/
+        AgAB4gH/AgAB4gH/AgAB4gH/AcIBggGDAf8BjgEHAQkB/wGIAgAB/wGEAgAF/wGEAgAB/wGEAgAF/wGE
+        AgAF/wGEAgAB/wGEAgAF/wFwAgAB/wFqAgAB/wExAgAB/wNlAf8DBAH/A00B/wOyAf8DsgH/A8AB/wMA
+        Af8DCgH/AwAB/wMAAf8DAAH/AwAB/wMKAf8DwAH/A8AB/wPAAf8DVQGyAT8BxgEuAf8BTAFxAUwB8wFZ
+        AVwBWQHMAVsBXgFbAdkBEwG3AQIB/wFQAWQBTgHvAVoBXQFaAdMDWQHMAVoBXQFaAdMBTwFjAU4B7wEU
+        AbcBAwH/ARMBtgECAf8BEgG2AQEB/wFYAVwBWAHRBAADJgE4AakBhwFIAf0C/gH6Av8B+QHpAv8B7wHY
+        Av8B5wHNAv8B4QHCAf8B/AHcAbsB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIAAeIB/wIA
+        AeIB/wIAAeIB/wHCAYIBgwH/AY4BBwEJAf8BiAIAAf8BhAIAAf8BhAIADf8BhAIADf8BhAIAAf8BcAIA
+        Af8BagIAAf8BMQIAAf8DwAH/A2UB/wMEAf8DAAH/AwAF/wMAAf8DBAH/A5YJ/wOGAf8DCgH/AwoB/wPA
+        Af8DwAH/AVkBXAFZAcwBPgHFAS0B/wE0AbsBIwH/AT0BxAEsAf8BMwG9ASIB/wESAasBAQH/ARQBrAED
+        Af8BGAGvAQcB/wEYAa8BBwH/ARcBrwEGAf8BUAFkAU4B7wFYAVwBWAHRAVgBXAFYAdEBTwFkAU4B7wFY
+        AVwBWAHRBAADTgGWAeIBzgG6Af8B9wHeAcYC/wHpAdEC/wH2AeIC/wHyAd0C/wHwAd0B/wH4AeoB2QH/
+        AfgB5gHUAf8B+wHfAccB/wH1Ac8BqwH/AgAB4gH/AgAB4gH/AfgB3QHDAf8B4gHOAboB/wNOAZYBwgGC
+        AYMB/wGOAQcBCQH/AYgCAAH/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAX/AYQCAAX/AYQCAAH/AYQCAAH/
+        AYQCAAH/AXACAAH/AWoCAAH/ATECAAH/A8AB/wPAAf8DwAH/A8AB/wMABf8DAAH/AwoR/wPAAf8DAAH/
+        A8AB/wPAAf8DVQGyAUYBzQE1Af8BTAFzAUwB8wFZAVwBWQHMAVsBXgFbAdkBJAGwARMB/wETAaIBAgH/
+        ARIBoQEBAf8BEgGhAQEB/wEZAagBCAH/AVoBXQFaAdMDPAFmAyMBMwNOAZkDPAFmBAACXgFbAdAB7wHg
+        AdAB/wHnAb4BlgH/AecBvAGUAf8B8AHMAakB/wH+AewB2gH/Ad0BxAGsAf8CZAFcAecCZAFcAecB3QHD
+        AaoB/wH4Ad0BxAH/AgAB4gH/AgAB4gH/AfUB1gG4Af8B8QHfAc8B/wJeAVsB0AHCAYIBgwH/AY4BBwEJ
+        Af8BiAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIABf8BhAIABf8BhAIAAf8BhAIAAf8BhAIAAf8BcAIA
+        Af8BagIAAf8BMQIAAf8DTQH/A00B/wNNAf8DTQH/AwAF/wMAAf8DAAH/AyEB/wPADf8DAAH/A00B/wNN
+        Af8BKwEsASsBQwFWAVcBVgG4AVYBVwFWAbgBKwEsASsBQwFZAVwBWQHMAUABxwEvAf8BLwG3AR4B/wEl
+        Aa0BFAH/ARsBpAEKAf8BIgGqAREB/wFZAVwBWQHMFAABagFkAVkB7AH1AeQB1QH/AekBvgGXAf8B6AG8
+        AZYB/wHnAbwBlAH/AfMB3gHKAf8BZgFhAVkB5gMUARsDFAEbAWYBYQFZAeYB9gHjAdMB/wIAAeIB/wIA
+        AeIB/wHtAckBpAH/AfYB5AHSAf8BagFkAVkB7AHCAYIBgwH/AY4BBwEJAf8BiAIAAf8BhAIAAf8BhAIA
+        Af8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BhAIAAf8BcAIAAf8BagIA
+        Af8BMQIAAf8DTQH/A00B/wNNAf8DTQH/AwAF/wMAAf8DJwH/AwQB/wMAAf8DAAH/AwAF/wMAAf8DTQH/
+        A00B/xAAAVkBXAFZAcwBQwHKATIB/wE1AbwBJAH/ATUBvAEkAf8BNQG8ASQB/wE9AcQBLAH/AVoBXQFa
+        AdMDPAFmAyMBMwNOAZkDPAFmBAABagFkAVkB7AH1AeQB1QH/AekBvwGZAf8B6QHAAZkB/wHpAcEBmgH/
+        AfMB3QHJAf8BZgFhAVkB5gMUARsDFAEbAWYBYQFZAeYB+AHoAdkB/wHyAdIBsgH/AfABzAGrAf8B8AHM
+        AasB/wH2AeQB0wH/AWoBZAFZAew0/wP2Af8D6gH/A24B/wNNAf8DTQH/A00B/wNNAf8DAAX/AwQB/wMA
+        Af8DCgH/AycB/wMnAf8DAAX/AwAB/wNNAf8DTQH/EAABWQFcAVkBzAFIAc8BNwH/AToBwQEpAf8BOgHB
+        ASkB/wE6AcEBKQH/ATwBwwErAf8BWAFmAVUB7wFYAVwBWAHRAVgBXAFYAdEBWAFmAVUB7wFZAVwBWQHM
+        BAACXgFbAdAB8AHhAdEB/wHqAcQBoQH/AekBwQGbAf8B6QHAAZcB/wHxAc4BsgH/AdwBwwGqAf8CZAFc
+        AecCZAFcAecB3QHEAawC/wH8AfMC/wH0AeUC/wHuAdoB/wH8AeUB0QH/AfEB4QHRAf8CXgFbAdAE/wGO
+        AQcBCQn/AYQCAA3/AYQCAAH/AYQCAA3/AXACAAH/AWoCAAH/A24B/wNNAf8DTQH/A00B/wNNAf8DAAn/
+        A4YB/wMKAf8DAAH/AwQB/wMABf8DAAH/A00B/wNNAf8QAAFZAVwBWQHMAVUB3AFEAf8BTQHUATwB/wFM
+        AdMBOwH/AUsB0gE6Af8BRQHMATQB/wE/AcYBLgH/AUcBzgE2Af8BUAHXAT8B/wFOAdUBPQH/AVkBXAFZ
+        AcwEAANOAZYB4gHOAboB/wHxAdIBtgH/AesBwQGbAf8B6wG/AZkC/wHkAdMC/wHoAdsB/wHzAdoBxwH/
+        AfgB8QHkAv8B+AHtAv8B9wHpAv8B/gHxAv8B/AHvAv8B/AHyAf8B4gHOAboB/wNOAZYE/wGOAQcBCQn/
+        AYQCAAn/AYQCABH/AYQCAAH/A/YB/wPqAf8DbgH/A00B/wNNAf8DTQH/A00B/wMAAf8Dsg3/A8AB/wM7
+        Af8DAAX/AwAB/wNNAf8DTQH/EAADTgGZAVkBXAFZAcwBWQFcAVkBzAFZAVwBWQHMAVkBXAFZAcwBWwFe
+        AVsB2QFLAdIBOgH/AVsBXgFbAdkBWQFcAVkBzAFZAVwBWQHMA04BmQQAAyYBOAGpAYcBSAH9AfoB7QHh
+        Af8B7AHHAaMC/wHsAdoF/wH3Ac0BtgH/AewBvQGXAv8B9AHcA/8B9wL/AfcB6AP/AfMD/wH5Af8C/gH5
+        Af8BqQGHAUgB/QMmATgE/wGOAQcBCQn/AYQCAAn/AYQCAAH/AYQCAAH/AYQCAAH/AYQCAAX/AYQCAAH/
+        AXACAAH/AWoCAAH/ATECAAH/A00B/wNNAf8DTQH/A00B/wMKAf8DIQH/A7IZ/wMAAf8DTQH/A00B/yAA
+        ASsBLAErAUMBWQFcAVkBzAFWAd0BRQH/AVkBXAFZAcwBKwEsASsBQxAAA04BlgHZAb8BpQL/AfoB8Ab/
+        Af0B8wH/AfABwQGjAf8B7gHGAaAB/wH9AfAB0QP/Af4C/wH9AfAC/wH9AfEF/wHZAb8BpQH/A04BlgQA
+        BP8BjgEHAQkB/wGIAgAF/wGEAgAJ/wGEAgAJ/wGEAgAF/wGEAgAB/wP2Af8D6gH/ATECAAH/A00B/wNN
+        Af8DTQH/A00B/wNNAf8DCgH/AwAB/wMKAf8DhhH/AwAB/wNNAf8DTQH/IAABVgFXAVYBuAFdAXsBTAHz
+        AVEB2AFAAf8BXQF7AUwB8wFWAVcBVgG4EAADCgENA1cBuAHZAb8BpQH/Af4B/QH8Av8B8QHkAf8B8gHK
+        Aa4B/wHyAdIBrQH/AfkB7QHIA/8B9wP/Af0B/wH+Af0B/AH/AdkBvwGlAf8DVwG4AwoBDQQABP8BkQEO
+        ARAJ/wGIAgAB/wGIAgAJ/wGIAgAB/wGIAgAN/wGDAgAB/wFuAgAB/wOAAf8DTQH/A00B/wNNAf8DTQH/
+        A00B/wNNAf8DTQH/AwoB/wMAAf8DBAH/A00B/wPABf8DAAH/A00B/wNNAf8gAAFWAVcBVgG4AWIB6QFR
+        Af8BXQHkAUwB/wFhAegBUAH/AVYBVwFWAbgUAAMKAQ0DTgGWAY8BcwFNAfoB4QHNAbkB/wHxAeIB1AH/
+        AfkB7AHfAf8B+wHzAeUB/wH0Ae0B5AH/AeIBzgG7Af8BjwFzAU0B+gNOAZYDCgENCAAE/wGVARgBGi3/
+        A/cB/wPsAf8DggH/BAADTQH/A00B/wNNAf8DTQH/A00B/wNNAf8DTQH/A00B/wNNAf8DBAH/AwAB/wMh
+        Af8DCgH/A00B/yQAASsBLAErAUMDVQGyAVkBXAFZAcwDVQGyASsBLAErAUMcAAMnATsDTgGUAl4BXAHO
+        AWoBYwFZAesBaAFiAVgB7wJeAVsB2QNPAZcDJwE7EAAI/wHDAYUBhin/A/wB/wP3Af8DvwH//wAFAAGZ
+        AswB/wFUAswB/wFUAswB/wFUAswB/wFUAswB/wFUAswB/wFUAswB/wPqAf8gAAGkAqAB/wNUAf8DzAH/
+        tAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wFUAswB/wFUAswB/wPxAf8gAAPXAf8DVAH/CAADmQH/
+        A00B/wNDAf8DQwH/AzAB/wMnAf8DIQH/AxcB/wOGAf8MAAGZAswB/wFUAswB/wFUAswB/wFUAswB/wFU
+        AswB/wFUAswB/wFUAswB/wFUAswB/wFUAswB/wPqAf8YAAGZAswB/wFUAswB/wFUAswB/wFUAswB/wFU
+        AswB/wFUAswB/wFUAswB/wFUAswB/wFUAswB/wPqAf8UAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AVQCzAH/AZkBzAL/ASECmQH/AVQCzAH/AVQCzAH/AZkCzAH/EAAD6gH/A1QB/wPqAf8IAANNAf8DVAH/
+        A0MB/wMwAf8DMAH/A0MB/wNUAf8DZQH/AxcB/wwAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AZkD/wFUAswB/wFUAswB/wPxAf8UAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BVALM
+        Af8BVALMAf8D8QH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wFUAswB/wFUAswB/wFUAswB/wEh
+        AswB/wGZA/8BmQLMAf8QAAOyAf8DhgH/A4YB/wgAAaQCoAH/A1QB/wNNAf8DTQH/A00B/wNDAf8DQwH/
+        AzAB/wOGAf8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BVALMAf8BmQHMAv8BVALM
+        Af8D8QH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AVQCzAH/AZkBzAL/AVQCzAH/
+        A/EB/wwAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BIQLMAf8BmQP/ASECmQH/
+        AVQCzAH/AZkCzAH/TAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AVQCzAH/AVQCzAH/
+        AVQCzAH/AZkCzAH/EAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AVQCzAH/AVQCzAH/
+        AVQCzAH/AZkCzAH/DAABmQLMAf8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEhAswB/wGZ
+        A/8BIQLMAf8BmQP/AZkCzAH/CAADZQH/A2UB/wNUAf84AAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQLMAf8QAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQLMAf8MAAGZAswB/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        ASECzAH/AZkD/wEhAswB/wGZA/8BmQLMAf8IAAPxAf8DlgX/CAABpAKgAf8DVAH/A1QB/wNUAf8DVAH/
+        A1QB/wNNAf8DTQH/A5kB/wwAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AZkD/wGZAswB/xAAAZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZ
+        AswB/wwAAZkCzAH/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BIQLMAf8BmQP/ASECzAH/
+        AZkD/wGZAswB/wwAA/EB/wOWAf8IAANUAf8DVAH/A0MB/wM7Af8DMAH/A0MB/wNUAf8DZQH/A00B/wwA
+        AZkCzAH/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/xAAAZkCzAH/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZAswB/wwAAcYB1gHvAf8BzAP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEhAswB/wGZA/8BIQLMAf8BmQP/AZkCzAH/CAADsgH/
+        A4YB/wOyAf8IAAOyAf8DZQH/A1QB/wNUAf8DVAH/A1QB/wNUAf8DVAH/AaQCoAH/DAABmQLMAf8BmQP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BmQP/AZkD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8CmQFUAf8BmQHMAZkB/wwAAcYB1gHvAf8BzAP/AcwD/wHM
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wEhAswB/wGZA/8BIQLMAf8BmQP/AZkCzAH/TAABmQLMAf8BzAP/
+        AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BzAP/AZkD/wGZ
+        A/8BmQP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQFUASEB/wGZAVQBIQH/A+MB/wgAAdYC5wH/AcYB1gHv
+        Af8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BmQP/ASECzAH/
+        AZkD/wGZAswB/wgAA4YB/wOGAf8DhgH/OAABmQLMAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AZkD/wGZA/8BmQP/AZkCzAH/EAABmQLMAf8BzAP/AZkD/wGZA/8BmQP/AZkD/wKZAVQB/wHMAZkBIQH/
+        AcwBmQEhAf8BzAGZASEB/wHMAZkBIQL/AcwBIQH/AcwBmQFUAf8D4wH/DAABxgHWAe8B/wHMA/8BzAP/
+        AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/ASECzAH/AZkD/wGZAswB/wwAA4YB/wwAA7IB/wOGAf8DZQH/
+        A2UB/wNlAf8DZQH/A1QB/wNUAf8BpAKgAf8MAAHGAdYB7wH/AcwD/wGZA/8BmQP/AZkD/wGZA/8BmQP/
+        AZkD/wGZA/8BmQP/AZkD/wHGAdYB7wH/EAABxgHWAe8B/wHMA/8BmQP/AZkD/wGZA/8BmQP/AcwBmQEh
+        Av8BzAGZAv8BzAFUAv8BzAFUAv8BzAFUAv8BzAFUAv8BzAFUAf8BzAGZAVQB/wwAAdYC5wH/AcYB1gHv
+        Af8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BVALMAf8BmQP/AcYB1gHv
+        Af8MAAOGAf8MAAOGAf8DVAH/A0MB/wNDAf8DOwH/AzsB/wNDAf8DVAH/A1QB/wwAAcYB1gHvAf8BzAP/
+        AcwD/wHMA/8BzAP/AZkD/wGZA/8BmQP/AZkD/wGZA/8BmQP/AcYB1gHvAf8QAAHGAdYB7wH/AcwD/wHM
+        A/8BzAP/AcwD/wGZA/8CzAGZAf8BzAGZAVQB/wHMAZkBVAH/AcwBmQFUAf8BzAGZAVQC/wHMAZkB/wHM
+        AZkBVAH/A+MB/xQAAcYB1gHvAf8BzAP/AcwD/wHMA/8BmQP/AZkD/wGZA/8BmQP/AZkD/wHGAdYB7wH/
+        CAADsgH/A4YB/wwAA7IB/wOGAf8DhgH/A4YB/wOGAf8DZQH/A2UB/wNlAf8DsgH/DAAB1gLnAf8BxgHW
+        Ae8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/
+        AcYB1gHvAf8BxgHWAe8B/wHWAucB/xAAAdYC5wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHv
+        Af8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcwBmQFUAf8BzAGZAVQB/wPq
+        Af8YAAHWAucB/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHGAdYB7wH/AcYB1gHvAf8BxgHWAe8B/wHG
+        AdYB7wH/AcYB1gHvAf8B1gLnAf+0AAHwAcoBpgH/A+oB/wgAAUIBTQE+BwABPgMAASgDAAFAAwABMAMA
+        AQEBAAEBBQABgAEBFgAD/wEAAfwBPwGAAQEC/wIAAfABDwIAAYABAQIAAeABBwIAAY8B8QIAAcABAwIA
+        AZ8B+QIAAYABAQIAAb8B/QIAAYABAQIAAb8B/QYAAb8B/QYAAb8B/QYAAb8B/QYAAb8BgQIAAYABAQIA
+        Ab8BkQIAAYABAQIAAb8BoQIAAcABAwIAAZ8BgwIAAeABBwIAAY8BhwIAAfABDwIAAYABDwIAAfwBPwGA
+        AQEC/wIAAYABAQEAAYAB8AEHBQABgAHAAQMEAAHwAYEBgAEBBQABgQGABgABAQcAAQEHAAEBBwABHwYA
+        AfABAQYAAfABAQYAAfABAQYAAfABAQYAAf8BBwGAAQEEAAH/AQcBgAEBBAAB/wEHAcABAwIAAYABAQH/
+        AQcB8AEPAgAI/wGAAX8BjwX/AYABPwHMAQEBwAEPAcABDwGAAQcBjAEBAcABBwHAAQcBgAEHAYwBAQHA
+        AQMBwAEDAYABAQL/AcABAwHAAQMBgAEBAY8B/wHAAQMBwAEDAYABAQGMAQEBwAEDAcABAwGAAQEBzAEB
+        AcABAwHAAQMBgAEBAYwBAQHAAQMBwAEDAYABAQL/AcABAwHAAQEBgAEBAY8B/wHAAQMBwAEAAeABAQHc
+        AQEBwAEDAcABAAHgAQEB3AEBAcABAwHAAQAB+AEBAZwBAQHAAQMBwAEBAfgBAQX/AfML
 </value>
   </data>
   <data name="bnComboBoxRelease.Location" type="System.Drawing.Point, System.Drawing">

--- a/CUERipper/frmCUERipper.ru-RU.resx
+++ b/CUERipper/frmCUERipper.ru-RU.resx
@@ -142,9 +142,6 @@
   <data name="lblWriteOffset.Size" type="System.Drawing.Size, System.Drawing">
     <value>61, 13</value>
   </data>
-  <data name="lblWriteOffset.Text" xml:space="preserve">
-    <value>Смещение</value>
-  </data>
   <data name="checkBoxEACMode.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 17</value>
   </data>
@@ -237,5 +234,13 @@
   </data>
   <data name="buttonReload.Text" xml:space="preserve">
     <value>П&amp;ерезагр.</value>
+  </data>
+  <data name="numericWriteOffset.ToolTip" xml:space="preserve">
+    <value>Смещение</value>
+  </data>
+  <data name="bnComboBoxC2ErrorModeSetting.ToolTip" xml:space="preserve">
+    <value>C2 Режим ошибки
+Параметр «Авто» работает с большинством приводов.
+При необходимости здесь можно установить C2 режим ошибки.</value>
   </data>
 </root>


### PR DESCRIPTION
Add a ComboBox left to the Read offset, which allows to select the
C2ErrorMode for each drive, if required. The default setting is `Auto`,
which preserves the behavior of CUERipper.
- Remove `lblWriteOffset` to free space for the new ComboBox
  `bnComboBoxC2ErrorModeSetting`
- Update `TabIndex` considering the added `bnComboBoxC2ErrorModeSetting`
- Add ToolTip to `bnComboBoxC2ErrorModeSetting` and `numericWriteOffset`
- Update the translation files and move the translation of the removed
  `lblWriteOffset.Text` to `numericWriteOffset.ToolTip`
