### PR TITLE
Allow tta decoding using ffmpeg.dll

### DIFF
--- a/CUETools.Codecs.ffmpeg/AudioDecoder.cs
+++ b/CUETools.Codecs.ffmpeg/AudioDecoder.cs
@@ -408,6 +408,18 @@ namespace CUETools.Codecs.ffmpegdll
                             }
                         }
                         break;
+                    case AVSampleFormat.AV_SAMPLE_FMT_S16:
+                        {
+                            short* ptr = (short*)(decoded_frame->data[0u]) + c->channels * m_decoded_frame_offset;
+                            fixed (int* dst_start = &buff.Samples[buffOffset, 0])
+                            {
+                                int* dst = dst_start;
+                                int* dst_end = dst_start + copyCount * c->channels;
+                                while (dst < dst_end)
+                                    *(dst++) = *(ptr++);
+                            }
+                        }
+                        break;
                     case AVSampleFormat.AV_SAMPLE_FMT_S16P:
                         for (Int32 iChan = 0; iChan < _channelCount; iChan++)
                         {


### PR DESCRIPTION
Typically, tta files can be decoded by CUETools using ttalib. An alternative possibility of decoding tta is ffmpeg.dll. The ffmpeg AVSampleFormat of tta files is AV_SAMPLE_FMT_S16 [1].

- Add `AVSampleFormat.AV_SAMPLE_FMT_S16` to CUETools.Codecs.ffmpeg\AudioDecoder.cs
- Fixes the following exception: Specified method is not supported
- Resolves: #254

[1] https://ffmpeg.org/doxygen/3.1/group__lavu__sampfmts.html