### PR TITLE
Fix C2 mode for UJ-868

### DIFF
--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -822,12 +822,14 @@ namespace CUETools.Ripper.SCSI
 				// ASUS DRW-24D5MT, ASUS DRW-24F1ST d,
 				// HL-DT-ST BD-RE BU40N, HL-DT-ST BD-RE WH10LS30, HL-DT-ST DVDRAM GH22LS51,
 				// LG GH24NSD1,
+				// MATSHITA DVD-R UJ-868,
 				// PIONEER BDR-XD05, PIONEER BDR-XD07U, PIONEER DVR-S21,
 				// PLDS DU-8A5LH,
 				// Slimtype - DVD A DU8AESH.
 				if (pathNoSpace.Contains("DRW-24D5MT") || pathNoSpace.Contains("DRW-24F1STd") ||
 					pathNoSpace.Contains("BU40N") || pathNoSpace.Contains("WH10LS30") || pathNoSpace.Contains("GH22LS51") ||
 					pathNoSpace.Contains("GH24NSD1") ||
+					pathNoSpace.Contains("UJ-868") ||
 					pathNoSpace.Contains("BDR-XD05") || pathNoSpace.Contains("BDR-XD07U") || pathNoSpace.Contains("DVR-S21") ||
 					pathNoSpace.Contains("DU-8A5LH") ||
 					pathNoSpace.Contains("DU8AESH"))


### PR DESCRIPTION
- `C2ErrorMode.Mode294` does not work for this drive:
  **`MATSHITA DVD-R UJ-868`**. Try `Mode296` first.
- See #296
