### PR TITLE
Update FFmpeg.AutoGen from 4.3.0.3 to 6.0.0

### DIFF
--- a/CUETools.Codecs.ffmpeg/AudioDecoder.cs
+++ b/CUETools.Codecs.ffmpeg/AudioDecoder.cs
@@ -93,7 +93,7 @@ namespace CUETools.Codecs.ffmpegdll
                 throw new Exception("Could not allocate audio frame");
 
             //ffmpeg.avcodec_register_all();
-            ffmpeg.av_register_all();
+            //ffmpeg.av_register_all();
 
 #if DEBUG
             ffmpeg.av_log_set_level(ffmpeg.AV_LOG_DEBUG);

--- a/collect_files.bat
+++ b/collect_files.bat
@@ -99,7 +99,7 @@ xcopy /Y /D %base_dir%\bin\Release\net47\plugins\de-DE\* %release_dir%\plugins\d
 xcopy /Y /D %base_dir%\bin\Release\net47\plugins\ru-RU\* %release_dir%\plugins\ru-RU\
 
 REM ThirdParty
-xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Release\net472\FFmpeg.AutoGen.dll %release_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Release\netstandard2.0\FFmpeg.AutoGen.dll %release_dir%\plugins\
 xcopy /Y /D %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %release_dir%\plugins\
 
 REM ThirdParty\Win32 plugins

--- a/collect_files_debug.bat
+++ b/collect_files_debug.bat
@@ -15,8 +15,8 @@ REM /D xcopy copies all Source files that are newer than existing Destination fi
 REM xcopy /Y /D %base_dir%\CUETools\user_profiles_enabled %debug_dir%
 
 REM ThirdParty
-xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net472\FFmpeg.AutoGen.dll %debug_dir%\plugins\
-xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\net472\FFmpeg.AutoGen.pdb %debug_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\netstandard2.0\FFmpeg.AutoGen.dll %debug_dir%\plugins\
+xcopy /Y /D %base_dir%\ThirdParty\FFmpeg.AutoGen\FFmpeg.AutoGen\bin\Debug\netstandard2.0\FFmpeg.AutoGen.pdb %debug_dir%\plugins\
 xcopy /Y /D %base_dir%\ThirdParty\ICSharpCode.SharpZipLib.dll %debug_dir%\plugins\
 
 REM ThirdParty\Win32 plugins


### PR DESCRIPTION
- Checkout release 6.0.0 of `FFmpeg.AutoGen`. The previously used
  commit in CUETools was Ruslan-B/FFmpeg.AutoGen@e0d26f8 (tag [4.3.0.3](https://github.com/Ruslan-B/FFmpeg.AutoGen/releases/tag/4.3.0.3)).
- Use the following commands, to update the `FFmpeg.AutoGen` submodule to
  commit Ruslan-B/FFmpeg.AutoGen@15d15bd (tag [v6.0.0](https://github.com/Ruslan-B/FFmpeg.AutoGen/releases/tag/v6.0.0)):
```sh
    pushd ThirdParty/FFmpeg.AutoGen/
    git fetch
    git checkout 15d15bdb5230fb1457883ad2b918cb94e6e1be59
    popd
```
- Update **`CUETools.Codecs.ffmpeg\AudioDecoder.cs`** due to API changes [1]:
  - Comment out `ffmpeg.av_register_all()`.
      `av_register_all()` has been deprecated in ffmpeg 4.0. It is not
      needed and not available anymore.
- **`collect_files.bat, collect_files_debug.bat`**:
  Copy FFmpeg.AutoGen dll files from subdirectory `netstandard2.0`
  instead of previously `net472`.
  In FFmpeg.AutoGen 6.0.0 the `TargetFrameworks` in FFmpeg.AutoGen.csproj
  have been reduced to netstandard2.1 and netstandard2.0.
  However, `netstandard2.0` supports .NET Framework 4.6.1, 4.6.2, 4.7,
  4.7.1, 4.7.2, 4.8, 4.8.1 [2]


[1] https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges
[2] https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0

