### PR TITLE
Add setting for UTF-8-BOM

### DIFF
--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -40,6 +40,7 @@ namespace CUETools.Processor
         public bool embedLog;
         public bool extractLog;
         public bool alwaysWriteUTF8CUEFile;
+        public bool writeUTF8BOM;
         public bool fillUpCUE;
         public bool overwriteCUEData;
         public bool filenamesANSISafe;
@@ -110,6 +111,7 @@ namespace CUETools.Processor
             embedLog = true;
             extractLog = true;
             alwaysWriteUTF8CUEFile = false;
+            writeUTF8BOM = true;
             fillUpCUE = true;
             overwriteCUEData = false;
             filenamesANSISafe = true;
@@ -197,6 +199,7 @@ namespace CUETools.Processor
             embedLog = src.embedLog;
             extractLog = src.extractLog;
             alwaysWriteUTF8CUEFile = src.alwaysWriteUTF8CUEFile;
+            writeUTF8BOM = src.writeUTF8BOM;
             fillUpCUE = src.fillUpCUE;
             overwriteCUEData = src.overwriteCUEData;
             filenamesANSISafe = src.filenamesANSISafe;
@@ -285,6 +288,7 @@ namespace CUETools.Processor
             sw.Save("EmbedLog", embedLog);
             sw.Save("ExtractLog", extractLog);
             sw.Save("AlwaysWriteUTF8CUEFile", alwaysWriteUTF8CUEFile);
+            sw.Save("WriteUTF8BOM", writeUTF8BOM);
             sw.Save("FillUpCUE", fillUpCUE);
             sw.Save("OverwriteCUEData", overwriteCUEData);
             sw.Save("FilenamesANSISafe", filenamesANSISafe);
@@ -391,6 +395,7 @@ namespace CUETools.Processor
             embedLog = sr.LoadBoolean("EmbedLog") ?? true;
             extractLog = sr.LoadBoolean("ExtractLog") ?? true;
             alwaysWriteUTF8CUEFile = sr.LoadBoolean("AlwaysWriteUTF8CUEFile") ?? false;
+            writeUTF8BOM = sr.LoadBoolean("WriteUTF8BOM") ?? true;
             fillUpCUE = sr.LoadBoolean("FillUpCUE") ?? true;
             overwriteCUEData = sr.LoadBoolean("OverwriteCUEData") ?? false;
             filenamesANSISafe = sr.LoadBoolean("FilenamesANSISafe") ?? true;

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -2387,7 +2387,7 @@ namespace CUETools.Processor
         public static void WriteText(CUEConfig _config, string path, string text)
         {
             bool utf8Required = (_config.alwaysWriteUTF8CUEFile && Path.GetExtension(path) == ".cue") || (CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(text)) != text);
-            var encoding = utf8Required ? Encoding.UTF8 : CUESheet.Encoding;
+            var encoding = utf8Required ? new UTF8Encoding(_config.writeUTF8BOM) : CUESheet.Encoding;
             // Preserve original UTF-16LE encoding of EAC log files, which contain a log checksum
             if ((text.StartsWith("Exact Audio Copy") || text.StartsWith("EAC extraction logfile")) && text.Contains("==== Log checksum"))
                 encoding = Encoding.Unicode;

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -784,7 +784,7 @@ namespace JDP
                         if (File.Exists(fullCueName))
                             throw new Exception("file already exists");
                         bool utf8Required = _profile._config.alwaysWriteUTF8CUEFile || (CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(cueSheetContents)) != cueSheetContents);
-                        StreamWriter sw1 = new StreamWriter(fullCueName, false, utf8Required ? Encoding.UTF8 : CUESheet.Encoding);
+                        StreamWriter sw1 = new StreamWriter(fullCueName, false, utf8Required ? new UTF8Encoding(_profile._config.writeUTF8BOM) : CUESheet.Encoding);
                         sw1.Write(cueSheetContents);
                         sw1.Close();
                         BatchLog("created ok.", fullCueName);


### PR DESCRIPTION
This setting allows to enable/disable writing the byte-order mark (BOM)
in case of UTF-8 encoded CUE sheets.

- Add setting:
  `WriteUTF8BOM`
  Default:
  `WriteUTF8BOM=1`
  The setting is enabled by default, to preserve previous behavior.
- For now, the setting can be modified by editing `settings.txt` after
  closing CUETools or CUERipper:
  Use bool value 0, to disable writing the BOM to UTF-8 encoded CUE
  sheets.
- The setting is available in the CUETools as well as the CUERipper
  `settings.txt` file.
