### PR TITLE
Update WavPack from 5.6.0 to 5.7.0

### DIFF
--- a/CUETools.Codecs.libwavpack/libwavpack.cs
+++ b/CUETools.Codecs.libwavpack/libwavpack.cs
@@ -21,6 +21,9 @@ namespace CUETools.Codecs.libwavpack
         OPEN_ALT_TYPES = 0x400,     // application is aware of alternate file types & qmode
                                     // (just affects retrieving wrappers & MD5 checksums)
         OPEN_NO_CHECKSUM = 0x800,   // don't verify block checksums before decoding
+                                    // new for multithreaded
+        OPEN_THREADS_SHFT = 12,     // specify number of additional worker threads here for
+        OPEN_THREADS_MASK = 0xF000, // decode; 0 to disable, otherwise 1-15 added threads
     };
 
     internal enum ConfigFlags : uint
@@ -43,7 +46,7 @@ namespace CUETools.Codecs.libwavpack
         CONFIG_DYNAMIC_SHAPING = 0x20000,   // dynamic noise shaping
         CONFIG_CREATE_EXE = 0x40000,        // create executable
         CONFIG_CREATE_WVC = 0x80000,        // create correction file
-        CONFIG_OPTIMIZE_WVC = 0x100000,     // maximize bybrid compression
+        CONFIG_OPTIMIZE_WVC = 0x100000,     // maximize hybrid compression
         CONFIG_COMPATIBLE_WRITE = 0x400000, // write files for decoders < 4.3
         CONFIG_CALC_NOISE = 0x800000,       // calc noise in hybrid mode
         CONFIG_LOSSY_MODE = 0x1000000,      // obsolete (for information)
@@ -52,6 +55,7 @@ namespace CUETools.Codecs.libwavpack
         CONFIG_MD5_CHECKSUM = 0x8000000,    // compute & store MD5 signature
         CONFIG_MERGE_BLOCKS = 0x10000000,   // merge blocks of equal redundancy (for lossyWAV)
         CONFIG_PAIR_UNDEF_CHANS = 0x20000000, // encode undefined channels in stereo pairs
+        CONFIG_OPTIMIZE_32BIT = 0x40000000, // new optimizations for 32-bit integer files
         CONFIG_OPTIMIZE_MONO = 0x80000000,  // optimize for mono streams posing as stereo
     };
 
@@ -111,7 +115,7 @@ namespace CUETools.Codecs.libwavpack
         internal int qmode;
         internal ConfigFlags flags;
         internal int xmode, num_channels, float_norm_exp;
-        internal int block_samples, extra_flags, sample_rate, channel_mask;
+        internal int block_samples, worker_threads, sample_rate, channel_mask;
         internal fixed byte md5_checksum[16];
         internal byte md5_read;
         internal int num_tag_strings;

--- a/ThirdParty/submodule_WavPack_CUETools.patch
+++ b/ThirdParty/submodule_WavPack_CUETools.patch
@@ -34,7 +34,7 @@ index fd59f60..dcbf0b5 100644
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
    <ImportGroup Label="ExtensionSettings">
 diff --git a/src/libwavpack.vcxproj b/src/libwavpack.vcxproj
-index 3d586d6..7e4523b 100644
+index c9d3d40..5a01068 100644
 --- a/src/libwavpack.vcxproj
 +++ b/src/libwavpack.vcxproj
 @@ -1,5 +1,5 @@
@@ -97,8 +97,8 @@ index 3d586d6..7e4523b 100644
      <ClCompile>
        <Optimization>Disabled</Optimization>
        <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
--      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;ENABLE_THREADS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_THREADS;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <MinimalRebuild>true</MinimalRebuild>
        <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
 -      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -110,8 +110,8 @@ index 3d586d6..7e4523b 100644
      <ClCompile>
        <Optimization>Disabled</Optimization>
        <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
--      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;ENABLE_THREADS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_THREADS;NO_TAGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <MinimalRebuild>true</MinimalRebuild>
        <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
 -      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -123,8 +123,8 @@ index 3d586d6..7e4523b 100644
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
        <OmitFramePointers>true</OmitFramePointers>
--      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;ENABLE_THREADS;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_THREADS;NO_TAGS;OPT_ASM_X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <StringPooling>true</StringPooling>
        <ExceptionHandling />
 -      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -136,8 +136,8 @@ index 3d586d6..7e4523b 100644
        <IntrinsicFunctions>true</IntrinsicFunctions>
        <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
        <OmitFramePointers>true</OmitFramePointers>
--      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;NO_TAGS;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_DSD;ENABLE_THREADS;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;ENABLE_THREADS;NO_TAGS;OPT_ASM_X64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
        <StringPooling>true</StringPooling>
        <ExceptionHandling />
 -      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -184,7 +184,7 @@ index 3d586d6..7e4523b 100644
      <ClCompile Include="pack_utils.c" />
      <ClCompile Include="read_words.c" />
 diff --git a/wavpackdll/wavpackdll.vcxproj b/wavpackdll/wavpackdll.vcxproj
-index 2d97667..92e220d 100644
+index 2d97667..6143fe1 100644
 --- a/wavpackdll/wavpackdll.vcxproj
 +++ b/wavpackdll/wavpackdll.vcxproj
 @@ -1,5 +1,5 @@
@@ -416,7 +416,7 @@ index 2d97667..92e220d 100644
  /export:WavpackGetChannelLayout /export:WavpackSetFileInformation
  /export:WavpackSetConfiguration64 /export:WavpackSetChannelLayout
 diff --git a/wavpackexe/wavpack.vcxproj b/wavpackexe/wavpack.vcxproj
-index 5d4e2fe..d38b409 100644
+index 9cbf0d8..c6ee402 100644
 --- a/wavpackexe/wavpack.vcxproj
 +++ b/wavpackexe/wavpack.vcxproj
 @@ -1,5 +1,5 @@
@@ -527,7 +527,7 @@ index e7b87ad..516ddee 100644
      <WholeProgramOptimization>false</WholeProgramOptimization>
    </PropertyGroup>
 diff --git a/wvgainexe/wvgain.vcxproj b/wvgainexe/wvgain.vcxproj
-index b7331b9..81cf728 100644
+index 8c1dde4..55fa560 100644
 --- a/wvgainexe/wvgain.vcxproj
 +++ b/wvgainexe/wvgain.vcxproj
 @@ -1,5 +1,5 @@
@@ -597,7 +597,7 @@ index b593ab8..3e9fc24 100644
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
    <ImportGroup Label="ExtensionSettings">
 diff --git a/wvunpackexe/wvunpack.vcxproj b/wvunpackexe/wvunpack.vcxproj
-index ef39827..133a4de 100644
+index 1888d0d..4aa3fab 100644
 --- a/wvunpackexe/wvunpack.vcxproj
 +++ b/wvunpackexe/wvunpack.vcxproj
 @@ -1,5 +1,5 @@


### PR DESCRIPTION
- Checkout release 5.7.0 of [dbry/WavPack](https://github.com/dbry/WavPack). The previously used
  commit in CUETools was dbry/WavPack@e03e8e2 (tag 5.6.0).
- Use the following commands, to update the WavPack submodule to
  commit dbry/WavPack@63dd3fa (tag 5.7.0):
```sh
    pushd ThirdParty/WavPack/
    git fetch
    git checkout 63dd3fa3b69fc236cc17886af6d4bd7dbe856125
    popd
```
- Update `submodule_WavPack_CUETools.patch`
- Update `CUETools.Codecs.libwavpack/libwavpack.cs`
  according to upstream modifications to `include/wavpack.h`
