### PR TITLE
Update FFmpeg.AutoGen from 4.1.0.4 to 4.3.0.3

### DIFF
--- a/CUETools/collect_files.bat
+++ b/CUETools/collect_files.bat
@@ -99,7 +99,7 @@ xcopy /Y /D %base_dir%\bin\Release\net47\plugins\de-DE\* %release_dir%\plugins\d
 xcopy /Y /D %base_dir%\bin\Release\net47\plugins\ru-RU\* %release_dir%\plugins\ru-RU\
 
 REM ThirdParty
-xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Release\net45\FFmpeg.AutoGen.dll %release_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Release\net472\FFmpeg.AutoGen.dll %release_dir%\plugins\
 xcopy /Y /D %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %release_dir%\plugins\
 
 REM ThirdParty\Win32 plugins

--- a/CUETools/collect_files_debug.bat
+++ b/CUETools/collect_files_debug.bat
@@ -15,8 +15,8 @@ REM /D xcopy copies all Source files that are newer than existing Destination fi
 REM xcopy /Y /D %base_dir%\CUETools\user_profiles_enabled %debug_dir%
 
 REM ThirdParty
-xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net45\FFmpeg.AutoGen.dll %debug_dir%\plugins\
-xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net45\FFmpeg.AutoGen.pdb %debug_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net472\FFmpeg.AutoGen.dll %debug_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net472\FFmpeg.AutoGen.pdb %debug_dir%\plugins\
 xcopy /Y /D %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %debug_dir%\plugins\
 
 REM ThirdParty\Win32 plugins


### PR DESCRIPTION
- Checkout release 4.3.0.3 of `FFmpeg.AutoGen`. The previously used
  commit in CUETools was Ruslan-B/FFmpeg.AutoGen@9bb7daa ([4.1.0.4](https://github.com/Ruslan-B/FFmpeg.AutoGen/releases/tag/4.1.0.4)).
- Use the following commands, to update the `FFmpeg.AutoGen` submodule to
  commit Ruslan-B/FFmpeg.AutoGen@e0d26f8 (tag [4.3.0.3](https://github.com/Ruslan-B/FFmpeg.AutoGen/releases/tag/4.3.0.3)):
```sh
    pushd ThirdParty/FFmpeg.AutoGen/
    git fetch
    git checkout e0d26f8a24e36b6cec25c703336eddb38a6d017e
    popd
```
