### PR TITLE
CUETools, Correct filenames: Support UTF-8

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -1921,7 +1921,7 @@ namespace CUETools.Processor
             }
         }
 
-        private static StreamReader StreamReader_UTF_ANSI(string path)
+        public static StreamReader StreamReader_UTF_ANSI(string path)
         {
             // StreamReader() detects the encoding of files properly, if a BOM is present.
             // Enable detection of UTF-8 files without BOM. Otherwise fall back to default encoding, which is typically ANSI.

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -814,7 +814,7 @@ namespace JDP
                         if (Path.GetExtension(pathIn).ToLower() != ".cue")
                             throw new Exception("is not a .cue file");
                         string cue = null;
-                        using (StreamReader sr = new StreamReader(pathIn, CUESheet.Encoding))
+                        using (StreamReader sr = CUESheet.StreamReader_UTF_ANSI(pathIn))
                             cue = sr.ReadToEnd();
                         string extension;
                         string fixedCue;


### PR DESCRIPTION
So far, the CUETools action "Correct filenames" supports reading of
cuesheets in ANSI or UTF-8-BOM format. In case of UTF-8 files without
BOM, issues with special characters can occur.

- Add support for UTF-8 encoded cuesheets without BOM.
- Use method `CUESheet.StreamReader_UTF_ANSI()`.
  Detect, if file is `UTF-8-BOM` or `UTF-8` without BOM. Otherwise
  fall back to default encoding, which is typically `ANSI`.
- This is a follow-up to #140 (commit d6470d5)
- Fixes #326
