### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -25,7 +25,7 @@ jobs:
       MSBUILD_PATH: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe
       SLN_PATH: CUETools.sln
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Apply patches

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -26,7 +26,7 @@ jobs:
       MSBUILD_PATH: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe
       SLN_PATH: CUETools.sln
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Apply patches
@@ -53,7 +53,7 @@ jobs:
       - name: Collect files
         run: |
           collect_files.bat
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: deploy
           path: bin/Release/CUETools_*/


### PR DESCRIPTION
- Update actions/checkout [1] from v3 to v4
  This fixes the following warning:
  `build (windows-2022)`
  `Node.js 16 actions are deprecated. Please update the following`
  `actions to use Node.js 20: actions/checkout@v3.`
- Update actions/upload-artifact [2] from v3 to v4
  The `SHA256` hash of the uploaded zip file is now logged.

[1] https://github.com/actions/checkout
[2] https://github.com/actions/upload-artifact
