### PR TITLE
Add option to skip verifying when a rip log cannot be found

### DIFF
--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -150,6 +150,8 @@ namespace CUETools.Processor
                 new CUEAction[] { CUEAction.Verify, CUEAction.Encode }));
             scripts.Add("only if found", new CUEToolsScript("only if found",
                 new CUEAction[] { CUEAction.Verify }));
+            scripts.Add("only if rip log present", new CUEToolsScript("only if rip log present",
+                new CUEAction[] { CUEAction.Verify }));
             scripts.Add("fix offset", new CUEToolsScript("fix offset",
                 new CUEAction[] { CUEAction.Encode }));
             scripts.Add("encode if verified", new CUEToolsScript("encode if verified",
@@ -230,6 +232,8 @@ namespace CUETools.Processor
             scripts.Add("default", new CUEToolsScript("default",
                 new CUEAction[] { CUEAction.Verify, CUEAction.Encode }));
             scripts.Add("only if found", new CUEToolsScript("only if found",
+                new CUEAction[] { CUEAction.Verify }));
+            scripts.Add("only if rip log present", new CUEToolsScript("only if rip log present",
                 new CUEAction[] { CUEAction.Verify }));
             scripts.Add("fix offset", new CUEToolsScript("fix offset",
                 new CUEAction[] { CUEAction.Encode }));

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -4459,6 +4459,8 @@ namespace CUETools.Processor
                     return Go();
                 case "only if found":
                     return ArVerify.ExceptionStatus != WebExceptionStatus.Success ? WriteReport() : Go();
+                case "only if rip log present":
+                    return _eacLog == null ? "Rip log is not present." : Go();
                 case "repair":
                     {
                         UseCUEToolsDB("CUETools " + CUEToolsVersion, null, true, CTDBMetadataSearch.None);


### PR DESCRIPTION
*This description was updated to reflect the changes done after feedback was received.*

### Use case

When one wants to generate or update .accurip files for a whole music library that contains releases of multiple mediums.

### Showcase

![](https://user-images.githubusercontent.com/24987433/198877693-17756918-2911-426d-8652-051252a67143.png)

Added a new verify script. When it is selected CueTools will skip verifying releases if a rip log is not found.

### Tests

Output when the script is selected: ([directory contents](https://github.com/gchudov/cuetools.net/files/9895772/index.txt))

```
.\hires\1.flac: Audio format is not Red Book PCM..
.\log\1.flac: AR: rip accurate (7/7), CTDB: verified OK, confidence 32.
.\nolog\1.flac: Rip log is not present..
```