### PR TITLE
Add setting to toggle creating CUE file

### DIFF
--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -47,6 +47,7 @@ namespace CUETools.Processor
         public bool decodeHDCD;
         public bool wait750FramesForHDCD;
         public bool createM3U;
+        public bool createCUEFile;
         public bool createCUEFileWhenEmbedded;
         public bool truncate4608ExtraSamples;
         public bool decodeHDCDtoLW16;
@@ -114,6 +115,7 @@ namespace CUETools.Processor
             wait750FramesForHDCD = true;
             decodeHDCD = false;
             createM3U = false;
+            createCUEFile = true;
             createCUEFileWhenEmbedded = true;
             truncate4608ExtraSamples = true;
             decodeHDCDtoLW16 = false;
@@ -198,6 +200,7 @@ namespace CUETools.Processor
             wait750FramesForHDCD = src.wait750FramesForHDCD;
             decodeHDCD = src.decodeHDCD;
             createM3U = src.createM3U;
+            createCUEFile = src.createCUEFile;
             createCUEFileWhenEmbedded = src.createCUEFileWhenEmbedded;
             truncate4608ExtraSamples = src.truncate4608ExtraSamples;
             decodeHDCDtoLW16 = src.decodeHDCDtoLW16;
@@ -283,6 +286,7 @@ namespace CUETools.Processor
             sw.Save("Wait750FramesForHDCD", wait750FramesForHDCD);
             sw.Save("DecodeHDCD", decodeHDCD);
             sw.Save("CreateM3U", createM3U);
+            sw.Save("CreateCUEFile", createCUEFile);
             sw.Save("CreateCUEFileWhenEmbedded", createCUEFileWhenEmbedded);
             sw.Save("Truncate4608ExtraSamples", truncate4608ExtraSamples);
             sw.Save("DecodeHDCDToLossyWAV16", decodeHDCDtoLW16);
@@ -386,6 +390,7 @@ namespace CUETools.Processor
             wait750FramesForHDCD = sr.LoadBoolean("Wait750FramesForHDCD") ?? true;
             decodeHDCD = sr.LoadBoolean("DecodeHDCD") ?? false;
             createM3U = sr.LoadBoolean("CreateM3U") ?? false;
+            createCUEFile = sr.LoadBoolean("CreateCUEFile") ?? true;
             createCUEFileWhenEmbedded = sr.LoadBoolean("CreateCUEFileWhenEmbedded") ?? true;
             truncate4608ExtraSamples = sr.LoadBoolean("Truncate4608ExtraSamples") ?? true;
             decodeHDCDtoLW16 = sr.LoadBoolean("DecodeHDCDToLossyWAV16") ?? false;

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -2311,7 +2311,7 @@ namespace CUETools.Processor
         public List<string> OutputExists()
         {
             List<string> outputExists = new List<string>();
-            bool outputCUE = Action == CUEAction.Encode && (OutputStyle != CUEStyle.SingleFileWithCUE || _config.createCUEFileWhenEmbedded);
+            bool outputCUE = Action == CUEAction.Encode && _config.createCUEFile && (OutputStyle != CUEStyle.SingleFileWithCUE || _config.createCUEFileWhenEmbedded);
             bool outputAudio = Action == CUEAction.Encode && _audioEncoderType != AudioEncoderType.NoAudio;
             if (outputCUE)
                 outputExists.Add(_outputPath);
@@ -2738,7 +2738,7 @@ namespace CUETools.Processor
                     Directory.CreateDirectory(OutputDir);
             }
 
-            if (_action == CUEAction.Encode)
+            if (_action == CUEAction.Encode && _config.createCUEFile)
             {
                 string cueContents = GetCUESheetContents(OutputStyle);
                 if (_config.createEACLOG && _isCD)


### PR DESCRIPTION
The possibility to turn off writing CUE sheets has been on the wishlist
for CUETools:
https://hydrogenaud.io/index.php/topic,118915.msg980706.html#msg980706
Option to disable writing a CUE sheet for separate tracks.
A CUE sheet is not needed for lossy formats.

- Add the following setting:
  `CreateCUEFile`
  Default:
  `CreateCUEFile=1`
- For now, the setting can be modified by editing `settings.txt`:
  Use bool value 0, to turn off writing CUE sheets.
- A possibility to modify the setting from the GUI will be added later
  on under: `CUETools - Advanced Settings - CUETools - General`
- Resolves:
  https://hydrogenaud.io/index.php/topic,123620.0.html
