### PR TITLE
CUERipper: Consider allowEmbed of formats

### DIFF
--- a/CUERipper/frmCUERipper.cs
+++ b/CUERipper/frmCUERipper.cs
@@ -668,8 +668,10 @@ namespace CUERipper
 			data.selectedRelease.metadata.Save();
 
 			cueSheet.CopyMetadata(data.selectedRelease.metadata);
-			cueSheet.OutputStyle = bnComboBoxImage.SelectedIndex == 0 ? CUEStyle.SingleFileWithCUE :
-				CUEStyle.GapsAppended;
+			if (bnComboBoxImage.SelectedIndex == 0)
+				cueSheet.OutputStyle = selectedFormat.allowEmbed ? CUEStyle.SingleFileWithCUE : CUEStyle.SingleFile;
+			else
+				cueSheet.OutputStyle = CUEStyle.GapsAppended;
 			_pathOut = cueSheet.GenerateUniqueOutputPath(bnComboBoxOutputFormat.Text,
 					cueSheet.OutputStyle == CUEStyle.SingleFileWithCUE ? "." + selectedFormat.ToString() : ".cue",
 					CUEAction.Encode, null);
@@ -1269,7 +1271,11 @@ namespace CUERipper
 				txtOutputPath.Text = "";
 				return;
 			}
-			CUEStyle style = bnComboBoxImage.SelectedIndex == 0 ? CUEStyle.SingleFileWithCUE : CUEStyle.GapsAppended;
+			CUEStyle style;
+			if (bnComboBoxImage.SelectedIndex == 0)
+				style = selectedFormat.allowEmbed ? CUEStyle.SingleFileWithCUE : CUEStyle.SingleFile;
+			else
+				style = CUEStyle.GapsAppended;
 			CUESheet sheet = new CUESheet(_config);
 			sheet.TOC = selectedDriveInfo.drive.TOC;
 			sheet.CopyMetadata(data.selectedRelease.metadata);


### PR DESCRIPTION
Do not embed the `CUESHEET` tag in case of formats, which do not
support it (mp3, m4a, wma, ogg, opus, etc.).

- Consider `allowEmbed` of formats
- Use `CUEStyle.SingleFile` if embedding of the `CUESHEET` tag is not
  supported, which also ensures that a .cue file is written.
- Resolves #322
