### PR TITLE
Add setting to always write UTF-8 CUE sheet

### DIFF
--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -38,6 +38,7 @@ namespace CUETools.Processor
         public bool replaceSpaces;
         public bool embedLog;
         public bool extractLog;
+        public bool alwaysWriteUTF8CUEFile;
         public bool fillUpCUE;
         public bool overwriteCUEData;
         public bool filenamesANSISafe;
@@ -106,6 +107,7 @@ namespace CUETools.Processor
             replaceSpaces = false;
             embedLog = true;
             extractLog = true;
+            alwaysWriteUTF8CUEFile = false;
             fillUpCUE = true;
             overwriteCUEData = false;
             filenamesANSISafe = true;
@@ -191,6 +193,7 @@ namespace CUETools.Processor
             replaceSpaces = src.replaceSpaces;
             embedLog = src.embedLog;
             extractLog = src.extractLog;
+            alwaysWriteUTF8CUEFile = src.alwaysWriteUTF8CUEFile;
             fillUpCUE = src.fillUpCUE;
             overwriteCUEData = src.overwriteCUEData;
             filenamesANSISafe = src.filenamesANSISafe;
@@ -277,6 +280,7 @@ namespace CUETools.Processor
             sw.Save("ReplaceSpaces", replaceSpaces);
             sw.Save("EmbedLog", embedLog);
             sw.Save("ExtractLog", extractLog);
+            sw.Save("AlwaysWriteUTF8CUEFile", alwaysWriteUTF8CUEFile);
             sw.Save("FillUpCUE", fillUpCUE);
             sw.Save("OverwriteCUEData", overwriteCUEData);
             sw.Save("FilenamesANSISafe", filenamesANSISafe);
@@ -381,6 +385,7 @@ namespace CUETools.Processor
             replaceSpaces = sr.LoadBoolean("ReplaceSpaces") ?? false;
             embedLog = sr.LoadBoolean("EmbedLog") ?? true;
             extractLog = sr.LoadBoolean("ExtractLog") ?? true;
+            alwaysWriteUTF8CUEFile = sr.LoadBoolean("AlwaysWriteUTF8CUEFile") ?? false;
             fillUpCUE = sr.LoadBoolean("FillUpCUE") ?? true;
             overwriteCUEData = sr.LoadBoolean("OverwriteCUEData") ?? false;
             filenamesANSISafe = sr.LoadBoolean("FilenamesANSISafe") ?? true;

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -2384,9 +2384,9 @@ namespace CUETools.Processor
             }
         }
 
-        public static void WriteText(string path, string text)
+        public static void WriteText(CUEConfig _config, string path, string text)
         {
-            bool utf8Required = CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(text)) != text;
+            bool utf8Required = (_config.alwaysWriteUTF8CUEFile && Path.GetExtension(path) == ".cue") || (CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(text)) != text);
             var encoding = utf8Required ? Encoding.UTF8 : CUESheet.Encoding;
             // Preserve original UTF-16LE encoding of EAC log files, which contain a log checksum
             if ((text.StartsWith("Exact Audio Copy") || text.StartsWith("EAC extraction logfile")) && text.Contains("==== Log checksum"))
@@ -2750,9 +2750,9 @@ namespace CUETools.Processor
                 if (_config.createEACLOG && _isCD)
                     cueContents = CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(cueContents));
                 if (OutputStyle == CUEStyle.SingleFileWithCUE && _config.createCUEFileWhenEmbedded)
-                    WriteText(Path.ChangeExtension(_outputPath, ".cue"), cueContents);
+                    WriteText(_config, Path.ChangeExtension(_outputPath, ".cue"), cueContents);
                 else if (OutputStyle == CUEStyle.SingleFile || ((int)OutputStyle > 1 && _config.createCUEFileInTracksMode))
-                    WriteText(_outputPath, cueContents);
+                    WriteText(_config, _outputPath, cueContents);
             }
 
             if (_action == CUEAction.Verify)
@@ -2811,10 +2811,10 @@ namespace CUETools.Processor
                     _ripperLog = CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(_ripperLog));
 
                 if (_ripperLog != null)
-                    WriteText(Path.ChangeExtension(_outputPath, ".log"), _ripperLog);
+                    WriteText(_config, Path.ChangeExtension(_outputPath, ".log"), _ripperLog);
                 else
                     if (_eacLog != null && _config.extractLog)
-                        WriteText(Path.ChangeExtension(_outputPath, ".log"), _eacLog);
+                        WriteText(_config, Path.ChangeExtension(_outputPath, ".log"), _eacLog);
 
                 if (_audioEncoderType != AudioEncoderType.NoAudio && _config.extractAlbumArt)
                     ExtractAlbumArt();
@@ -2909,7 +2909,7 @@ namespace CUETools.Processor
                 else
                 {
                     if (_config.createM3U)
-                        WriteText(Path.ChangeExtension(_outputPath, ".m3u"), GetM3UContents(OutputStyle));
+                        WriteText(_config, Path.ChangeExtension(_outputPath, ".m3u"), GetM3UContents(OutputStyle));
                     if (_audioEncoderType != AudioEncoderType.NoAudio)
                         for (int iTrack = 0; iTrack < TrackCount; iTrack++)
                         {
@@ -3276,7 +3276,7 @@ namespace CUETools.Processor
                 {
                     if (!Directory.Exists(OutputDir))
                         Directory.CreateDirectory(OutputDir);
-                    WriteText(Path.ChangeExtension(_outputPath, ".toc"), CUESheetLogWriter.GetTOCContents(this));
+                    WriteText(_config, Path.ChangeExtension(_outputPath, ".toc"), CUESheetLogWriter.GetTOCContents(this));
                 }
             }
             return GenerateVerifyStatus();

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -783,7 +783,7 @@ namespace JDP
                         }
                         if (File.Exists(fullCueName))
                             throw new Exception("file already exists");
-                        bool utf8Required = CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(cueSheetContents)) != cueSheetContents;
+                        bool utf8Required = _profile._config.alwaysWriteUTF8CUEFile || (CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(cueSheetContents)) != cueSheetContents);
                         StreamWriter sw1 = new StreamWriter(fullCueName, false, utf8Required ? Encoding.UTF8 : CUESheet.Encoding);
                         sw1.Write(cueSheetContents);
                         sw1.Close();
@@ -846,7 +846,7 @@ namespace JDP
                         {
                             if (toolStripButtonCorrectorOverwrite.Checked)
                             {
-                                CUESheet.WriteText(pathIn, fixedCue);
+                                CUESheet.WriteText(_profile._config, pathIn, fixedCue);
                                 BatchLog("corrected ({0}).", pathIn, extension);
                             }
                             else
@@ -856,7 +856,7 @@ namespace JDP
                                     BatchLog("corrected cue already exists.", pathIn);
                                 else
                                 {
-                                    CUESheet.WriteText(fixedPath, fixedCue);
+                                    CUESheet.WriteText(_profile._config, fixedPath, fixedCue);
                                     BatchLog("corrected ({0}).", pathIn, extension);
                                 }
                             }


### PR DESCRIPTION
So far, cue sheets were only written in UTF-8, if they contained
characters, which could not be encoded in the local Windows codepage.
These UTF-8 encoded cue files contain a BOM (UTF-8-BOM).
The new setting allows to always write cue sheets using `Encoding.UTF8`.

- Add setting:
  `AlwaysWriteUTF8CUEFile`
  Default:
  `AlwaysWriteUTF8CUEFile=0`
  The setting is disabled by default, to preserve previous behavior.
- For now, the setting can be modified by editing `settings.txt`:
  Use bool value 1, to always write CUE sheets using UTF-8 encoding.
- The setting is available in the CUETools as well as the CUERipper
  `settings.txt` file.
- Resolves:
  Option to always write utf-8 CUE sheet
  https://hydrogenaud.io/index.php/topic,118915.0.html#post_g07
  https://hydrogenaud.io/index.php/topic,117151.0.html