### PR TITLE
Copy basic tags TRACKNUMBER and TRACKTOTAL

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -2956,6 +2956,10 @@ namespace CUETools.Processor
 
                                 if (_config.copyBasicTags && sourceFileInfo != null)
                                 {
+                                    if (fileInfo.Tag.TrackCount == 0)
+                                        fileInfo.Tag.TrackCount = sourceFileInfo.Tag.TrackCount;
+                                    if (fileInfo.Tag.Track == 0)
+                                        fileInfo.Tag.Track = sourceFileInfo.Tag.Track;
                                     if (fileInfo.Tag.Title == null && _tracks[iTrack]._fileInfo != null)
                                         fileInfo.Tag.Title = _tracks[iTrack]._fileInfo.Tag.Title;
                                     if (fileInfo.Tag.DiscCount == 0)


### PR DESCRIPTION
So far, the tags `TRACKNUMBER` and `TRACKTOTAL` have not been copied in this case:
```
CUETools - Advanced settings - Tagging:
  Write basic tags from CUE data: disabled
  Copy basic tags: enabled
```
- Copy the basic tags 'Track' and 'Trackcount', if 'CopyBasicTags=1'
- Resolves #221