### PR TITLE
Use HTTPS for AccurateRip database lookups

### DIFF
--- a/CUETools.AccurateRip/AccurateRip.cs
+++ b/CUETools.AccurateRip/AccurateRip.cs
@@ -826,7 +826,7 @@ namespace CUETools.AccurateRip
 			discId2 = UInt32.Parse(n[1], NumberStyles.HexNumber);
 			cddbDiscId = UInt32.Parse(n[2], NumberStyles.HexNumber);
 
-			string url = String.Format("http://www.accuraterip.com/accuraterip/{0:x}/{1:x}/{2:x}/dBAR-{3:d3}-{4:x8}-{5:x8}-{6:x8}.bin",
+			string url = String.Format("https://www.accuraterip.com/accuraterip/{0:x}/{1:x}/{2:x}/dBAR-{3:d3}-{4:x8}-{5:x8}-{6:x8}.bin",
 				discId1 & 0xF, discId1 >> 4 & 0xF, discId1 >> 8 & 0xF, _toc.AudioTracks, discId1, discId2, cddbDiscId);
 
 			HttpWebRequest req = (HttpWebRequest)WebRequest.Create(url);
@@ -1227,7 +1227,7 @@ namespace CUETools.AccurateRip
 			string fileName = System.IO.Path.Combine(CachePath, "DriveOffsets.bin");
 			if (!File.Exists(fileName) || (DateTime.Now - File.GetLastWriteTime(fileName) > TimeSpan.FromDays(10)))
 			{
-				HttpWebRequest req = (HttpWebRequest)WebRequest.Create("http://www.accuraterip.com/accuraterip/DriveOffsets.bin");
+				HttpWebRequest req = (HttpWebRequest)WebRequest.Create("https://www.accuraterip.com/accuraterip/DriveOffsets.bin");
 				req.Method = "GET";
 				try
 				{

--- a/CUETools/frmCUETools.cs
+++ b/CUETools/frmCUETools.cs
@@ -21,7 +21,7 @@
 // ****************************************************************************
 // ****************************************************************************
 // Access to AccurateRip is regulated, see
-// http://www.accuraterip.com/3rdparty-access.htm for details.
+// https://www.accuraterip.com/3rdparty-access.htm for details.
 // ****************************************************************************
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
## Summary

- use HTTPS for AccurateRip dBAR database lookups
- use HTTPS when refreshing `DriveOffsets.bin`
- do not fall back to cleartext HTTP

## Why

Both payloads were downloaded over HTTP. The payloads are not independently
signed, so an on-path modification could change verification data or drive
offset data before CUETools caches and consumes it. AccurateRip currently serves
both routes over HTTPS.

This patch changes only the scheme. URL paths, request methods, proxy behavior,
request throttling, cache behavior, parsing, and existing failure handling stay
unchanged.

## Validation

- `dotnet build CUETools.AccurateRip/CUETools.AccurateRip.csproj -c Release`
  builds net20, net47, and netstandard2.0 with zero warnings and zero errors
- `DriveOffsets.bin` returned HTTP 200 over HTTPS with a valid TLS chain on
  2026-07-31
- a deliberately nonexistent dBAR URL reached the HTTPS route and returned the
  expected HTTP 404 on 2026-07-31
- the three C# files in `CUETools.AccurateRip` contain zero cleartext AccurateRip
  runtime URLs and two HTTPS runtime URLs
