### PR TITLE
CUERipper: Fix incorrect TOC entry of first track

### DIFF
--- a/Bwg.Scsi/TocEntry.cs
+++ b/Bwg.Scsi/TocEntry.cs
@@ -74,7 +74,14 @@ namespace Bwg.Scsi
             if (mode)
                 StartMSF = new MinuteSecondFrame(Get8(offset + 5), Get8(offset + 6), Get8(offset + 7));
             else
-                StartSector = Get32(offset + 4) ;
+            {
+                StartSector = Get32(offset + 4);
+                if (StartSector > 16777216 - 150)
+                {
+                    // Fix incorrect TOC, where the first track is reported to start at a frame smaller than 150
+                    StartSector = 0;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In rare cases, the first track is reported to start at a frame lower
than 150. This leads to an incorrect TOC entry. In such cases, the
`StartSector` is assigned a wrong value of e.g. 16777141 (16777216 - 75).

- Set `StartSector` to `0` in cases,
  where a value larger than (16777216 - 150) is reported.
- Fixes #236
- See also:
  https://hydrogenaud.io/index.php/topic,125779.0.html
