### PR TITLE
[CUETools] Fix tta decoding exception

### DIFF
--- a/CUETools.Codecs.TTA/CUETools.Codecs.TTA.cpp
+++ b/CUETools.Codecs.TTA/CUETools.Codecs.TTA.cpp
@@ -56,7 +56,7 @@ namespace TTA {
 		[System::ComponentModel::Browsable(false)]
 		virtual property int Priority
 		{
-			int get() { return 1; }
+			int get() { return 2; }
 		}
 
 		virtual IAudioDecoderSettings^ Clone()


### PR DESCRIPTION
Set `ttalib` as default decoder for `tta` instead of `ffmpeg.dll`.
This is a follow-up to commit 18c6c1a, where the priority has already
been updated for `libwavpack` and `MACLib`.

- Increase the priority of the `ttalib` `AudioDecoder` from `1` to `2`
- Resolves: #207