### PR TITLE
Fix C2 mode for WH10LS30

### DIFF
--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -820,13 +820,13 @@ namespace CUETools.Ripper.SCSI
 
 				// Mode294 does not work for these drives. Try Mode296 first, which has been reported to work:
 				// ASUS DRW-24D5MT, ASUS DRW-24F1ST d,
-				// HL-DT-ST BD-RE BU40N, HL-DT-ST DVDRAM GH22LS51,
+				// HL-DT-ST BD-RE BU40N, HL-DT-ST BD-RE WH10LS30, HL-DT-ST DVDRAM GH22LS51,
 				// LG GH24NSD1,
 				// PIONEER BDR-XD05, PIONEER BDR-XD07U, PIONEER DVR-S21,
 				// PLDS DU-8A5LH,
 				// Slimtype - DVD A DU8AESH.
 				if (pathNoSpace.Contains("DRW-24D5MT") || pathNoSpace.Contains("DRW-24F1STd") ||
-					pathNoSpace.Contains("BU40N") || pathNoSpace.Contains("GH22LS51") ||
+					pathNoSpace.Contains("BU40N") || pathNoSpace.Contains("WH10LS30") || pathNoSpace.Contains("GH22LS51") ||
 					pathNoSpace.Contains("GH24NSD1") ||
 					pathNoSpace.Contains("BDR-XD05") || pathNoSpace.Contains("BDR-XD07U") || pathNoSpace.Contains("DVR-S21") ||
 					pathNoSpace.Contains("DU-8A5LH") ||


### PR DESCRIPTION
- `C2ErrorMode.Mode294` does not work for this drive:
  **`HL-DT-ST BD-RE WH10LS30`**. Try `Mode296` first.
- Resolves #290
