### PR TITLE
libFLAC: Fix arithmetic overflow under 32-bit

### DIFF
--- a/CUETools.Codecs.libFLAC/FLACDLL.cs
+++ b/CUETools.Codecs.libFLAC/FLACDLL.cs
@@ -138,7 +138,7 @@ namespace CUETools.Codecs.libFLAC
         internal static extern int FLAC__stream_encoder_set_blocksize(IntPtr encoder, int value);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate FLAC__StreamEncoderWriteStatus FLAC__StreamEncoderWriteCallback(IntPtr encoder, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] buffer, long bytes, int samples, int current_frame, void* client_data);
+        internal delegate FLAC__StreamEncoderWriteStatus FLAC__StreamEncoderWriteCallback(IntPtr encoder, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] byte[] buffer, UIntPtr bytes, int samples, int current_frame, void* client_data);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate FLAC__StreamEncoderSeekStatus FLAC__StreamEncoderSeekCallback(IntPtr encoder, long absolute_byte_offset, void* client_data);

--- a/CUETools.Codecs.libFLAC/Writer.cs
+++ b/CUETools.Codecs.libFLAC/Writer.cs
@@ -188,7 +188,7 @@ namespace CUETools.Codecs.libFLAC
             m_samplesWritten += sampleBuffer.Length;
         }
 
-        internal FLAC__StreamEncoderWriteStatus StreamEncoderWriteCallback(IntPtr encoder, byte[] buffer, long bytes, int samples, int current_frame, void* client_data)
+        internal FLAC__StreamEncoderWriteStatus StreamEncoderWriteCallback(IntPtr encoder, byte[] buffer, UIntPtr bytes, int samples, int current_frame, void* client_data)
         {
             try
             {


### PR DESCRIPTION
So far, an arithmetic overflow has occurred, when running CUETools
under 32-bit and using libFLAC for encoding.
See: https://hydrogenaud.io/index.php/topic,116743.0.html

- `FLAC__StreamEncoderWriteCallback`:
  Use `UIntPtr bytes` instead of `long bytes`, whereas C# `UIntPtr`
  matches `size_t` under 64 and 32-bit. Link to FLAC documentation:
  https://xiph.org/flac/api/stream__encoder_8h.html
- Fixes the following exception:
  `Arithmetic operation resulted in an overflow.`
