### PR TITLE
ffmpeg: Support positive Offset

### DIFF
--- a/CUETools.Codecs.ffmpeg/AudioDecoder.cs
+++ b/CUETools.Codecs.ffmpeg/AudioDecoder.cs
@@ -264,13 +264,10 @@ namespace CUETools.Codecs.ffmpegdll
 
             set
             {
-                throw new NotSupportedException();
-                //_bufferOffset = 0;
-                //_bufferLength = 0;
-                //_sampleOffset = value;
-                //int res = MACLibDll.c_APEDecompress_Seek(pAPEDecompress, (int)value);
-                //if (0 != res)
-                //    throw new Exception("unable to seek:" + res.ToString());
+                _sampleOffset = value;
+                int res = ffmpeg.av_seek_frame(fmt_ctx, stream->index, _sampleOffset, ffmpeg.AVSEEK_FLAG_FRAME);
+                if (0 != res)
+                    throw new Exception("unable to seek:" + res.ToString());
             }
         }
 


### PR DESCRIPTION
So far, seeking to `_sampleOffset` has not been implemented in the
CUETools ffmpeg plugin. Seeking is required in case of positive
offsets. Negative offsets have been working before.

- Resolves #352
