### PR TITLE
CUERipper: Detect too large album art earlier

### DIFF
--- a/CUERipper/Properties/Resources.Designer.cs
+++ b/CUERipper/Properties/Resources.Designer.cs
@@ -71,6 +71,24 @@ namespace CUERipper.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Selected album art has a size of {0} bytes, which is too large for embedding (max 16 MB). Small album art will be used instead..
+        /// </summary>
+        internal static string AlbumArtTooLargeMessage {
+            get {
+                return ResourceManager.GetString("AlbumArtTooLargeMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Album art too large.
+        /// </summary>
+        internal static string AlbumArtTooLargeTitle {
+            get {
+                return ResourceManager.GetString("AlbumArtTooLargeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
         /// </summary>
         internal static System.Drawing.Icon ape {
@@ -183,6 +201,15 @@ namespace CUERipper.Properties {
         internal static string DoneRippingRepair {
             get {
                 return ResourceManager.GetString("DoneRippingRepair", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading album art....
+        /// </summary>
+        internal static string DownloadingAlbumArt {
+            get {
+                return ResourceManager.GetString("DownloadingAlbumArt", resourceCulture);
             }
         }
         

--- a/CUERipper/Properties/Resources.de-DE.resx
+++ b/CUERipper/Properties/Resources.de-DE.resx
@@ -147,4 +147,13 @@
   <data name="Retry" xml:space="preserve">
     <value>erneut versuchen</value>
   </data>
+  <data name="DownloadingAlbumArt" xml:space="preserve">
+    <value>Coverbild wird heruntergeladen …</value>
+  </data>
+  <data name="AlbumArtTooLargeMessage" xml:space="preserve">
+    <value>Das gewählte Coverbild hat eine Größe von {0} Bytes und ist somit zu groß (max. 16 MB). Die kleine Coverbildgröße (Small) wird stattdessen verwendet.</value>
+  </data>
+  <data name="AlbumArtTooLargeTitle" xml:space="preserve">
+    <value>Coverbild zu groß</value>
+  </data>
 </root>

--- a/CUERipper/Properties/Resources.resx
+++ b/CUERipper/Properties/Resources.resx
@@ -223,4 +223,13 @@
   <data name="opus" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\opus.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="DownloadingAlbumArt" xml:space="preserve">
+    <value>Downloading album art...</value>
+  </data>
+  <data name="AlbumArtTooLargeMessage" xml:space="preserve">
+    <value>Selected album art has a size of {0} bytes, which is too large for embedding (max 16 MB). Small album art will be used instead.</value>
+  </data>
+  <data name="AlbumArtTooLargeTitle" xml:space="preserve">
+    <value>Album art too large</value>
+  </data>
 </root>

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -628,7 +628,15 @@ namespace CUERipper
                     try
                     {
                         if (cueSheet.CTDB.FetchFile(albumArt[currentAlbumArt].meta.uri, ms))
-                            albumArt[currentAlbumArt].contents = ms.ToArray();
+                        {
+                            if (ms.Length < 0xffffff || !_config.embedAlbumArt)
+                                albumArt[currentAlbumArt].contents = ms.ToArray();
+                            else
+                                MessageBox.Show(this, String.Format("Selected album art has a size of {0} bytes, " +
+                                "which is too large for embedding (max 16 MB). " +
+                                "Small album art will be used instead.", ms.Length),
+                                "Album art too large", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        }
                     } catch (Exception)
                     {
                     }

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -627,15 +627,14 @@ namespace CUERipper
                     var ms = new MemoryStream();
                     try
                     {
+                        toolStripStatusLabel1.Text = Properties.Resources.DownloadingAlbumArt;
                         if (cueSheet.CTDB.FetchFile(albumArt[currentAlbumArt].meta.uri, ms))
                         {
                             if (ms.Length < 0xffffff || !_config.embedAlbumArt)
                                 albumArt[currentAlbumArt].contents = ms.ToArray();
                             else
-                                MessageBox.Show(this, String.Format("Selected album art has a size of {0} bytes, " +
-                                "which is too large for embedding (max 16 MB). " +
-                                "Small album art will be used instead.", ms.Length),
-                                "Album art too large", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                MessageBox.Show(this, String.Format(Properties.Resources.AlbumArtTooLargeMessage, ms.Length),
+                                Properties.Resources.AlbumArtTooLargeTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         }
                     } catch (Exception)
                     {


### PR DESCRIPTION
The maximum size of embedded album art is 16 MB each.
So far, in case of too large album art, an exception was shown after
ripping the CD, when tagging the files: "Block size too large."
When using libFLAC, an exception appeared at the beginning of ripping
"Exception: unable to initialize the encoder:"
`FLAC__STREAM_ENCODER_INIT_STATUS_ENCODER_ERROR`

- Show an earlier warning, after downloading too large album art
  and before starting to rip the CD.
- Switch to `Album art size` `Small`, if the album art is larger than
  16 MB and `Embed album art` is set.
- The following warning is shown:
  "Selected album art has a size of x bytes, which is too large for
  embedding (max 16 MB). Small album art will be used instead."
- This is a follow-up to commit gchudov/taglib-sharp@8590ad0
  Prevent taglib from corrupting flac files when embedded album art
  exceeds 16Mb
- Use `Properties.Resources` for the title and message in the new
  MessageBox "Album art too large" to allow translation.
- Show "Downloading album art..." in the status of CUERipper to inform
  the user, what is going on, because downloading of large album art
  may take some time.
- Add German translations.
