### PR TITLE
Add setting for writing dummy CUE sheet comment

### DIFF
--- a/CUETools.Processor/CUEConfig.cs
+++ b/CUETools.Processor/CUEConfig.cs
@@ -41,6 +41,7 @@ namespace CUETools.Processor
         public bool extractLog;
         public bool alwaysWriteUTF8CUEFile;
         public bool writeUTF8BOM;
+        public bool writeDummyCUESheetComment;
         public bool fillUpCUE;
         public bool overwriteCUEData;
         public bool filenamesANSISafe;
@@ -112,6 +113,7 @@ namespace CUETools.Processor
             extractLog = true;
             alwaysWriteUTF8CUEFile = false;
             writeUTF8BOM = true;
+            writeDummyCUESheetComment = true;
             fillUpCUE = true;
             overwriteCUEData = false;
             filenamesANSISafe = true;
@@ -200,6 +202,7 @@ namespace CUETools.Processor
             extractLog = src.extractLog;
             alwaysWriteUTF8CUEFile = src.alwaysWriteUTF8CUEFile;
             writeUTF8BOM = src.writeUTF8BOM;
+            writeDummyCUESheetComment = src.writeDummyCUESheetComment;
             fillUpCUE = src.fillUpCUE;
             overwriteCUEData = src.overwriteCUEData;
             filenamesANSISafe = src.filenamesANSISafe;
@@ -289,6 +292,7 @@ namespace CUETools.Processor
             sw.Save("ExtractLog", extractLog);
             sw.Save("AlwaysWriteUTF8CUEFile", alwaysWriteUTF8CUEFile);
             sw.Save("WriteUTF8BOM", writeUTF8BOM);
+            sw.Save("WriteDummyCUESheetComment", writeDummyCUESheetComment);
             sw.Save("FillUpCUE", fillUpCUE);
             sw.Save("OverwriteCUEData", overwriteCUEData);
             sw.Save("FilenamesANSISafe", filenamesANSISafe);
@@ -396,6 +400,7 @@ namespace CUETools.Processor
             extractLog = sr.LoadBoolean("ExtractLog") ?? true;
             alwaysWriteUTF8CUEFile = sr.LoadBoolean("AlwaysWriteUTF8CUEFile") ?? false;
             writeUTF8BOM = sr.LoadBoolean("WriteUTF8BOM") ?? true;
+            writeDummyCUESheetComment = sr.LoadBoolean("WriteDummyCUESheetComment") ?? true;
             fillUpCUE = sr.LoadBoolean("FillUpCUE") ?? true;
             overwriteCUEData = sr.LoadBoolean("OverwriteCUEData") ?? false;
             filenamesANSISafe = sr.LoadBoolean("FilenamesANSISafe") ?? true;

--- a/CUETools.Processor/CUESheet.cs
+++ b/CUETools.Processor/CUESheet.cs
@@ -3888,7 +3888,8 @@ namespace CUETools.Processor
             }
 
             StringWriter sw = new StringWriter();
-            sw.WriteLine(String.Format("REM COMMENT \"CUETools generated dummy CUE sheet\""));
+            if (_config.writeDummyCUESheetComment)
+                sw.WriteLine(String.Format("REM COMMENT \"CUETools generated dummy CUE sheet\""));
             int trackNo = 0;
             foreach (FileSystemInfo file in fileGroup.files)
             {


### PR DESCRIPTION
If desired, this setting allows disabling writing of the following
comment in dummy CUE sheets:
`REM COMMENT "CUETools generated dummy CUE sheet"`

- Add setting:
  `WriteDummyCUESheetComment`
  Default:
  `WriteDummyCUESheetComment=1`
  The setting is enabled by default, to preserve previous behavior.
- The setting can be modified by editing `settings.txt` after
  closing CUETools:
  Use bool value 0, to disable writing the dummy CUE sheet comment.
- Resolves: #343
