### PR TITLE
Fix decoding flac using ffmpeg.dll plugin

### DIFF
--- a/CUETools.Codecs.ffmpeg/AudioDecoder.cs
+++ b/CUETools.Codecs.ffmpeg/AudioDecoder.cs
@@ -291,6 +291,7 @@ namespace CUETools.Codecs.ffmpegdll
                 _readBuffer = new byte[Math.Max(@buf_size, 0x4000)];
             int len = m_stream.Read(_readBuffer, 0, @buf_size);
             if (len > 0) Marshal.Copy(_readBuffer, 0, (IntPtr)buf, len);
+            else if (len == 0) return ffmpeg.AVERROR_EOF;
             return len;
         }
 


### PR DESCRIPTION
Flac files could not be decoded anymore using ffmpeg.dll since ffmpeg
version 5.0 (4.4 and earlier were OK).

- Using ffmpeg 4.4 or earlier, the following message appeared in the
  debug output, when decoding flac files using ffmpeg.dll:
  `Invalid return value 0 for stream protocol`
- Newer versions of ffmpeg dlls like 5.0 to 6.1 did not show this
  output anymore, whereas CUETools got stuck at:
  "Analyzing input file..."
- The problem occurred in `av_read_frame()` and the `readPacketCallback()`,
  where a value of `len = 0` was returned at the end of flac files.
- Only decoding of flac files using ffmpeg.dll was affected. Other file
  formats like aiff, ape, m4a, tta and wv could be decoded properly.
- Return `AVERROR_EOF` instead of `0` in `readPacketCallback()`
- Resolves #300
