### PR TITLE
Add replace function

### DIFF
--- a/CUETools.Processor/General.cs
+++ b/CUETools.Processor/General.cs
@@ -266,6 +266,11 @@ namespace CUETools.Processor
                         try { Returns(sb, Path.GetFileNameWithoutExtension(GetArg(sb, 0))); }
                         catch { return false; }
                         return true;
+                    case "replace":
+                        if (positions.Count != 3)
+                            return false;
+                        Returns(sb, GetArg(sb, 0).Replace(GetArg(sb, 1), GetArg(sb, 2)));
+                        return true;
                 }
                 return false;
             }


### PR DESCRIPTION
Add a replace function for path formatting. It will be useful when defining the output directory. For example, in batch processing, I can use `$replace(%directoryname%,C:\Music,D:\ReEncoded)` to rewrite the output path to another location while retaining the original directory structure.