### PR TITLE
Preserve encoding of localized EAC log files

### DIFF
--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -2389,7 +2389,7 @@ namespace CUETools.Processor
             bool utf8Required = (_config.alwaysWriteUTF8CUEFile && Path.GetExtension(path) == ".cue") || (CUESheet.Encoding.GetString(CUESheet.Encoding.GetBytes(text)) != text);
             var encoding = utf8Required ? new UTF8Encoding(_config.writeUTF8BOM) : CUESheet.Encoding;
             // Preserve original UTF-16LE encoding of EAC log files, which contain a log checksum
-            if ((text.StartsWith("Exact Audio Copy") || text.StartsWith("EAC extraction logfile")) && text.Contains("==== Log checksum"))
+            if (Path.GetExtension(path) == ".log" && text.StartsWith("Exact Audio Copy") && (text.EndsWith(" ====\r\n") || text.EndsWith(" ====\n")))
                 encoding = Encoding.Unicode;
             using (StreamWriter sw1 = new StreamWriter(path, false, encoding))
                 sw1.Write(text);


### PR DESCRIPTION
EAC log files are encoded using `UTF-16LE` since version 1.0 beta 1.
Since #51 (commit 9f80400) this encoding is preserved in case of EAC
log files, which contain a log checksum. However, only English log
files have been supported so far.

- Also preserve the encoding of EAC log files in different languages,
  if they contain a log checksum.
- Just in case an EAC log file with a checksum has been converted
  to EOL `LF`, which is fine for CheckLog.exe, preserve `UTF-16LE` too.
- Resolves #330
