### PR TITLE
Update libFLAC from 1.3.4 to 1.4.1

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Apply patches
         # yamllint disable-line rule:line-length
         run: |
-          git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
+          git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose --whitespace=nowarn
           git apply --directory=ThirdParty/MAC_SDK ThirdParty/submodule_MAC_SDK_CUETools.patch --verbose
           git apply --directory=ThirdParty/taglib-sharp ThirdParty/submodule_taglib-sharp_CUETools.patch --verbose
           git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools.patch --verbose

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Apply patches
         # yamllint disable-line rule:line-length
         run: |
-          git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose
+          git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --verbose --whitespace=nowarn
           git apply --directory=ThirdParty/MAC_SDK ThirdParty/submodule_MAC_SDK_CUETools.patch --verbose
           git apply --directory=ThirdParty/taglib-sharp ThirdParty/submodule_taglib-sharp_CUETools.patch --verbose
           git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools.patch --verbose

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Prebuilt binaries can be downloaded from [CUETools Download](http://cue.tools/wi
 * Get the required submodules using:  
 `git submodule update --init --recursive`
 * Apply patches to submodules:  
-`git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch`  
+`git apply --directory=ThirdParty/flac ThirdParty/submodule_flac_CUETools.patch --whitespace=nowarn`  
 `git apply --directory=ThirdParty/MAC_SDK ThirdParty/submodule_MAC_SDK_CUETools.patch`  
 `git apply --directory=ThirdParty/taglib-sharp ThirdParty/submodule_taglib-sharp_CUETools.patch`  
 `git apply --directory=ThirdParty/WavPack ThirdParty/submodule_WavPack_CUETools.patch`  
-`git apply --directory=ThirdParty/WindowsMediaLib ThirdParty/submodule_WindowsMediaLib_CUETools.patch --verbose`
+`git apply --directory=ThirdParty/WindowsMediaLib ThirdParty/submodule_WindowsMediaLib_CUETools.patch`
 * The solution can be built using Microsoft Visual Studio 2017 or newer (Community Edition will work)
   * Install the required .NET development tools (currently .NET Framework 4.7 and .NET Core 2.0)
   * Install an appropriate Windows SDK version (e.g. 10.0.16299.0 or newer)

--- a/ThirdParty/submodule_flac_CUETools.patch
+++ b/ThirdParty/submodule_flac_CUETools.patch
@@ -1,176 +1,569 @@
 diff --git a/src/libFLAC/libFLAC_dynamic.vcxproj b/src/libFLAC/libFLAC_dynamic.vcxproj
-index 056df9c0..f271bf02 100644
---- a/src/libFLAC/libFLAC_dynamic.vcxproj
+new file mode 100644
+index 00000000..2720333d
+--- /dev/null
 +++ b/src/libFLAC/libFLAC_dynamic.vcxproj
-@@ -1,5 +1,5 @@
- ﻿<?xml version="1.0" encoding="utf-8"?>
--<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+@@ -0,0 +1,331 @@
++﻿<?xml version="1.0" encoding="utf-8"?>
 +<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <ItemGroup Label="ProjectConfigurations">
-     <ProjectConfiguration Include="Debug|Win32">
-       <Configuration>Debug</Configuration>
-@@ -22,21 +22,28 @@
-     <ProjectGuid>{4cefbc83-c215-11db-8314-0800200c9a66}</ProjectGuid>
-     <RootNamespace>libFLAC_dynamic</RootNamespace>
-     <Keyword>Win32Proj</Keyword>
++  <ItemGroup Label="ProjectConfigurations">
++    <ProjectConfiguration Include="Debug|Win32">
++      <Configuration>Debug</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
++    <ProjectConfiguration Include="Debug|x64">
++      <Configuration>Debug</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
++    <ProjectConfiguration Include="Release|Win32">
++      <Configuration>Release</Configuration>
++      <Platform>Win32</Platform>
++    </ProjectConfiguration>
++    <ProjectConfiguration Include="Release|x64">
++      <Configuration>Release</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
++  </ItemGroup>
++  <PropertyGroup Label="Globals">
++    <ProjectGuid>{4cefbc83-c215-11db-8314-0800200c9a66}</ProjectGuid>
++    <RootNamespace>libFLAC_dynamic</RootNamespace>
++    <Keyword>Win32Proj</Keyword>
 +    <!-- Latest Target Version property -->
 +    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
 +    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
-   </PropertyGroup>
-   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-     <ConfigurationType>DynamicLibrary</ConfigurationType>
-     <WholeProgramOptimization>true</WholeProgramOptimization>
++  </PropertyGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
++    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
 +    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-     <ConfigurationType>DynamicLibrary</ConfigurationType>
-     <WholeProgramOptimization>true</WholeProgramOptimization>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
++    <ConfigurationType>DynamicLibrary</ConfigurationType>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
 +    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-     <ConfigurationType>DynamicLibrary</ConfigurationType>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
++    <ConfigurationType>DynamicLibrary</ConfigurationType>
 +    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-     <ConfigurationType>DynamicLibrary</ConfigurationType>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
++    <ConfigurationType>DynamicLibrary</ConfigurationType>
 +    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
-   </PropertyGroup>
-   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-   <ImportGroup Label="ExtensionSettings">
-@@ -58,23 +65,23 @@
-     <_ProjectFileVersion>12.0.30501.0</_ProjectFileVersion>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
--    <OutDir>$(SolutionDir)objs\$(Configuration)\lib\</OutDir>
--    <IntDir>$(Configuration)_dynamic\</IntDir>
++  </PropertyGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
++  <ImportGroup Label="ExtensionSettings">
++  </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
++  <PropertyGroup Label="UserMacros" />
++  <PropertyGroup>
++    <_ProjectFileVersion>12.0.30501.0</_ProjectFileVersion>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
 +    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
 +    <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
-     <LinkIncremental>true</LinkIncremental>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-     <LinkIncremental>true</LinkIncremental>
--    <OutDir>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\</OutDir>
++    <LinkIncremental>true</LinkIncremental>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
++    <LinkIncremental>true</LinkIncremental>
 +    <OutDir>$(SolutionDir)..\ThirdParty$(Configuration)\$(Platform)\</OutDir>
-     <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
--    <OutDir>$(SolutionDir)objs\$(Configuration)\lib\</OutDir>
--    <IntDir>$(Configuration)_dynamic\</IntDir>
++    <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
 +    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
 +    <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
-     <LinkIncremental>false</LinkIncremental>
-   </PropertyGroup>
-   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-     <LinkIncremental>false</LinkIncremental>
--    <OutDir>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\</OutDir>
++    <LinkIncremental>false</LinkIncremental>
++  </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
++    <LinkIncremental>false</LinkIncremental>
 +    <OutDir>$(SolutionDir)..\ThirdParty\$(Platform)\</OutDir>
-     <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
-   </PropertyGroup>
-   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-@@ -82,7 +89,7 @@
-       <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
-       <Optimization>Disabled</Optimization>
-       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
--      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-       <MinimalRebuild>true</MinimalRebuild>
-       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-@@ -92,7 +99,6 @@
-       <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-     </ClCompile>
-     <Link>
--      <AdditionalDependencies>$(SolutionDir)objs\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
-       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-       <GenerateDebugInformation>true</GenerateDebugInformation>
-       <SubSystem>Windows</SubSystem>
-@@ -104,7 +110,7 @@
-       <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
-       <Optimization>Disabled</Optimization>
-       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
--      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-       <WarningLevel>Level3</WarningLevel>
-@@ -113,7 +119,6 @@
-       <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-     </ClCompile>
-     <Link>
--      <AdditionalDependencies>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
-       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-       <GenerateDebugInformation>true</GenerateDebugInformation>
-       <SubSystem>Windows</SubSystem>
-@@ -127,8 +132,8 @@
-       <OmitFramePointers>true</OmitFramePointers>
-       <WholeProgramOptimization>true</WholeProgramOptimization>
-       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
--      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
--      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++    <IntDir>$(Platform)\$(Configuration)_dynamic\</IntDir>
++  </PropertyGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
++    <ClCompile>
++      <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
++      <Optimization>Disabled</Optimization>
++      <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.4.1";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <MinimalRebuild>true</MinimalRebuild>
++      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <WarningLevel>Level3</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <CompileAs>Default</CompileAs>
++      <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
++    </ClCompile>
++    <Link>
++      <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Windows</SubSystem>
++      <TargetMachine>MachineX86</TargetMachine>
++    </Link>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
++    <ClCompile>
++      <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
++      <Optimization>Disabled</Optimization>
++      <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.4.1";DEBUG;FLAC__OVERFLOW_DETECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
++      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
++      <WarningLevel>Level3</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <CompileAs>Default</CompileAs>
++      <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
++    </ClCompile>
++    <Link>
++      <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Windows</SubSystem>
++    </Link>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
++    <ClCompile>
++      <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
++      <IntrinsicFunctions>true</IntrinsicFunctions>
++      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
++      <OmitFramePointers>true</OmitFramePointers>
++      <WholeProgramOptimization>true</WholeProgramOptimization>
++      <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;FLAC__CPU_IA32;FLAC__HAS_NASM;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.4.1";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 +      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-       <BufferSecurityCheck>false</BufferSecurityCheck>
-       <WarningLevel>Level3</WarningLevel>
-       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-@@ -137,7 +142,6 @@
-       <FloatingPointModel>Fast</FloatingPointModel>
-     </ClCompile>
-     <Link>
--      <AdditionalDependencies>$(SolutionDir)objs\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
-       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-       <GenerateDebugInformation>true</GenerateDebugInformation>
-       <SubSystem>Windows</SubSystem>
-@@ -155,8 +159,8 @@
-       <OmitFramePointers>true</OmitFramePointers>
-       <WholeProgramOptimization>true</WholeProgramOptimization>
-       <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
--      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
--      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.3.4";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <BufferSecurityCheck>false</BufferSecurityCheck>
++      <WarningLevel>Level3</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <CompileAs>Default</CompileAs>
++      <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
++      <FloatingPointModel>Fast</FloatingPointModel>
++    </ClCompile>
++    <Link>
++      <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Windows</SubSystem>
++      <OptimizeReferences>true</OptimizeReferences>
++      <EnableCOMDATFolding>true</EnableCOMDATFolding>
++      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
++      <TargetMachine>MachineX86</TargetMachine>
++    </Link>
++  </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
++    <ClCompile>
++      <AdditionalOptions>/D "_USE_MATH_DEFINES" %(AdditionalOptions)</AdditionalOptions>
++      <IntrinsicFunctions>true</IntrinsicFunctions>
++      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
++      <OmitFramePointers>true</OmitFramePointers>
++      <WholeProgramOptimization>true</WholeProgramOptimization>
++      <AdditionalIncludeDirectories>.\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FLAC_API_EXPORTS;FLAC__HAS_OGG=0;ENABLE_64_BIT_WORDS;FLAC__CPU_X86_64;FLAC__HAS_X86INTRIN;FLAC__ALIGN_MALLOC_DATA;PACKAGE_VERSION="1.4.1";FLaC__INLINE=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 +      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-       <BufferSecurityCheck>false</BufferSecurityCheck>
-       <WarningLevel>Level3</WarningLevel>
-       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-@@ -165,7 +169,6 @@
-       <FloatingPointModel>Fast</FloatingPointModel>
-     </ClCompile>
-     <Link>
--      <AdditionalDependencies>$(SolutionDir)objs\$(Platform)\$(Configuration)\lib\libogg_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
-       <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
-       <GenerateDebugInformation>true</GenerateDebugInformation>
-       <SubSystem>Windows</SubSystem>
-@@ -241,10 +244,6 @@
-     <ClCompile Include="memory.c" />
-     <ClCompile Include="metadata_iterators.c" />
-     <ClCompile Include="metadata_object.c" />
--    <ClCompile Include="ogg_decoder_aspect.c" />
--    <ClCompile Include="ogg_encoder_aspect.c" />
--    <ClCompile Include="ogg_helper.c" />
--    <ClCompile Include="ogg_mapping.c" />
-     <ClCompile Include="stream_decoder.c" />
-     <ClCompile Include="stream_encoder.c" />
-     <ClCompile Include="stream_encoder_framing.c" />
++      <BufferSecurityCheck>false</BufferSecurityCheck>
++      <WarningLevel>Level3</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <CompileAs>Default</CompileAs>
++      <DisableSpecificWarnings>4267;4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
++      <FloatingPointModel>Fast</FloatingPointModel>
++    </ClCompile>
++    <Link>
++      <IgnoreSpecificDefaultLibraries>uuid.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Windows</SubSystem>
++      <OptimizeReferences>true</OptimizeReferences>
++      <EnableCOMDATFolding>true</EnableCOMDATFolding>
++      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
++    </Link>
++  </ItemDefinitionGroup>
++  <ItemGroup>
++    <ClInclude Include="..\..\include\FLAC\all.h" />
++    <ClInclude Include="..\..\include\FLAC\assert.h" />
++    <ClInclude Include="..\..\include\FLAC\callback.h" />
++    <ClInclude Include="..\..\include\FLAC\export.h" />
++    <ClInclude Include="..\..\include\FLAC\format.h" />
++    <ClInclude Include="..\..\include\FLAC\metadata.h" />
++    <ClInclude Include="..\..\include\FLAC\ordinals.h" />
++    <ClInclude Include="..\..\include\FLAC\stream_decoder.h" />
++    <ClInclude Include="..\..\include\FLAC\stream_encoder.h" />
++    <ClInclude Include="..\..\include\share\alloc.h" />
++    <ClInclude Include="..\..\include\share\compat.h" />
++    <ClInclude Include="..\..\include\share\endswap.h" />
++    <ClInclude Include="..\..\include\share\macros.h" />
++    <ClInclude Include="..\..\include\share\private.h" />
++    <ClInclude Include="..\..\include\share\safe_str.h" />
++    <ClInclude Include="..\..\include\share\win_utf8_io.h" />
++    <ClInclude Include="ia32\nasm.h" />
++    <ClInclude Include="include\private\all.h" />
++    <ClInclude Include="include\private\bitmath.h" />
++    <ClInclude Include="include\private\bitreader.h" />
++    <ClInclude Include="include\private\bitwriter.h" />
++    <ClInclude Include="include\private\cpu.h" />
++    <ClInclude Include="include\private\crc.h" />
++    <ClInclude Include="include\private\fixed.h" />
++    <ClInclude Include="include\private\float.h" />
++    <ClInclude Include="include\private\format.h" />
++    <ClInclude Include="include\private\lpc.h" />
++    <ClInclude Include="include\private\md5.h" />
++    <ClInclude Include="include\private\memory.h" />
++    <ClInclude Include="include\private\metadata.h" />
++    <ClInclude Include="include\private\ogg_decoder_aspect.h" />
++    <ClInclude Include="include\private\ogg_encoder_aspect.h" />
++    <ClInclude Include="include\private\ogg_helper.h" />
++    <ClInclude Include="include\private\ogg_mapping.h" />
++    <ClInclude Include="include\private\stream_encoder.h" />
++    <ClInclude Include="include\private\stream_encoder_framing.h" />
++    <ClInclude Include="include\private\window.h" />
++    <ClInclude Include="include\protected\all.h" />
++    <ClInclude Include="include\protected\stream_decoder.h" />
++    <ClInclude Include="include\protected\stream_encoder.h" />
++  </ItemGroup>
++  <ItemGroup>
++    <ClCompile Include="bitmath.c" />
++    <ClCompile Include="bitreader.c" />
++    <ClCompile Include="bitwriter.c" />
++    <ClCompile Include="cpu.c" />
++    <ClCompile Include="crc.c" />
++    <ClCompile Include="fixed.c" />
++    <ClCompile Include="fixed_intrin_sse2.c" />
++    <ClCompile Include="fixed_intrin_ssse3.c" />
++    <ClCompile Include="float.c" />
++    <ClCompile Include="format.c" />
++    <ClCompile Include="lpc.c" />
++    <ClCompile Include="lpc_intrin_avx2.c">
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++    </ClCompile>
++    <ClCompile Include="lpc_intrin_fma.c">
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/arch:AVX2 /fp:fast %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/arch:AVX2 /fp:fast %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/arch:AVX2 /fp:fast %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/arch:AVX2 /fp:fast %(AdditionalOptions)</AdditionalOptions>
++    </ClCompile>
++    <ClCompile Include="lpc_intrin_sse2.c" />
++    <ClCompile Include="lpc_intrin_sse41.c" />
++    <ClCompile Include="md5.c" />
++    <ClCompile Include="memory.c" />
++    <ClCompile Include="metadata_iterators.c" />
++    <ClCompile Include="metadata_object.c" />
++    <ClCompile Include="stream_decoder.c" />
++    <ClCompile Include="stream_encoder.c" />
++    <ClCompile Include="stream_encoder_framing.c" />
++    <ClCompile Include="stream_encoder_intrin_avx2.c">
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
++    </ClCompile>
++    <ClCompile Include="stream_encoder_intrin_sse2.c" />
++    <ClCompile Include="stream_encoder_intrin_ssse3.c" />
++    <ClCompile Include="window.c" />
++    <ClCompile Include="..\share\win_utf8_io\win_utf8_io.c" />
++  </ItemGroup>
++  <ItemGroup>
++    <CustomBuild Include="ia32\cpu_asm.nasm">
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/cpu_asm.nasm -o ia32/cpu_asm.obj
++</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/cpu_asm.nasm -o ia32/cpu_asm.obj
++</Command>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ia32/cpu_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ia32/cpu_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ia32/cpu_asm.obj;%(Outputs)</Outputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ia32/cpu_asm.obj;%(Outputs)</Outputs>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/cpu_asm.nasm -o ia32/cpu_asm.obj
++</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/cpu_asm.nasm -o ia32/cpu_asm.obj
++</Command>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ia32/cpu_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ia32/cpu_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ia32/cpu_asm.obj;%(Outputs)</Outputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ia32/cpu_asm.obj;%(Outputs)</Outputs>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++    </CustomBuild>
++    <CustomBuild Include="ia32\fixed_asm.nasm">
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/fixed_asm.nasm -o ia32/fixed_asm.obj
++</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/fixed_asm.nasm -o ia32/fixed_asm.obj
++</Command>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ia32/fixed_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ia32/fixed_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ia32/fixed_asm.obj;%(Outputs)</Outputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ia32/fixed_asm.obj;%(Outputs)</Outputs>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/fixed_asm.nasm -o ia32/fixed_asm.obj
++</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/fixed_asm.nasm -o ia32/fixed_asm.obj
++</Command>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ia32/fixed_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ia32/fixed_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ia32/fixed_asm.obj;%(Outputs)</Outputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ia32/fixed_asm.obj;%(Outputs)</Outputs>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++    </CustomBuild>
++    <CustomBuild Include="ia32\lpc_asm.nasm">
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/lpc_asm.nasm -o ia32/lpc_asm.obj
++</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/lpc_asm.nasm -o ia32/lpc_asm.obj
++</Command>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ia32/lpc_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ia32/lpc_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ia32/lpc_asm.obj;%(Outputs)</Outputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ia32/lpc_asm.obj;%(Outputs)</Outputs>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/lpc_asm.nasm -o ia32/lpc_asm.obj
++</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ia32/ ia32/lpc_asm.nasm -o ia32/lpc_asm.obj
++</Command>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ia32/lpc_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ia32/lpc_asm.nasm;ia32/nasm.h;%(AdditionalInputs)</AdditionalInputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ia32/lpc_asm.obj;%(Outputs)</Outputs>
++      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ia32/lpc_asm.obj;%(Outputs)</Outputs>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
++      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
++    </CustomBuild>
++  </ItemGroup>
++  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
++  <ImportGroup Label="ExtensionTargets">
++  </ImportGroup>
++</Project>
 diff --git a/src/libFLAC/libFLAC_dynamic.vcxproj.filters b/src/libFLAC/libFLAC_dynamic.vcxproj.filters
-index 875c0216..a92f2a74 100644
---- a/src/libFLAC/libFLAC_dynamic.vcxproj.filters
+new file mode 100644
+index 00000000..86cca943
+--- /dev/null
 +++ b/src/libFLAC/libFLAC_dynamic.vcxproj.filters
-@@ -193,18 +193,6 @@
-     <ClCompile Include="metadata_object.c">
-       <Filter>Source Files</Filter>
-     </ClCompile>
--    <ClCompile Include="ogg_decoder_aspect.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
--    <ClCompile Include="ogg_encoder_aspect.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
--    <ClCompile Include="ogg_helper.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
--    <ClCompile Include="ogg_mapping.c">
--      <Filter>Source Files</Filter>
--    </ClCompile>
-     <ClCompile Include="stream_decoder.c">
-       <Filter>Source Files</Filter>
-     </ClCompile>
+@@ -0,0 +1,226 @@
++﻿<?xml version="1.0" encoding="utf-8"?>
++<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
++  <ItemGroup>
++    <Filter Include="Header Files">
++      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
++      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
++    </Filter>
++    <Filter Include="Source Files">
++      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
++      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
++    </Filter>
++    <Filter Include="Public Header Files">
++      <UniqueIdentifier>{c048646d-1833-4a52-9849-022db831cc79}</UniqueIdentifier>
++    </Filter>
++  </ItemGroup>
++  <ItemGroup>
++    <ClInclude Include="include\private\all.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\protected\all.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\bitmath.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\bitreader.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\bitwriter.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\cpu.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\crc.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\fixed.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\float.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\format.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\lpc.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\md5.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\memory.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\metadata.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="ia32\nasm.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\ogg_decoder_aspect.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\ogg_encoder_aspect.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\ogg_helper.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\ogg_mapping.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\protected\stream_decoder.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\protected\stream_encoder.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\stream_encoder.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\stream_encoder_framing.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="include\private\window.h">
++      <Filter>Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\all.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\assert.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\callback.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\export.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\format.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\metadata.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\ordinals.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\stream_decoder.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\FLAC\stream_encoder.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\alloc.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\compat.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\endswap.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\macros.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\private.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\safe_str.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++    <ClInclude Include="..\..\include\share\win_utf8_io.h">
++      <Filter>Public Header Files</Filter>
++    </ClInclude>
++  </ItemGroup>
++  <ItemGroup>
++    <ClCompile Include="bitmath.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="bitreader.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="bitwriter.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="cpu.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="crc.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="fixed.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="fixed_intrin_sse2.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="fixed_intrin_ssse3.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="float.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="format.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="lpc.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="lpc_intrin_sse2.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="lpc_intrin_sse41.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="lpc_intrin_avx2.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="lpc_intrin_fma.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="md5.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="memory.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="metadata_iterators.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="metadata_object.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="stream_decoder.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="stream_encoder.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="stream_encoder_framing.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="stream_encoder_intrin_sse2.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="stream_encoder_intrin_ssse3.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="stream_encoder_intrin_avx2.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="window.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++    <ClCompile Include="..\share\win_utf8_io\win_utf8_io.c">
++      <Filter>Source Files</Filter>
++    </ClCompile>
++  </ItemGroup>
++  <ItemGroup>
++    <CustomBuild Include="ia32\cpu_asm.nasm" />
++    <CustomBuild Include="ia32\fixed_asm.nasm" />
++    <CustomBuild Include="ia32\lpc_asm.nasm" />
++  </ItemGroup>
++</Project>


### PR DESCRIPTION
- Checkout release 1.4.1 of FLAC. The previously used
  commit in CUETools was xiph/flac@1151c93 (1.3.4).
- Use the following commands, to update the flac submodule to
  commit xiph/flac@b6fbd6b (tag 1.4.1):
```sh
    pushd ThirdParty/flac/
    git fetch
    git checkout b6fbd6b3d97e2da4481bdbd25176f263fd6a5e75
    popd
```
- Update `submodule_flac_CUETools.patch` to 1.4.1
- Resolves #217
