### PR TITLE
ChaptersToCue: Add TaglibSharp ProjectReference

### DIFF
--- a/CUETools.ChaptersToCue/CUETools.ChaptersToCue.csproj
+++ b/CUETools.ChaptersToCue/CUETools.ChaptersToCue.csproj
@@ -55,10 +55,6 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="TaglibSharp, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\bin\$(Configuration)\net47\TagLibSharp.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -80,6 +76,10 @@
     <ProjectReference Include="..\CUETools.Codecs\CUETools.Codecs.csproj">
       <Project>{6458A13A-30EF-45A9-9D58-E5031B17BEE2}</Project>
       <Name>CUETools.Codecs</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ThirdParty\taglib-sharp\src\TaglibSharp\TaglibSharp.csproj">
+      <Project>{1219a514-d3fa-40db-bbb2-92ce05e35839}</Project>
+      <Name>TaglibSharp</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
So far, **`CUETools.ChaptersToCue.csproj`** contained a `Reference Include`
to `TaglibSharp` with a `HintPath` to `TagLibSharp.dll`. This has worked
in VS2017 or VS2019. However, in **`VS2022`** a build error occurs during
the first attempt of building the Solution.

- CUETools.ChaptersToCue.csproj:
  Add `ProjectReference` to `TaglibSharp`
- Fixes the following errors, when building using VS2022:
```
  Error CS0246 The type or namespace name 'TagLib' could not be found
    (are you missing a using directive or an assembly reference?)
    CUETools.ChaptersToCue\Program.cs
  Error CS0103 The name 'TagLib' does not exist in the current context
    CUETools.ChaptersToCue\Program.cs
```
