### PR TITLE
Fix APE encoding under 32-bit

### DIFF
--- a/CUETools.Codecs.MACLib/MACLibDll.cs
+++ b/CUETools.Codecs.MACLib/MACLibDll.cs
@@ -36,7 +36,7 @@ namespace CUETools.Codecs.MACLib
         internal static extern void c_APECompress_Destroy(IntPtr hAPECompress);
 
         [DllImport(DllName, CallingConvention = DllCallingConvention)]
-        internal static extern int c_APECompress_Finish(IntPtr hAPECompress, char* pTerminatingData, int nTerminatingBytes, int nWAVTerminatingBytes);
+        internal static extern int c_APECompress_Finish(IntPtr hAPECompress, byte* pTerminatingData, long nTerminatingBytes, long nWAVTerminatingBytes);
 
         [DllImport(DllName, CallingConvention = DllCallingConvention)]
         internal static extern long c_APECompress_AddData(IntPtr hAPECompress, byte* pData, int nBytes);


### PR DESCRIPTION
APE files are not encoded correctly using CUETools.Codecs.MACLib,
when CUETools is run under 32-bit. This is a regression since the
update of MAC_SDK to 9.04 (#246). No problem under 64-bit.
Affected CUETools versions under 32-bit: v2.2.4, v2.2.3

- MACLibDll.cs, `c_APECompress_Finish()`:
  Use `long`, which corresponds to `APE::int64`
