### PR TITLE
Fix encoding single selected album twice

### DIFF
--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -977,6 +977,10 @@ namespace JDP
                                 {
                                     cueSheet.Close();
                                     SetupControls(false);
+                                    if (_batchPaths.Count == 1)
+                                    {
+                                        _batchPaths.Clear();
+                                    }
                                 }
                                 else if (_profile._config.advanced.CacheMetadata && dlg.ChosenRelease != null)
                                 {


### PR DESCRIPTION
If a single .cue file is selected in the "Multiselect Browser", `frmChoice` appears after clicking Go. When closing this form by clicking on X and hitting the Go button again, the selected .cue file will be encoded twice.

- Clear `_batchPaths` in case of `DialogResult.Cancel`, if only one .cue file has been selected in Multiselect Browser.
- Resolves #224
