### PR TITLE
Preserve settings for builtin formats

### DIFF
--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -454,9 +454,9 @@ namespace CUETools.Processor
                     advanced.decodersViewModel = new DecoderListViewModel(advanced.decoders);
 
                     // Reset the links in formats
-                    foreach (var extension in formats.Keys)
+                    foreach (var extension in backup.formats.Keys)
                     {
-                        var format = formats[extension];
+                        var format = backup.formats[extension];
                         AudioEncoderSettingsViewModel encoderLossless, encoderLossy;
                         AudioDecoderSettingsViewModel decoder;
                         if (format.encoderLossless == null || !Encoders.TryGetValue(extension, true, format.encoderLossless.Name, out encoderLossless))
@@ -468,6 +468,7 @@ namespace CUETools.Processor
                         format.encoderLossless = encoderLossless;
                         format.encoderLossy = encoderLossy;
                         format.decoder = decoder;
+                        advanced.formats.Add(extension, format);
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
The settings of builtin formats were not disabled anymore
in Settings - Formats since e1f8906 (last working in release: 2.1.7).
They were only disabled at the first start of CUETools. As soon as a
settings.txt file was available, this was not the case anymore. 

- Furthermore, this fixes availability of newly added formats like
  aiff, if a `settings.txt` file from a previous version of CUETools is
  already present.
