### PR TITLE
libFLAC: Fix unable to retrieve metadata (32-bit)

### DIFF
--- a/CUETools.Codecs.libFLAC/FLACDLL.cs
+++ b/CUETools.Codecs.libFLAC/FLACDLL.cs
@@ -19,7 +19,7 @@ namespace CUETools.Codecs.libFLAC
         public static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate FLAC__StreamDecoderReadStatus FLAC__StreamDecoderReadCallback(IntPtr decoder, byte* buffer, ref long bytes, void* client_data);
+        internal delegate FLAC__StreamDecoderReadStatus FLAC__StreamDecoderReadCallback(IntPtr decoder, byte* buffer, ref UIntPtr bytes, void* client_data);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate FLAC__StreamDecoderSeekStatus FLAC__StreamDecoderSeekCallback(IntPtr decoder, long absolute_byte_offset, void* client_data);

--- a/CUETools.Codecs.libFLAC/Reader.cs
+++ b/CUETools.Codecs.libFLAC/Reader.cs
@@ -245,19 +245,19 @@ namespace CUETools.Codecs.libFLAC
             }
 		}
 
-        FLAC__StreamDecoderReadStatus ReadCallback(IntPtr decoder, byte* buffer, ref long bytes, void* client_data)
+        FLAC__StreamDecoderReadStatus ReadCallback(IntPtr decoder, byte* buffer, ref UIntPtr bytes, void* client_data)
         {
-            if (bytes <= 0 || bytes > int.MaxValue)
+            if ((long)bytes <= 0 || (long)bytes > int.MaxValue)
                 return FLAC__StreamDecoderReadStatus.FLAC__STREAM_DECODER_READ_STATUS_ABORT; /* abort to avoid a deadlock */
 
-            if (m_readBuffer == null || m_readBuffer.Length < bytes)
-                m_readBuffer = new byte[Math.Max(bytes, 0x4000)];
+            if (m_readBuffer == null || m_readBuffer.Length < (long)bytes)
+                m_readBuffer = new byte[Math.Max((long)bytes, 0x4000)];
 
-            bytes = m_stream.Read(m_readBuffer, 0, (int)bytes);
+            bytes = (UIntPtr)m_stream.Read(m_readBuffer, 0, (int)bytes);
             //if(ferror(decoder->private_->file))
             //return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
             //else 
-            if (bytes == 0)
+            if ((long)bytes == 0)
                 return FLAC__StreamDecoderReadStatus.FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
 
             Marshal.Copy(m_readBuffer, 0, (IntPtr)buffer, (int)bytes);


### PR DESCRIPTION
So far, an exception has occurred, when running CUETools
under 32-bit and using libFLAC for decoding.

- `FLAC__StreamDecoderReadCallback`:
  Use `ref UIntPtr bytes` instead of `ref long bytes`, whereas C#
  `UIntPtr` matches `size_t` under 64 and 32-bit.
  Link to FLAC documentation:
  https://xiph.org/flac/api/group__flac__stream__decoder.html
- Fixes the following exception:
  `unable to retrieve metadata`
