### PR TITLE
Fix Microsoft.NETCore.App vulnerability warnings

### DIFF
--- a/CUETools.ALACEnc/CUETools.ALACEnc.csproj
+++ b/CUETools.ALACEnc/CUETools.ALACEnc.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.ALACEnc</AssemblyName>
     <RootNamespace>CUETools.ALACEnc</RootNamespace>

--- a/CUETools.ARCUE/CUETools.ARCUE.csproj
+++ b/CUETools.ARCUE/CUETools.ARCUE.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.ARCUE</AssemblyName>
     <RootNamespace>CUETools.ARCUE</RootNamespace>

--- a/CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
+++ b/CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.CTDB.Converter</AssemblyName>
     <RootNamespace>CUETools.CTDB.Converter</RootNamespace>

--- a/CUETools.Converter/CUETools.Converter.csproj
+++ b/CUETools.Converter/CUETools.Converter.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.Converter</AssemblyName>
     <RootNamespace>CUETools.Converter</RootNamespace>

--- a/CUETools.Flake/CUETools.Flake.csproj
+++ b/CUETools.Flake/CUETools.Flake.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.Flake</AssemblyName>
     <RootNamespace>CUETools.Flake</RootNamespace>

--- a/CUETools.LossyWAV/CUETools.LossyWAV.csproj
+++ b/CUETools.LossyWAV/CUETools.LossyWAV.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;net20;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.LossyWAV</AssemblyName>
     <RootNamespace>CUETools.LossyWAV</RootNamespace>

--- a/CUETools.eac3to/CUETools.eac3to.csproj
+++ b/CUETools.eac3to/CUETools.eac3to.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp2.0'">2.0.9</RuntimeFrameworkVersion>
     <Version>2.2.4.0</Version>
     <AssemblyName>CUETools.eac3to</AssemblyName>
     <RootNamespace>CUETools.eac3to</RootNamespace>


### PR DESCRIPTION
Microsoft.NETCore.App 2.0.0 contains a vulnerability.

- Switch to version 2.0.9 by specifying `RuntimeFrameworkVersion`.
- Fixes the following warnings:
  Warning NU1903 Package 'Microsoft.NETCore.App' 2.0.0 has a known
  high severity vulnerability,
  https://github.com/advisories/GHSA-7mfr-774f-w5r9
- This only concerns the TargetFramework `netcoreapp2.0` of:
  CUETools.ALACEnc/CUETools.ALACEnc.csproj
  CUETools.ARCUE/CUETools.ARCUE.csproj
  CUETools.CTDB.Converter/CUETools.CTDB.Converter.csproj
  CUETools.Converter/CUETools.Converter.csproj
  CUETools.Flake/CUETools.Flake.csproj
  CUETools.LossyWAV/CUETools.LossyWAV.csproj
  CUETools.eac3to/CUETools.eac3to.csproj
