### PR TITLE
Set Offset to 0 for repair script

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -4483,6 +4483,7 @@ namespace CUETools.Processor
                 case "repair":
                     {
                         UseCUEToolsDB("CUETools " + CUEToolsVersion, null, true, CTDBMetadataSearch.None);
+                        WriteOffset = 0;
                         Action = CUEAction.Verify;
                         if (CTDB.DBStatus != null)
                             return CTDB.DBStatus;

--- a/CUETools/frmCUETools.Designer.cs
+++ b/CUETools/frmCUETools.Designer.cs
@@ -754,6 +754,7 @@ namespace JDP {
             this.comboBoxScript.FormattingEnabled = true;
             this.comboBoxScript.Name = "comboBoxScript";
             this.toolTip1.SetToolTip(this.comboBoxScript, resources.GetString("comboBoxScript.ToolTip"));
+            this.comboBoxScript.SelectedIndexChanged += new System.EventHandler(this.comboBoxScript_SelectedIndexChanged);
             // 
             // rbActionCorrectFilenames
             // 

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -1263,7 +1263,7 @@ namespace JDP
             toolStripMenu.Enabled = !running;
             fileSystemTreeView1.Enabled = !running;
             txtInputPath.Enabled = !running;
-            grpExtra.Enabled = !running && (converting || verifying);
+            grpExtra.Enabled = !running && (converting || verifying) && !(SelectedScript == "fix offset" || SelectedScript == "repair");
             //groupBoxCorrector.Enabled = !running && SelectedAction == CUEAction.CorrectFilenames;
             //grpOutputStyle.Enabled = !running && converting;
             groupBoxMode.Enabled = !running;
@@ -1350,7 +1350,7 @@ namespace JDP
 
         private bool CheckWriteOffset()
         {
-            if (!rbActionEncode.Checked || SelectedOutputAudioType == AudioEncoderType.NoAudio || 0 == Int32.Parse(textBoxOffset.Text))
+            if (!rbActionEncode.Checked || SelectedOutputAudioType == AudioEncoderType.NoAudio || 0 == Int32.Parse(textBoxOffset.Text) || SelectedScript == "fix offset" || SelectedScript == "repair")
             {
                 return true;
             }
@@ -2719,6 +2719,17 @@ namespace JDP
         {
             // Trigger textBoxOffset_Validating event, when clicking here
             toolStripOutput.Focus();
+        }
+
+        private void comboBoxScript_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (SelectedScript == "fix offset" || SelectedScript == "repair")
+            {
+                txtPreGapLength.Text = "00:00:00";
+                txtDataTrackLength.Text = "00:00:00";
+                textBoxOffset.Text = "0";
+            }
+            SetupControls(false);
         }
 
         private void backgroundWorkerAddToLocalDB_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)


### PR DESCRIPTION
Adding a value in Extra: Offset breaks repair. So far, the `Offset` has
been set to `0` in case of the "fix offset" script. Do the same for the
"repair" script.

- Set the `Offset` to `0`, when the Encode - repair script is run.
- Do not show the warning "Write offset setting is non-zero ..."
  anymore in case of scripts "fix offset" or "repair".
- Disable (gray-out) the 'Extra' section when the "fix offset" or
  "repair" script is selected and set the values of `Pregap`, `Data track`
  and `Offset` to zero.
- Resolves #265
