### PR TITLE
Collect FFmpeg.AutoGen.dll

### DIFF
--- a/CUETools/collect_files.bat
+++ b/CUETools/collect_files.bat
@@ -98,6 +98,8 @@ REM plugins translation files
 xcopy /Y /D %base_dir%\bin\Release\net47\plugins\de-DE\* %release_dir%\plugins\de-DE\
 xcopy /Y /D %base_dir%\bin\Release\net47\plugins\ru-RU\* %release_dir%\plugins\ru-RU\
 
+REM ThirdParty
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Release\net45\FFmpeg.AutoGen.dll %release_dir%\plugins\
 xcopy /Y /D %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %release_dir%\plugins\
 
 REM ThirdParty\Win32 plugins

--- a/CUETools/collect_files_debug.bat
+++ b/CUETools/collect_files_debug.bat
@@ -14,7 +14,10 @@ REM /D xcopy copies all Source files that are newer than existing Destination fi
 
 REM xcopy /Y /D %base_dir%\CUETools\user_profiles_enabled %debug_dir%
 
-xcopy /Y /D  %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %debug_dir%\plugins\
+REM ThirdParty
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net45\FFmpeg.AutoGen.dll %debug_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net45\FFmpeg.AutoGen.pdb %debug_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %debug_dir%\plugins\
 
 REM ThirdParty\Win32 plugins
 xcopy /Y /D %base_dir%\ThirdParty\Win32\hdcd.dll %debug_dir%\plugins\win32\


### PR DESCRIPTION
`FFmpeg.AutoGen.dll` is required by the experimental ffmpeg plugin of
CUETools.

- Update the scripts `collect_files.bat` and `collect_files_debug.bat`
- Fixes Exception: Could not load file or assembly 'FFmpeg.AutoGen,
  Version=4.1.0.4, Culture=neutral, PublicKeyToken=9b7632533a381715' or
  one of its dependencies. The system cannot find the file specified.
- Remark: For using the FFmpeg plugin, further dll files are required
  from FFmpeg.AutoGen\FFmpeg\bin\x64 in their matching
  version and need to be copied to plugins\x64\. They are not
  distributed together with CUETools.
  Currently, CUETools is set to use FFmpeg.AutoGen 4.1.0.4, which
  requires the following FFmpeg 4.1 dlls:
  avcodec-58.dll, avdevice-58.dll, avfilter-7.dll, avformat-58.dll,
  avutil-56.dll, postproc-55.dll, swresample-3.dll, swscale-5.dll
