### PR TITLE
Fix path of collect_files.bat in release-windows

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -52,7 +52,7 @@ jobs:
           "%DEVENV_PATH%" "%SLN_PATH%" /Build "Release|Win32"
       - name: Collect files
         run: |
-          CUETools\collect_files.bat
+          collect_files.bat
       - uses: actions/upload-artifact@v3
         with:
           name: deploy

--- a/collect_files.bat
+++ b/collect_files.bat
@@ -59,7 +59,7 @@ xcopy /Y /D %base_dir%\bin\Release\net47\Freedb.dll %release_dir%
 xcopy /Y /D %base_dir%\bin\Release\net47\ProgressODoom.dll %release_dir%
 xcopy /Y /D %base_dir%\bin\Release\net47\TagLibSharp.dll %release_dir%
 
-xcopy /Y /D %base_dir%\CUETools\License.txt %release_dir%
+xcopy /Y /D %base_dir%\License.txt %release_dir%
 xcopy /Y /D %base_dir%\CUETools\user_profiles_enabled %release_dir%
 
 xcopy /Y /D %base_dir%\bin\Release\net47\de-DE\* %release_dir%\de-DE\


### PR DESCRIPTION
Part of #253, `collect_files.bat` and `License.txt` have been moved to
the root of the repo.

- Update path to `collect_files.bat` in GitHub Action
  `.github/workflows/release-windows.yml`
- Furthermore, update path of moved `License.txt` file in
  `collect_files.bat`
