### PR TITLE
Fix default C2 error mode for further drives

### DIFF
--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -812,20 +812,45 @@ namespace CUETools.Ripper.SCSI
 				return true;
 
 			ReadCDCommand[] readmode = { ReadCDCommand.ReadCdBEh, ReadCDCommand.ReadCdD8h };
-			// Device.C2ErrorMode[] c2mode = { Device.C2ErrorMode.Mode294, Device.C2ErrorMode.Mode296, Device.C2ErrorMode.None };
 			Device.C2ErrorMode[] c2mode = { Device.C2ErrorMode.Mode294 };
 			if (_driveC2ErrorMode == DriveC2ErrorModeSetting.Auto)
 			{
-				Array.Resize(ref c2mode, 3);
-				c2mode.SetValue(Device.C2ErrorMode.Mode296, 1);
-				c2mode.SetValue(Device.C2ErrorMode.None, 2);
-				// Mode294 does not work for these drives: LG GH24NSD1, ASUS DRW-24D5MT, ASUS DRW-24F1ST d, PIONEER DVR-S21, PIONEER BDR-XD05, PIONEER BDR-XD07U, HL-DT-ST BD-RE BU40N, Slimtype - DVD A DU8AESH. Try Mode296 first
 				// Drives can contain one or multiple spaces in the name, e.g. "ASUS DRW-24F1ST   d". Remove any spaces from Path.
 				string pathNoSpace = Path.Replace(" ", String.Empty);
-				if (pathNoSpace.Contains("GH24NSD1") || pathNoSpace.Contains("DRW-24D5MT") || pathNoSpace.Contains("DRW-24F1STd") || pathNoSpace.Contains("DVR-S21") || pathNoSpace.Contains("BDR-XD05") || pathNoSpace.Contains("BDR-XD07U") || pathNoSpace.Contains("BU40N") || pathNoSpace.Contains("DU8AESH"))
+
+				// Mode294 does not work for these drives. Try Mode296 first, which has been reported to work:
+				// ASUS DRW-24D5MT, ASUS DRW-24F1ST d,
+				// HL-DT-ST BD-RE BU40N,
+				// LG GH24NSD1,
+				// PIONEER BDR-XD05, PIONEER BDR-XD07U, PIONEER DVR-S21,
+				// PLDS DU-8A5LH,
+				// Slimtype - DVD A DU8AESH.
+				if (pathNoSpace.Contains("DRW-24D5MT") || pathNoSpace.Contains("DRW-24F1STd") ||
+					pathNoSpace.Contains("BU40N") ||
+					pathNoSpace.Contains("GH24NSD1") ||
+					pathNoSpace.Contains("BDR-XD05") || pathNoSpace.Contains("BDR-XD07U") || pathNoSpace.Contains("DVR-S21") ||
+					pathNoSpace.Contains("DU-8A5LH") ||
+					pathNoSpace.Contains("DU8AESH"))
 				{
+					Array.Resize(ref c2mode, 2);
 					c2mode.SetValue(Device.C2ErrorMode.Mode296, 0);
-					c2mode.SetValue(Device.C2ErrorMode.Mode294, 1);
+					c2mode.SetValue(Device.C2ErrorMode.None, 1);
+				}
+
+				// Mode294 does not work for this drive, C2ErrorMode.None has been reported to work:
+				// iHAS324 F.
+				else if (pathNoSpace.Contains("iHAS324F"))
+				{
+					c2mode.SetValue(Device.C2ErrorMode.None, 0);
+				}
+
+				// Default. Auto detection of C2ErrorMode for most drives.
+				// Device.C2ErrorMode[] c2mode = { Device.C2ErrorMode.Mode294, Device.C2ErrorMode.Mode296, Device.C2ErrorMode.None };
+				else
+				{
+					Array.Resize(ref c2mode, 3);
+					c2mode.SetValue(Device.C2ErrorMode.Mode296, 1);
+					c2mode.SetValue(Device.C2ErrorMode.None, 2);
 				}
 			}
 			else


### PR DESCRIPTION
The auto-detected `C2ErrorMode.Mode294` does not work for these drives:
PLDS DU-8A5LH, iHAS324 F. Specify the reported working `C2ErrorMode`.

- PLDS DU-8A5LH:
  `C2ErrorMode.Mode296` has been reported to work.
  https://hydrogenaud.io/index.php?topic=122161.msg1011466#msg1011466
- iHAS324 F
  `C2ErrorMode.None` has been reported to work.
  https://github.com/gchudov/cuetools.net/issues/107#issuecomment-1145410404
- Sort the list of drives, which require special attention concerning
  `C2ErrorMode`
- Revise the code concerning `C2ErrorMode` of drives in order to handle
  the following three cases:
  * Default. Automatic detection like in the past.
    `C2ErrorMode` is tried in the following order: `Mode294, Mode296, None`
  * Drives, where `Mode294` was detected but not working. `Mode296` works.
    Use `Mode296` and leave `C2ErrorMode.None` as fallback.
  * Drives, where `Mode294` was detected but not working. `Mode296` didn't
    work either. Use `C2ErrorMode.None`
