### PR TITLE
CUETools.ALACEnc.exe: Add check for StereoMethod

### DIFF
--- a/CUETools.ALACEnc/Program.cs
+++ b/CUETools.ALACEnc/Program.cs
@@ -188,7 +188,13 @@ namespace CUETools.ALACEnc
 			try
 			{
 				if (stereo_method != null)
+				{
 					alac.StereoMethod = Alac.LookupStereoMethod(stereo_method);
+					if (!Enum.IsDefined(typeof(StereoMethod), alac.StereoMethod))
+					{
+						throw new Exception("Invalid stereo method specified.");
+					}
+				}
 				if (order_method != null)
 					alac.OrderMethod = Alac.LookupOrderMethod(order_method);
 				if (window_function != null)
@@ -217,7 +223,7 @@ namespace CUETools.ALACEnc
 			{
 				Usage();
 				Console.WriteLine("");
-				Console.WriteLine("Error: {0}.", ex.Message);
+				Console.WriteLine("Error: {0}", ex.Message);
 				return 3;
 			}
 

--- a/CUETools.Codecs.ALAC/ALACWriter.cs
+++ b/CUETools.Codecs.ALAC/ALACWriter.cs
@@ -1847,10 +1847,11 @@ namespace CUETools.Codecs.ALAC
 
 		// stereo decorrelation method
 		// set by user prior to calling encode_init
-		// if set to less than 0, it is chosen based on compression.
-		// valid values are 0 to 2
-		// 0 = independent L+R channels
-		// 1 = mid-side encoding
+		// valid values are 0 to 3
+		// 0 = Independent
+		// 1 = Estimate
+		// 2 = Evaluate
+		// 3 = Search
 		public StereoMethod stereo_method;
 
 		public WindowMethod window_method;


### PR DESCRIPTION
The following stereo methods are supported using the command line
option "`-s <method>`":
`Independent = 0, Estimate = 1, Evaluate = 2, Search = 3`
Default: `Estimate` at compression level `5`.
The methods can be specified using the name or the corresponding
number, e.g.:
`CUETools.ALACEnc.exe test.wav -s Independent`
`CUETools.ALACEnc.exe test.wav -s 0`

- Add a check of the specified stereo method number for validity.
- In case of invalid method numbers:
  Show usage and output "`Invalid stereo method specified.`"
- Fixes #241
- Update comments in ALACWriter.cs, `struct ALACEncodeParams` for:
  `public StereoMethod stereo_method;`
  Looks like the previous comments were from FLACCLWriter.cs
  (FlaCudaWriter.cs). The comments contain the same info now as the
  `enum StereoMethod` (see StereoMethod.cs).
- Further modification:
  Remove double full stop at the end of error messages.
