### PR TITLE
[CUERipper] Add setting to force ReadCDCommand

### DIFF
--- a/CUERipper/CUERipperConfig.cs
+++ b/CUERipper/CUERipperConfig.cs
@@ -84,6 +84,7 @@ namespace CUERipper
 
             this.DriveOffsets = new SerializableDictionary<string, int>();
             this.DriveC2ErrorModes = new SerializableDictionary<string, int>();
+            this.ReadCDCommands = new SerializableDictionary<string, int>();
         }
 
         internal static XmlSerializer serializer = new XmlSerializer(typeof(CUERipperConfig));
@@ -103,5 +104,9 @@ namespace CUERipper
 
         // 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto)
         public SerializableDictionary<string, int> DriveC2ErrorModes { get; set; }
+
+        // 0 (ReadCdBEh), 1 (ReadCdD8h), 2 (Unknown/AutoDetect)
+        public SerializableDictionary<string, int> ReadCDCommands { get; set; }
+
     }
 }

--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -361,6 +361,26 @@ namespace CUERipper
 						reader.DriveC2ErrorMode = 3; // 0 (None), 1 (Mode294), 2 (Mode296), 3 (Auto)
 					}
 					cueRipperConfig.DriveC2ErrorModes[reader.ARName] = reader.DriveC2ErrorMode;
+
+					int readCDCommand;
+					if (cueRipperConfig.ReadCDCommands.ContainsKey(reader.ARName))
+					{
+						readCDCommand = cueRipperConfig.ReadCDCommands[reader.ARName];
+						if (readCDCommand == 0)
+							reader.ForceBE = true;
+						else if (readCDCommand == 1)
+							reader.ForceD8 = true;
+						else if (readCDCommand < 0 || readCDCommand > 2)
+						{
+							// Invalid setting, use 2 (Unknown)
+							readCDCommand = 2;
+						}
+					}
+					else
+					{
+						readCDCommand = 2; // 0 (ReadCdBEh), 1 (ReadCdD8h), 2 (Unknown/AutoDetect)
+					}
+					cueRipperConfig.ReadCDCommands[reader.ARName] = readCDCommand;
 				}
 				data.Drives.Add(new DriveInfo(m_icon_mgr, drive + ":\\", reader));
 			}

--- a/CUETools.Ripper/Ripper.cs
+++ b/CUETools.Ripper/Ripper.cs
@@ -20,6 +20,8 @@ namespace CUETools.Ripper
 		string EACName { get; }
 		int DriveOffset { get; set; }
 		int DriveC2ErrorMode { get; set; }
+		bool ForceBE { get; set; }
+		bool ForceD8 { get; set; }
 		string RipperVersion { get; }
 		string CurrentReadCommand { get; }
 		int CorrectionQuality { get; set; }


### PR DESCRIPTION
The `ReadCDCommand` is not detected correctly in some cases. This has
been reported for Plextor drives PX-5224TA and PX-708A.

- Add CUERipper setting `ReadCDCommands`
  The setting can be modified by editing `CUERipper\settings.txt`
  Remark: CUERipper needs to be closed while editing the file.
- Values for the drive specific setting `ReadCDCommands` are:
  0 (ReadCdBEh), 1 (ReadCdD8h), 2 (Unknown/AutoDetect)
  Default: 2
- Resolves:
  https://hydrogenaud.io/index.php/topic,125668.0.html