### PR TITLE
Show complete MACLib version string in settings

### DIFF
--- a/CUETools.Codecs.MACLib/DecoderSettings.cs
+++ b/CUETools.Codecs.MACLib/DecoderSettings.cs
@@ -34,6 +34,6 @@ namespace CUETools.Codecs.MACLib
 
         [DisplayName("Version")]
         [Description("Library version")]
-        public string Version => Marshal.PtrToStringAnsi(MACLibDll.GetVersionString());
+        public string Version => Marshal.PtrToStringUni(MACLibDll.GetVersionString());
     }
 }

--- a/CUETools.Codecs.MACLib/EncoderSettings.cs
+++ b/CUETools.Codecs.MACLib/EncoderSettings.cs
@@ -63,6 +63,6 @@ namespace CUETools.Codecs.MACLib
 
         [DisplayName("Version")]
         [Description("Library version")]
-        public string Version => Marshal.PtrToStringAnsi(MACLibDll.GetVersionString());
+        public string Version => Marshal.PtrToStringUni(MACLibDll.GetVersionString());
     };
 }


### PR DESCRIPTION
Only the first char of the MACLib version string has been shown in
Advanced Settings - Encoders - MACLib [ape] ("4" instead of "4.33").

- `MAC_VERSION_STRING` is returned as `wchar_t`, therefore use
  `Marshal.PtrToStringUni` instead of `Marshal.PtrToStringAnsi`
