### PR TITLE
Allow decoding aiff using ffmpeg.dll

### DIFF
--- a/CUETools.Codecs.ffmpeg/DecoderSettings.cs
+++ b/CUETools.Codecs.ffmpeg/DecoderSettings.cs
@@ -120,4 +120,13 @@ namespace CUETools.Codecs.ffmpegdll
             this.Init();
         }
     }
+    public class AiffDecoderSettings : DecoderSettings, IAudioDecoderSettings
+    {
+        public override string Extension => "aiff";
+        public override string Format => "aiff";
+        public AiffDecoderSettings()
+        {
+            this.Init();
+        }
+    }
 }

--- a/CUETools.Codecs/CUEToolsCodecsConfig.cs
+++ b/CUETools.Codecs/CUEToolsCodecsConfig.cs
@@ -90,6 +90,7 @@ namespace CUETools.Codecs
             formats.Add("opus", new CUEToolsFormat("opus", CUEToolsTagger.TagLibSharp, false, true, false, true, null, encodersViewModel.GetDefault("opus", false), null));
             formats.Add("mlp", new CUEToolsFormat("mlp", CUEToolsTagger.APEv2, true, false, false, false, null, null, decodersViewModel.GetDefault("mlp")));
             formats.Add("aob", new CUEToolsFormat("aob", CUEToolsTagger.APEv2, true, false, false, false, null, null, decodersViewModel.GetDefault("aob")));
+            formats.Add("aiff", new CUEToolsFormat("aiff", CUEToolsTagger.TagLibSharp, true, false, false, true, null, null, decodersViewModel.GetDefault("aiff")));
         }
     }
 }

--- a/CUETools/frmSettings.resx
+++ b/CUETools/frmSettings.resx
@@ -2985,7 +2985,7 @@ You can set up foobar2000 to show those values, and see if your music was ripped
     <value>6, 6</value>
   </data>
   <data name="listViewFormats.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 269</value>
+    <value>124, 272</value>
   </data>
   <data name="listViewFormats.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>


### PR DESCRIPTION
- Add `aiff` to `Settings - Formats`. Use `ffmpeg.dll` as Decoder.
- Slightly increase height of `listViewFormats` in order to avoid
  initial scrollbars in `Settings - Formats`, after aiff has been added.
- In order to decode AIFF files using CUETools, ffmpeg 6.0 dlls
  need to be copied to `plugins\win32` or `plugins\x64` as usual.
- Resolves #298

Screenshot of `aiff` added to `Settings - Formats`, taken from [CUETools_2.2.4_2023-10-12_git_955881a_Allow_decoding_aiff_using_ffmpeg.dll.zip](https://github.com/gchudov/cuetools.net/files/12889452/CUETools_2.2.4_2023-10-12_git_955881a_Allow_decoding_aiff_using_ffmpeg.dll.zip):

![Settings_Formats_2_aiff_added_no_scrollbars](https://github.com/gchudov/cuetools.net/assets/371551/496fd84c-fb73-43ce-b0a6-164206614c3c)
