### PR TITLE
Add GUI setting to always write UTF-8 CUE sheet

### DIFF
--- a/CUETools/frmSettings.Designer.cs
+++ b/CUETools/frmSettings.Designer.cs
@@ -39,6 +39,7 @@ namespace JDP
             this.chkTruncateExtra4206Samples = new System.Windows.Forms.CheckBox();
             this.chkCreateCUEFileInTracksMode = new System.Windows.Forms.CheckBox();
             this.chkCreateCUEFileWhenEmbedded = new System.Windows.Forms.CheckBox();
+            this.chkAlwaysWriteUTF8CUEFile = new System.Windows.Forms.CheckBox();
             this.chkCreateM3U = new System.Windows.Forms.CheckBox();
             this.chkAutoCorrectFilenames = new System.Windows.Forms.CheckBox();
             this.labelLanguage = new System.Windows.Forms.Label();
@@ -229,6 +230,7 @@ namespace JDP
             this.grpGeneral.Controls.Add(this.chkTruncateExtra4206Samples);
             this.grpGeneral.Controls.Add(this.chkCreateCUEFileInTracksMode);
             this.grpGeneral.Controls.Add(this.chkCreateCUEFileWhenEmbedded);
+            this.grpGeneral.Controls.Add(this.chkAlwaysWriteUTF8CUEFile);
             this.grpGeneral.Controls.Add(this.chkCreateM3U);
             this.grpGeneral.Controls.Add(this.chkAutoCorrectFilenames);
             resources.ApplyResources(this.grpGeneral, "grpGeneral");
@@ -283,6 +285,13 @@ namespace JDP
             this.chkCreateCUEFileWhenEmbedded.Name = "chkCreateCUEFileWhenEmbedded";
             this.toolTip1.SetToolTip(this.chkCreateCUEFileWhenEmbedded, resources.GetString("chkCreateCUEFileWhenEmbedded.ToolTip"));
             this.chkCreateCUEFileWhenEmbedded.UseVisualStyleBackColor = true;
+            // 
+            // chkAlwaysWriteUTF8CUEFile
+            // 
+            resources.ApplyResources(this.chkAlwaysWriteUTF8CUEFile, "chkAlwaysWriteUTF8CUEFile");
+            this.chkAlwaysWriteUTF8CUEFile.Name = "chkAlwaysWriteUTF8CUEFile";
+            this.toolTip1.SetToolTip(this.chkAlwaysWriteUTF8CUEFile, resources.GetString("chkAlwaysWriteUTF8CUEFile.ToolTip"));
+            this.chkAlwaysWriteUTF8CUEFile.UseVisualStyleBackColor = true;
             // 
             // chkCreateM3U
             // 
@@ -1466,6 +1475,7 @@ namespace JDP
         private System.Windows.Forms.CheckBox chkCreateM3U;
         private System.Windows.Forms.CheckBox chkCreateCUEFileInTracksMode;
         private System.Windows.Forms.CheckBox chkCreateCUEFileWhenEmbedded;
+        private System.Windows.Forms.CheckBox chkAlwaysWriteUTF8CUEFile;
         private System.Windows.Forms.CheckBox chkTruncateExtra4206Samples;
         private System.Windows.Forms.CheckBox chkReducePriority;
         private System.Windows.Forms.CheckBox chkHDCDLW16;

--- a/CUETools/frmSettings.cs
+++ b/CUETools/frmSettings.cs
@@ -73,6 +73,7 @@ namespace JDP
 			chkCreateM3U.Checked = _config.createM3U;
 			chkCreateCUEFileInTracksMode.Checked = _config.createCUEFileInTracksMode;
 			chkCreateCUEFileWhenEmbedded.Checked = _config.createCUEFileWhenEmbedded;
+			chkAlwaysWriteUTF8CUEFile.Checked = _config.alwaysWriteUTF8CUEFile;
 			chkTruncateExtra4206Samples.Checked = _config.truncate4608ExtraSamples;
 			chkHDCDLW16.Checked = _config.decodeHDCDtoLW16;
 			chkHDCD24bit.Checked = _config.decodeHDCDto24bit;
@@ -219,6 +220,7 @@ namespace JDP
 			_config.createM3U = chkCreateM3U.Checked;
 			_config.createCUEFileInTracksMode = chkCreateCUEFileInTracksMode.Checked;
 			_config.createCUEFileWhenEmbedded = chkCreateCUEFileWhenEmbedded.Checked;
+			_config.alwaysWriteUTF8CUEFile = chkAlwaysWriteUTF8CUEFile.Checked;
 			_config.truncate4608ExtraSamples = chkTruncateExtra4206Samples.Checked;
 			_config.decodeHDCDtoLW16 = chkHDCDLW16.Checked;
 			_config.decodeHDCDto24bit = chkHDCD24bit.Checked;

--- a/CUETools/frmSettings.de-DE.resx
+++ b/CUETools/frmSettings.de-DE.resx
@@ -486,4 +486,10 @@ Sie können foobar2000 dazu bringen, die Werte anzuzeigen, und sehen, ob Ihre Mu
   <data name="chkCreateCUEFileInTracksMode.ToolTip" xml:space="preserve">
     <value>Einstellung, mit der das Erstellen einer CUE-Datei im Einzeldatei-Modus deaktiviert werden kann.</value>
   </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.Text" xml:space="preserve">
+    <value>Immer UTF-8 CUE-Sheet schreiben</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.ToolTip" xml:space="preserve">
+    <value>Standardmäßig UTF-8-Kodierung zum Schreiben von CUE-Sheets verwenden</value>
+  </data>
 </root>

--- a/CUETools/frmSettings.resx
+++ b/CUETools/frmSettings.resx
@@ -126,7 +126,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>268, 320</value>
+    <value>268, 337</value>
   </data>
   <data name="btnCancel.Size" type="System.Drawing.Size, System.Drawing">
     <value>73, 23</value>
@@ -154,13 +154,13 @@
     <value>True</value>
   </data>
   <data name="checkBoxSeparateDecodingThread.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 157</value>
+    <value>12, 174</value>
   </data>
   <data name="checkBoxSeparateDecodingThread.Size" type="System.Drawing.Size, System.Drawing">
     <value>168, 17</value>
   </data>
   <data name="checkBoxSeparateDecodingThread.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="checkBoxSeparateDecodingThread.Text" xml:space="preserve">
     <value>Separate thread for decoding</value>
@@ -381,6 +381,39 @@
   <data name="&gt;&gt;chkCreateCUEFileWhenEmbedded.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+<data name="chkAlwaysWriteUTF8CUEFile.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 140</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>172, 17</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.Text" xml:space="preserve">
+    <value>Always write UTF-8 CUE sheet</value>
+  </data>
+  <data name="chkAlwaysWriteUTF8CUEFile.ToolTip" xml:space="preserve">
+    <value>Always use UTF-8 encoding for writing CUE sheets</value>
+  </data>
+  <data name="&gt;&gt;chkAlwaysWriteUTF8CUEFile.Name" xml:space="preserve">
+    <value>chkAlwaysWriteUTF8CUEFile</value>
+  </data>
+  <data name="&gt;&gt;chkAlwaysWriteUTF8CUEFile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkAlwaysWriteUTF8CUEFile.Parent" xml:space="preserve">
+    <value>grpGeneral</value>
+  </data>
+  <data name="&gt;&gt;chkAlwaysWriteUTF8CUEFile.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>  
   <data name="chkCreateM3U.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -421,13 +454,13 @@
     <value>NoControl</value>
   </data>
   <data name="chkAutoCorrectFilenames.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 140</value>
+    <value>12, 157</value>
   </data>
   <data name="chkAutoCorrectFilenames.Size" type="System.Drawing.Size, System.Drawing">
     <value>155, 17</value>
   </data>
   <data name="chkAutoCorrectFilenames.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="chkAutoCorrectFilenames.Text" xml:space="preserve">
     <value>Locate audio files if missing</value>
@@ -451,7 +484,7 @@
     <value>6, 6</value>
   </data>
   <data name="grpGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 182</value>
+    <value>252, 199</value>
   </data>
   <data name="grpGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -529,7 +562,7 @@
     <value>NoControl</value>
   </data>
   <data name="btnOK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 320</value>
+    <value>189, 337</value>
   </data>
   <data name="btnOK.Size" type="System.Drawing.Size, System.Drawing">
     <value>73, 23</value>
@@ -1620,7 +1653,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>264, 6</value>
   </data>
   <data name="grpAudioFilenames.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 195</value>
+    <value>252, 199</value>
   </data>
   <data name="grpAudioFilenames.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1644,7 +1677,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>Top, Left, Right</value>
   </data>
   <data name="groupBoxGaps.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 193</value>
+    <value>6, 210</value>
   </data>
   <data name="groupBoxGaps.Size" type="System.Drawing.Size, System.Drawing">
     <value>250, 98</value>
@@ -1674,7 +1707,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPage1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2151,7 +2184,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>4, 22</value>
   </data>
   <data name="tabPage6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage6.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -2607,7 +2640,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2976,7 +3009,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPage3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3159,7 +3192,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>0, 0</value>
   </data>
   <data name="propertyGridEncoderSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>394, 236</value>
+    <value>394, 251</value>
   </data>
   <data name="propertyGridEncoderSettings.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -3180,10 +3213,10 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>Fill</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>132, 46</value>
+    <value>132, 48</value>
   </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>394, 236</value>
+    <value>394, 251</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3355,7 +3388,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>132, 3</value>
   </data>
   <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>394, 37</value>
+    <value>394, 39</value>
   </data>
   <data name="panel3.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -3379,7 +3412,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3</value>
   </data>
   <data name="listBoxEncoders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 279</value>
+    <value>123, 296</value>
   </data>
   <data name="listBoxEncoders.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3406,7 +3439,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>2</value>
   </data>
   <data name="tableLayoutPanel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>529, 285</value>
+    <value>529, 302</value>
   </data>
   <data name="tableLayoutPanel4.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3433,7 +3466,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPageEncoders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPageEncoders.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3598,10 +3631,10 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>Fill</value>
   </data>
   <data name="groupBoxExternalDecoder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>132, 44</value>
+    <value>132, 47</value>
   </data>
   <data name="groupBoxExternalDecoder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>394, 238</value>
+    <value>394, 252</value>
   </data>
   <data name="groupBoxExternalDecoder.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3779,7 +3812,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>132, 3</value>
   </data>
   <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>394, 35</value>
+    <value>394, 38</value>
   </data>
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3803,7 +3836,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3</value>
   </data>
   <data name="listBoxDecoders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 279</value>
+    <value>123, 296</value>
   </data>
   <data name="listBoxDecoders.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3830,7 +3863,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>2</value>
   </data>
   <data name="tableLayoutPanel5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>529, 285</value>
+    <value>529, 302</value>
   </data>
   <data name="tableLayoutPanel5.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3857,7 +3890,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPage11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage11.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -3941,7 +3974,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPage4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage4.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3989,7 +4022,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>3, 3, 3, 3</value>
   </data>
   <data name="tabPage7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>535, 291</value>
+    <value>535, 308</value>
   </data>
   <data name="tabPage7.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -4016,7 +4049,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>543, 317</value>
+    <value>543, 334</value>
   </data>
   <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -4118,7 +4151,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>542, 355</value>
+    <value>542, 372</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Tahoma, 8.25pt</value>


### PR DESCRIPTION
The setting `AlwaysWriteUTF8CUEFile` has been introduced in
commit 9e1d3f2.

- Add GUI setting "Always write UTF-8 CUE sheet" under
  `CUETools - Advanced Settings - CUETools - General`
- The height of the CUETools Settings form has been increased by 17 to
  accommodate the new setting.
- Add German translation of the setting
