### PR TITLE
ffmpeg: Seek to positive Offset only for AIFF

### DIFF
--- a/CUETools.Codecs.ffmpeg/AudioDecoder.cs
+++ b/CUETools.Codecs.ffmpeg/AudioDecoder.cs
@@ -265,9 +265,15 @@ namespace CUETools.Codecs.ffmpegdll
             set
             {
                 _sampleOffset = value;
-                int res = ffmpeg.av_seek_frame(fmt_ctx, stream->index, _sampleOffset, ffmpeg.AVSEEK_FLAG_FRAME);
-                if (0 != res)
-                    throw new Exception("unable to seek:" + res.ToString());
+                // Seeking is supported in case of AIFF files (PCM_S16BE)
+                if (stream->codecpar->codec_id == AVCodecID.AV_CODEC_ID_PCM_S16BE)
+                {
+                    int res = ffmpeg.av_seek_frame(fmt_ctx, stream->index, _sampleOffset, ffmpeg.AVSEEK_FLAG_FRAME);
+                    if (0 != res)
+                        throw new Exception("Unable to seek: " + res.ToString());
+                }
+                else
+                    throw new Exception("Seeking not supported");
             }
         }
 


### PR DESCRIPTION
Restrict seeking to positive Offset to the AIFF file format, when
using ffmpeg.dll for decoding. Other formats are not supported.

- Check for `AV_CODEC_ID_PCM_S16BE`
  Remark: Consider only PCM_S16BE, as PCM_S16LE is not supported
  by taglib-sharp (Exception: File form type is not AIFF).
