### PR TITLE
Improvements to EAC and XLD log parsing

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1726,6 +1726,7 @@ namespace CUETools.Processor
                 sr = new StringReader(_eacLog);
                 bool isEACLog = false;
                 bool isXLDLog = false;
+                bool isXLDTracks = false;
                 bool isWhipperLog = false;
                 int trNo = 1;
                 while ((lineStr = sr.ReadLine()) != null)
@@ -1749,9 +1750,16 @@ namespace CUETools.Processor
                     {
                         if (lineStr.Contains(" CRC32 hash  "))
                         {
+                            // If a CRC is found before "Track 01" expect a disc CRC.
+                            if (!isXLDTracks)
+                                trNo = 0;
                             string[] parts = lineStr.Split(':');
                             if (parts.Length == 2 && uint.TryParse(parts[1], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var crc))
                                 _arVerify.CRCLOG(trNo++, crc);
+                        }
+                        else if (lineStr == "Track 01")
+                        {
+                            isXLDTracks = true;
                         }
                     }
                     else if (isWhipperLog && trNo <= TrackCount)
@@ -1764,14 +1772,14 @@ namespace CUETools.Processor
                     else
                         if (lineStr.StartsWith("Exact Audio Copy")
                             || lineStr.StartsWith("EAC extraction logfile"))
-                            isEACLog = true;
+                        isEACLog = true;
                     else
                         if (lineStr.StartsWith("X Lossless Decoder")
                             || lineStr.StartsWith("XLD extraction logfile"))
-                            isXLDLog = true;
+                        isXLDLog = true;
                     else
                         if (lineStr.StartsWith("Log created by: whipper"))
-                            isWhipperLog = true;
+                        isWhipperLog = true;
                 }
                 if (trNo == 2 && isEACLog)
                 {

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1733,7 +1733,7 @@ namespace CUETools.Processor
                 {
                     if (isEACLog && trNo <= TrackCount)
                     {
-                        string[] s = { "Copy CRC ", "CRC копии" };
+                        string[] s = { "Copy CRC ", "CRC копии", "复制 CRC ", "コピーCRC " };
                         string[] s1 = { "CRC" };
                         string[] n = lineStr.Split(s, StringSplitOptions.None);
                         uint crc;

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1772,14 +1772,14 @@ namespace CUETools.Processor
                     else
                         if (lineStr.StartsWith("Exact Audio Copy")
                             || lineStr.StartsWith("EAC extraction logfile"))
-                        isEACLog = true;
+                            isEACLog = true;
                     else
                         if (lineStr.StartsWith("X Lossless Decoder")
                             || lineStr.StartsWith("XLD extraction logfile"))
-                        isXLDLog = true;
+                            isXLDLog = true;
                     else
                         if (lineStr.StartsWith("Log created by: whipper"))
-                        isWhipperLog = true;
+                            isWhipperLog = true;
                 }
                 if (trNo == 2 && isEACLog)
                 {


### PR DESCRIPTION
### 1. XLD logs with disc CRC

Apparently some XLD logs can contain a disc CRC before track CRCs.

#### Tests

[CD1.log](https://github.com/gchudov/cuetools.net/files/9846854/CD1.log) with correct tracks used to produce [this](https://user-images.githubusercontent.com/24987433/197399477-ec567f98-41db-4a75-814c-cbed945ab9af.png) and now produces [this](https://user-images.githubusercontent.com/24987433/197399581-f69df18f-b68e-425e-89c3-1f5d809755f5.png).

### 2. EAC logs in Japanese and Chinese

Previously only English and Russian logs were supported. There are definitely many more languages to support but here I only added those for which I had logs handy.

#### Tests

* Chinese [CD1.log](https://github.com/gchudov/cuetools.net/files/9846867/CD1.log) with correct (split) tracks now produces [this](https://user-images.githubusercontent.com/24987433/197400315-a29b12a1-3265-4d12-9746-687867e1ffde.png).
* Japanese [CD1.log](https://github.com/gchudov/cuetools.net/files/9846878/CD1.log) with correct (split) tracks now produces [this](https://user-images.githubusercontent.com/24987433/197400448-c5e831d9-d267-49a8-828e-3c5599343148.png).