### PR TITLE
CUERipper: Allow editing Metadata using F2

### DIFF
--- a/CUERipper/frmCUERipper.Designer.cs
+++ b/CUERipper/frmCUERipper.Designer.cs
@@ -647,6 +647,8 @@ namespace CUERipper
             this.listMetadata.AfterLabelEdit += new System.Windows.Forms.LabelEditEventHandler(this.listMetadata_AfterLabelEdit);
             this.listMetadata.BeforeLabelEdit += new System.Windows.Forms.LabelEditEventHandler(this.listMetadata_BeforeLabelEdit);
             this.listMetadata.Click += new System.EventHandler(this.listMetadata_Click);
+            this.listMetadata.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listMetadata_KeyDown);
+            this.listMetadata.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.listMetadata_PreviewKeyDown);
             // 
             // columnHeaderValue
             // 

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -1856,6 +1856,28 @@ namespace CUERipper
                 selectedDriveInfo.drive.DriveC2ErrorMode = (int)bnComboBoxC2ErrorModeSetting.SelectedItem;
             }
         }
+
+        private void listMetadata_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.F2)
+            {
+                listMetadata.FocusedItem.BeginEdit();
+            }
+        }
+
+        private void listMetadata_PreviewKeyDown(object sender, PreviewKeyDownEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                if (listMetadata.FocusedItem != null && listMetadata.FocusedItem.Index + 1 < listMetadata.Items.Count)// && e.Label != null)
+                {
+                    listMetadata.FocusedItem.Selected = false;
+                    listMetadata.FocusedItem = listMetadata.Items[listMetadata.FocusedItem.Index + 1];
+                    listMetadata.FocusedItem.Selected = true;
+                    listMetadata.FocusedItem.BeginEdit();
+                }
+            }
+        }
     }
 
     internal class BackgroundWorkerArtworkArgs


### PR DESCRIPTION
Editing Track Titles has been possible using F2. Add the same behavior
to the Metadata list. This is an additional possibility using the
keyboard instead of clicking.

- Add `listMetadata_KeyDown` event for key `F2`
- Add `listMetadata_PreviewKeyDown` event for `Enter`
  Hitting Enter after editing will move to the next Metadata item now,
  as in `listTracks`.
- Keys for navigation in CUERipper under Tracks or Meta:
  Moving: Cursor up, Cursor down
  Editing: F2, Enter, Ctrl+Tab, Ctrl+Shift+Tab, Esc
