### PR TITLE
Fix C2 error mode for HP DH16ACSH JHD6

### DIFF
--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -821,6 +821,7 @@ namespace CUETools.Ripper.SCSI
 				// Mode294 does not work for these drives. Try Mode296 first, which has been reported to work:
 				// ASUS DRW-24D5MT, ASUS DRW-24F1ST d,
 				// HL-DT-ST BD-RE BU40N, HL-DT-ST BD-RE WH10LS30, HL-DT-ST DVDRAM GH22LS51,
+				// HP DH16ACSH JHD6,
 				// LG GH24NSD1, GH24NSD5,
 				// LITEON DH-20A4P,
 				// MATSHITA DVD-R UJ-868,
@@ -829,6 +830,7 @@ namespace CUETools.Ripper.SCSI
 				// Slimtype - DVD A DU8AESH.
 				if (pathNoSpace.Contains("DRW-24D5MT") || pathNoSpace.Contains("DRW-24F1STd") ||
 					pathNoSpace.Contains("BU40N") || pathNoSpace.Contains("WH10LS30") || pathNoSpace.Contains("GH22LS51") ||
+					pathNoSpace.Contains("DH16ACSHJHD6") ||
 					pathNoSpace.Contains("GH24NSD1") || pathNoSpace.Contains("GH24NSD5") ||
 					pathNoSpace.Contains("DH20A4P") ||
 					pathNoSpace.Contains("UJ-868") ||

--- a/CUETools.Ripper.SCSI/SCSIDrive.cs
+++ b/CUETools.Ripper.SCSI/SCSIDrive.cs
@@ -821,7 +821,7 @@ namespace CUETools.Ripper.SCSI
 				// Mode294 does not work for these drives. Try Mode296 first, which has been reported to work:
 				// ASUS DRW-24D5MT, ASUS DRW-24F1ST d,
 				// HL-DT-ST BD-RE BU40N, HL-DT-ST BD-RE WH10LS30, HL-DT-ST DVDRAM GH22LS51,
-				// HP DH16ACSH JHD6,
+				// HP DH16ACSH,
 				// LG GH24NSD1, GH24NSD5,
 				// LITEON DH-20A4P,
 				// MATSHITA DVD-R UJ-868,
@@ -830,7 +830,7 @@ namespace CUETools.Ripper.SCSI
 				// Slimtype - DVD A DU8AESH.
 				if (pathNoSpace.Contains("DRW-24D5MT") || pathNoSpace.Contains("DRW-24F1STd") ||
 					pathNoSpace.Contains("BU40N") || pathNoSpace.Contains("WH10LS30") || pathNoSpace.Contains("GH22LS51") ||
-					pathNoSpace.Contains("DH16ACSHJHD6") ||
+					pathNoSpace.Contains("DH16ACSH") ||
 					pathNoSpace.Contains("GH24NSD1") || pathNoSpace.Contains("GH24NSD5") ||
 					pathNoSpace.Contains("DH20A4P") ||
 					pathNoSpace.Contains("UJ-868") ||


### PR DESCRIPTION
Hi,

This change fixes the error `Exception: Error reading CD: IoctlFailed` for the following drive:

HP
Model: DH-16ACSH-HT2
F/W: JHD6
H/W: 01.01

Recognized by CueRipper as a "hp       DVD A DH16ACSH JHD6".

Issue similar to #178. `Mode294` does not work with this drive, use `Mode296` first.
