### PR TITLE
FFmpeg plugin: Fix Audio file length is unknown

### DIFF
--- a/CUETools.Codecs.ffmpeg/AudioDecoder.cs
+++ b/CUETools.Codecs.ffmpeg/AudioDecoder.cs
@@ -437,6 +437,9 @@ namespace CUETools.Codecs.ffmpegdll
             }
 
             buff.Length = (int)buffOffset;
+            // EOF
+            if (buff.Length == 0)
+                _sampleCount = _sampleOffset;
             return buff.Length;
         }
 


### PR DESCRIPTION
So far, `_sampleCount` has been permanently set to `-1`. It is used for
calculating the `Length`.

- Assign value to `_sampleCount` at EOF
- Fixes the following exception:
  `Audio file length is unknown or invalid`
