### PR TITLE
Avoid applying offset twice

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -3476,7 +3476,7 @@ namespace CUETools.Processor
 
         internal void ApplyWriteOffset()
         {
-            if (_writeOffset == 0)
+            if (_writeOffset == 0 || _appliedWriteOffset)
                 return;
 
             int absOffset = Math.Abs(_writeOffset);


### PR DESCRIPTION
The offset has been applied twice in case of the scripts "repair"
or "encode if verified".

- Any offset is already applied during the verification step.
  Check if an offset has been applied.
- Resolves #265 and
  https://hydrogenaud.io/index.php/topic,122081.0.html
